### PR TITLE
ci: run tests on macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - run: pnpm test
       - run: pnpm build
 
-  app-build:
-    name: app build (${{ matrix.os }})
+  app:
+    name: app (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +39,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      # Belt and suspenders: mise.toml requests rustfmt/clippy components, but
+      # ensure they exist on the active toolchain even if a cached install lacks them.
+      - run: rustup component add rustfmt clippy
+      - run: cargo fmt --check
+      - run: cargo clippy -p simple-archiver-core --all-targets -- -D warnings
+      - run: cargo nextest run -p simple-archiver-core --profile ci
       - run: pnpm install --frozen-lockfile
+      - run: pnpm test
       - run: pnpm build
       - run: pnpm tauri build --no-bundle


### PR DESCRIPTION
## Summary

Run the Rust and frontend unit suites on macOS and Windows in CI, not only on Linux. The existing macOS/Windows matrix job is renamed `app-build` → `app` and extended to run `cargo fmt`/`clippy`/`nextest` and `pnpm test` (Vitest) alongside the build it already performed.

## Background / Motivation

- Until now the unit suites (`cargo nextest`, Vitest) ran only on `ubuntu-latest`; the macOS/Windows matrix job built the app but never executed a single test, so OS-specific defects could merge undetected.
- simple-archiver extracts rar files and writes zip archives, manipulating filesystem paths — behavior that diverges across platforms (path separators, case sensitivity, line endings). These code paths need coverage on the OSes the app actually ships to.
- macOS and Windows are the product's only target OSes (Tauri desktop app), yet they had the weakest test coverage of the three CI platforms.
- The repository is public, so GitHub-hosted standard runners (including macOS/Windows) are free with unlimited minutes — there is no billing reason to keep tests Linux-only.

## Changes

### `app` matrix job (renamed from `app-build`)

- Rename job `app-build` → `app`; it now runs the full lint+test+build pipeline rather than just the build, so the old name was misleading.
- Add `rustup component add rustfmt clippy` before the Rust checks (belt-and-suspenders, mirroring the `core` job).
- Add `cargo fmt --check`, `cargo clippy -p simple-archiver-core --all-targets -- -D warnings`, and `cargo nextest run -p simple-archiver-core --profile ci`.
- Add `pnpm test` (Vitest) before `pnpm build`.
- `pnpm install --frozen-lockfile` is reused within the same job, so no second macOS/Windows runner is spun up for tests.

### Linux coverage (unchanged)

- The `core` (ubuntu) and `frontend` (ubuntu) jobs are untouched; Linux continues to run fmt/clippy/nextest and Vitest/build.

## Verification

In the Actions run for this PR, confirm the macOS/Windows jobs now execute tests, not just the build — the `app (macos-latest)` and `app (windows-latest)` jobs should contain these steps:

```
cargo nextest run -p simple-archiver-core --profile ci
pnpm test
```

The workflow was validated locally with `actionlint` (no findings).

⚠️ Status check rename: `app build (macos-latest)` / `app build (windows-latest)` → `app (macos-latest)` / `app (windows-latest)`. If `main` branch protection lists the old names as required checks, update them.

## Test plan

- [ ] CI run on this PR shows `app (macos-latest)` and `app (windows-latest)` jobs green.
- [ ] Both jobs' logs include a `cargo nextest run -p simple-archiver-core --profile ci` step that actually executed.
- [ ] Both jobs' logs include a `pnpm test` (Vitest) step that actually executed.
- [ ] `app` jobs still run `pnpm build` and `pnpm tauri build --no-bundle` after the tests (build regression check).
- [ ] `core` and `frontend` ubuntu jobs remain green and unchanged.
- [ ] `actionlint .github/workflows/ci.yml` reports no errors.
