### PR TITLE
chore: introduce Renovate for grouped, security-gated dependency updates

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,10 @@
 [tools]
 # Install rustfmt and clippy alongside rust so CI (mise-action) has them.
 # Without explicit components, rustup uses the minimal profile and `cargo fmt`/`clippy` are absent.
-rust = { version = "latest", components = "rustfmt,clippy" }
-node = "latest"
-pnpm = "latest"
-"cargo:cargo-nextest" = "latest"
+rust = { version = "1.96.0", components = "rustfmt,clippy" }
+node = "24.15.0"
+pnpm = "11.1.3"
+"cargo:cargo-nextest" = "0.9.137"
 
 [settings]
 # Prefer binary fetch via cargo-binstall when available (faster installs)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "prConcurrentLimit": 10,
+  "labels": ["dependencies"],
+  "packageRules": [
+    { "matchManagers": ["npm"], "groupName": "frontend (npm)", "addLabels": ["frontend"] },
+    { "matchManagers": ["cargo"], "groupName": "backend (cargo)", "addLabels": ["backend"] },
+    { "matchManagers": ["github-actions"], "groupName": "github-actions", "addLabels": ["ci"] },
+    { "matchManagers": ["mise"], "groupName": "mise", "addLabels": ["tooling"] },
+    {
+      "matchPackageNames": [
+        "tauri", "tauri-build", "tauri-plugin-opener", "tauri-plugin-dialog",
+        "@tauri-apps/**"
+      ],
+      "matchUpdateTypes": ["major"],
+      "groupName": "fixed-libs major (review required)",
+      "addLabels": ["review-required"],
+      "automerge": false
+    },
+    {
+      "matchPackageNames": ["async_zip", "unrar", "mockall", "loom"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "fixed-libs major (review required)",
+      "addLabels": ["review-required"],
+      "automerge": false
+    },
+    {
+      "matchPackageNames": ["bitflags"],
+      "groupName": "fixed-libs major (review required)",
+      "addLabels": ["review-required"],
+      "automerge": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 9am on monday"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `renovate.json` to enable automated dependency updates via the Renovate GitHub App, and pins all four `mise.toml` tool versions from `latest` to explicit version numbers so Renovate can track and propose updates. Dependencies are grouped by ecosystem, low-risk patches automerge, and pinned libraries (Tauri, 0.x crates, `bitflags`) are gated behind manual review.

## Background / Motivation

- `mise.toml` used `latest` for all four tools (rust, node, pnpm, cargo-nextest), so there was no stable baseline to diff against — Renovate cannot propose a version bump if the current version is `latest`.
- Without a Renovate configuration, dependency updates must be tracked and applied manually, which is error-prone and easy to neglect over time.
- Several fixed libraries (`async_zip`, `unrar`, `mockall`, `loom` are all 0.x; `bitflags = "=2.8.0"` is exact-pinned in `Cargo.toml` for the `dispatch2` recursion-limit workaround) cannot be automerged safely because even patch/minor releases may be breaking under Cargo SemVer pre-1.0 semantics.
- Supply-chain risk is real: new releases need a 7-day settling window so known CVEs and yanked versions surface before auto-application.

## Changes

### `renovate.json` (new file)

- Extends `config:best-practices`; timezone `Asia/Tokyo`, schedule `before 9am on monday`.
- `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"` — blocks automerge until a release has been live for 7 days and all Renovate internal checks pass.
- Four dependency groups, each with a matching label: `frontend (npm)`, `backend (cargo)`, `github-actions`, `mise`.
- Protected libraries (manual review, `automerge: false`):
  - Tauri crates and `@tauri-apps/**`: major updates only.
  - 0.x crates (`async_zip`, `unrar`, `mockall`, `loom`): major, minor, and patch updates.
  - `bitflags`: all update types (exact-pinned at `=2.8.0`).
- Automerge enabled for: GitHub Actions digest/pin updates, npm devDependencies patch updates.
- `lockFileMaintenance` enabled with `automerge: true` on the Monday schedule.

### `mise.toml` (pinned versions)

- `rust`: `latest` → `1.96.0`
- `node`: `latest` → `24.15.0`
- `pnpm`: `latest` → `11.1.3`
- `cargo-nextest`: `latest` → `0.9.137`

## Verification

Run `renovate-config-validator renovate.json` locally — should exit 0 with no errors. On the Renovate dry-run, confirm the `mise` manager detects all four tools (`rust`, `node`, `pnpm`, `cargo-nextest`) with their pinned versions as the current baseline.

After installing the Renovate GitHub App on `yasuflatland-lf/simple-archiver`, confirm Renovate creates an onboarding PR automatically.

## Test plan

- [ ] `renovate-config-validator renovate.json` exits 0.
- [ ] Renovate dry-run (`LOG_LEVEL=debug renovate --dry-run=full yasuflatland-lf/simple-archiver`) lists all four `mise` tools as detected packages with their pinned versions.
- [ ] `cargo fmt --check` reports no formatting diff.
- [ ] `cargo clippy --workspace --all-targets -D warnings` reports zero warnings.
- [ ] `cargo nextest run` passes — all 8 tests green.
- [ ] `pnpm test` (Vitest) passes — 3 tests green.
- [ ] Manual follow-up: install the Renovate GitHub App on this repository and confirm the onboarding PR is generated.
