### PR TITLE
ci: install dependency-hygiene tools only in the hygiene job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
   hygiene:
     name: hygiene (deps + orphan files)
     runs-on: ubuntu-latest
+    # Load mise.ci-hygiene.toml so mise-action installs cargo-modules here only — it compiles
+    # rust-analyzer from source (~16 min on Windows), and this is the sole job that runs it.
+    env:
+      MISE_ENV: ci-hygiene
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2

--- a/mise.ci-hygiene.toml
+++ b/mise.ci-hygiene.toml
@@ -1,0 +1,10 @@
+# mise config environment, loaded only when MISE_ENV=ci-hygiene (set on the `hygiene` CI job).
+#
+# cargo-modules has no prebuilt binary, so mise compiles it — together with the whole
+# rust-analyzer crate graph — from source (~16 min on a Windows runner, and it does not cache
+# reliably there). It is used ONLY by the `hygiene` job's `cargo modules orphans` step, so it is
+# kept out of the shared `mise.toml`: otherwise every job (core / frontend / app on macOS+Windows)
+# would install it via mise-action despite never running it. Renovate's mise manager matches this
+# file by default (`mise.<env>.toml`), so the pin is still tracked.
+[tools]
+"cargo:cargo-modules" = "0.26.0"

--- a/mise.ci-hygiene.toml
+++ b/mise.ci-hygiene.toml
@@ -1,10 +1,12 @@
 # mise config environment, loaded only when MISE_ENV=ci-hygiene (set on the `hygiene` CI job).
 #
-# cargo-modules has no prebuilt binary, so mise compiles it — together with the whole
-# rust-analyzer crate graph — from source (~16 min on a Windows runner, and it does not cache
-# reliably there). It is used ONLY by the `hygiene` job's `cargo modules orphans` step, so it is
-# kept out of the shared `mise.toml`: otherwise every job (core / frontend / app on macOS+Windows)
-# would install it via mise-action despite never running it. Renovate's mise manager matches this
-# file by default (`mise.<env>.toml`), so the pin is still tracked.
+# Both hygiene tools compile from source (no prebuilt binary fetched via binstall); cargo-modules
+# additionally pulls in the whole rust-analyzer crate graph (~16 min on a Windows runner, which
+# also does not cache it reliably). They are used ONLY by the `hygiene` job (`cargo machete` /
+# `cargo modules orphans`), so they are kept out of the shared `mise.toml`: otherwise every job
+# (core / frontend / app on macOS+Windows) would compile them via mise-action despite never running
+# them. Renovate's mise manager matches this file by default (`mise.<env>.toml`), so the pins stay
+# tracked.
 [tools]
 "cargo:cargo-modules" = "0.26.0"
+"cargo:cargo-machete" = "0.9.2"

--- a/mise.toml
+++ b/mise.toml
@@ -5,10 +5,9 @@ rust = { version = "1.96.0", components = "rustfmt,clippy" }
 node = "24.15.0"
 pnpm = "11.1.3"
 "cargo:cargo-nextest" = "0.9.137"
-# cargo-machete (unused-dep gate for the `hygiene` CI job) installs fast from a prebuilt binary on
-# every OS, so it stays in the shared config. cargo-modules is heavier (compiles rust-analyzer from
-# source) and is scoped to the hygiene job only — see mise.ci-hygiene.toml.
-"cargo:cargo-machete" = "0.9.2"
+# The dependency-hygiene tools (cargo-modules, cargo-machete) live in mise.ci-hygiene.toml: both
+# compile from source and are only used by the `hygiene` CI job (MISE_ENV=ci-hygiene), so keeping
+# them out of this shared config avoids that compile in the core / frontend / app jobs.
 
 [settings]
 # Prefer binary fetch via cargo-binstall when available (faster installs)

--- a/mise.toml
+++ b/mise.toml
@@ -5,11 +5,9 @@ rust = { version = "1.96.0", components = "rustfmt,clippy" }
 node = "24.15.0"
 pnpm = "11.1.3"
 "cargo:cargo-nextest" = "0.9.137"
-# Dependency-hygiene gates (see the `hygiene` CI job): unused deps + orphan files.
-# These install from source and cargo-modules pulls in the whole rust-analyzer crate graph, so a
-# fixed version keeps the mise/CI install cache stable instead of recompiling on every upstream
-# release. Renovate (mise manager) bumps these like any other pin.
-"cargo:cargo-modules" = "0.26.0"
+# cargo-machete (unused-dep gate for the `hygiene` CI job) installs fast from a prebuilt binary on
+# every OS, so it stays in the shared config. cargo-modules is heavier (compiles rust-analyzer from
+# source) and is scoped to the hygiene job only — see mise.ci-hygiene.toml.
 "cargo:cargo-machete" = "0.9.2"
 
 [settings]


### PR DESCRIPTION
## Summary

Installs the two source-compiled dependency-hygiene tools (`cargo-modules`, `cargo-machete`) only in the ubuntu `hygiene` job instead of in every CI job. This removes their from-source compile — notably `cargo-modules`' ~16-minute rust-analyzer build on Windows — from `core`/`frontend`/`app`, with no change to test coverage: those jobs never *ran* the tools, they only installed them.

## Background / Motivation

- #16 added `cargo:cargo-modules` and `cargo:cargo-machete` to `mise.toml`, and `jdx/mise-action@v2` installs every `mise.toml` tool in every job.
- Neither tool ships a prebuilt binary, so mise compiles them from source. `cargo-modules` additionally pulls in the whole rust-analyzer crate graph — ~16 min on the `app (windows-latest)` runner, which also doesn't cache it. That mise step (not the ~5-min Tauri build) is what made CI "not finish".
- Only the ubuntu `hygiene` job runs `cargo machete` / `cargo modules orphans`; the other jobs compiled both tools but never invoked them.

## Changes

### Scope the hygiene tools to the hygiene job

- `mise.ci-hygiene.toml` (new): a mise config environment holding `cargo:cargo-modules = "0.26.0"` and `cargo:cargo-machete = "0.9.2"`, loaded only when `MISE_ENV=ci-hygiene`.
- `mise.toml`: drop both tools. The shared config now keeps only download/binstall-backed tools (`rust`, `node`, `pnpm`, `cargo-nextest`), so the core/frontend/app jobs do no source compiles at all.
- `.github/workflows/ci.yml`: set `env: MISE_ENV: ci-hygiene` on the `hygiene` job so `jdx/mise-action@v2` installs the two tools there — and nowhere else.

### Renovate

- No `renovate.json` change needed: the mise manager's default patterns already match `mise.<env>.toml`, so both pins stay tracked.

## No coverage change

The `core`/`frontend`/`app` jobs never invoked these tools — every test and build (`cargo nextest`, `pnpm test`, `pnpm build`, `pnpm tauri build --no-bundle`) and the orphan-file gate are unchanged. Orphan detection is OS-independent, so running it once on ubuntu fully covers macOS and Windows.

## Measured effect

On the first CI run of this branch, the `app (windows-latest)` `jdx/mise-action@v2` step dropped from ~984 s (cargo-modules in the shared config) to ~397 s. Moving `cargo-machete` out as well removes the last from-source compile from the non-hygiene jobs (they now install only download/binstall tools), bringing their mise step down further — especially on warm caches.

## Verification

Local mise scoping confirmed: with no `MISE_ENV`, the active tools exclude both `cargo-modules` and `cargo-machete`; with `MISE_ENV=ci-hygiene`, both resolve and `mise.ci-hygiene.toml` is loaded. Under the hygiene env, `cargo machete` and `cargo modules orphans -p simple-archiver-core --lib --deny` both exit 0.

## Test plan

- [ ] CI is green on this PR (`core`, `hygiene`, `frontend`, `app` ×2).
- [ ] `core`/`frontend`/`app` mise-action steps no longer compile `cargo-modules` or `cargo-machete` (they install only rust/node/pnpm/cargo-nextest).
- [ ] `app (windows-latest)` mise-action step is well below the previous ~16 min.
- [ ] The `hygiene` job still runs `cargo machete` and `cargo modules orphans -p simple-archiver-core --lib --deny` (loads `mise.ci-hygiene.toml` via `MISE_ENV`).
