### PR TITLE
refactor(domain): remove unused ArchiveTask::progress field (#44)

### DIFF
--- a/.claude/conventions.md
+++ b/.claude/conventions.md
@@ -58,6 +58,12 @@ This repository requires **all in-code comments to be written in English**.
 
 Entity fields are private; only the aggregate root constructs/mutates entities via `pub(crate)` constructors and mutators (e.g. `ArchiveTask::new` / `set_output_name` / `apply_event`, `TaskId::new` are `pub(crate)`; external code obtains a `TaskId` only via `id()`). **Why:** the "names bound to position, `TaskId` stable" invariant is then structurally enforceable — external code cannot fabricate ids, build entities out of band, or reorder the private `Vec`.
 
+### No zero-information field — let the real owner be the single source of truth
+
+**Why:** a domain entity must not carry a field that is structurally constant across every instance and has no write path. Such a field carries zero information, is a **false ownership claim** (it looks like the entity owns the data but never updates it), and sets up a **dual source of truth** with whatever actually maintains the live value. Delete it (YAGNI) and let the real owner be the single source of truth.
+
+**What:** PR-12b removed `ArchiveTask::progress` — a `TaskProgress` field initialized to `TaskProgress::zero()` at plan time with no mutator, so it was always `zero()` and read only by tests. Live progress is owned by the application-layer `Aggregator` (a `HashMap<TaskId, TaskProgress>`); the presentation `ProgressEvent` is built from that snapshot, never from the entity. After removal the split is clean: `ArchiveTask` is pure **identity/lifecycle** (`TaskId` / `SourceItem` / `OutputFileName` / `TaskStatus`) while the aggregator owns **live progress**. This is the data analogue of "re-derive, never store a second copy" (architecture.md aggregate-root rule): if a value already has a live owner, an entity field that merely shadows it as a constant is the thing to remove — don't add a speculative field "in case the entity needs it later."
+
 ## Value-object equality
 
 Derive **both `PartialEq` and `Eq`** on value objects whenever all fields are `Eq`-capable (not just `PartialEq`). **Why:** it's an honest value-equality contract, enables use as map/set keys, and avoids artificially blocking `Eq` up the whole aggregate. (PR3's `NamingRule` / `Segment` derived only `PartialEq` despite `Eq`-capable fields, which cascaded into blocking `Eq` on `ArchiveJob` until fixed in PR4.)

--- a/.claude/domain-model.md
+++ b/.claude/domain-model.md
@@ -16,10 +16,10 @@
 
 ### `ArchiveTask` (entity)
 
-- Fields: `TaskId` / `SourceItem` / resolved `OutputFileName` / `TaskStatus` / `TaskProgress`.
+- Fields: `TaskId` / `SourceItem` / resolved `OutputFileName` / `TaskStatus`. (Live byte progress is **not** an entity field — it is owned by the application-layer aggregator's `HashMap<TaskId, TaskProgress>` as the single source of truth; see `architecture.md` "Execution engine".)
 - **`TaskStatus` state machine:** source-agnostic, forward-only; terminal states (`Completed` / `Failed` / `Cancelled`) are irreversible. Normal path: `Pending → Extracting → Compressing → Completed`. Folder fast-path: `Pending → Compressing → Completed` (no extraction needed; the engine picks the first event, the machine doesn't inspect the source type). Error/cancel transitions: any non-terminal state → `Failed` or `Cancelled`. Modelled as `apply(self, Event) -> Result<Self, IllegalTransition>` — see conventions.md "State-machine convention" (the `&mut self` driver `apply_event` uses the `std::mem::replace` hot-path variant to skip the happy-path clone).
 - `TaskStatus` variants: `Pending` / `Extracting` / `Compressing` / `Completed` / `Failed { reason }` / `Cancelled`.
-- **`TaskId(u32)` vs `SequenceNumber` (identity vs position):** `TaskId` is a stable task identity assigned once at plan time (`TaskId(i + 1)` for item at index `i`) and is never re-derived or changed by reordering. `SequenceNumber` is the 1-based position in the job's ordering (`position + 1`), is **derived and never stored**, and changes when tasks are reordered via `move_up` / `move_down`. Output names are bound to the sequence/position (not to the `TaskId`), so reordering rebinds names while preserving `TaskId`, `TaskStatus`, and `TaskProgress`.
+- **`TaskId(u32)` vs `SequenceNumber` (identity vs position):** `TaskId` is a stable task identity assigned once at plan time (`TaskId(i + 1)` for item at index `i`) and is never re-derived or changed by reordering. `SequenceNumber` is the 1-based position in the job's ordering (`position + 1`), is **derived and never stored**, and changes when tasks are reordered via `move_up` / `move_down`. Output names are bound to the sequence/position (not to the `TaskId`), so reordering rebinds names while preserving `TaskId` and `TaskStatus`.
 
 ### `ArchiveJob` (aggregate root)
 

--- a/crates/core/src/domain/archive_job.rs
+++ b/crates/core/src/domain/archive_job.rs
@@ -82,7 +82,7 @@ fn seq_index(i: usize) -> u32 {
 /// **Position/identity invariant:** the task at position `p` always holds the
 /// name `rule.resolve(p + 1)`. This is established by [`ArchiveJob::plan`] and
 /// preserved by every reorder: names are position-derived and stay with the
-/// position, while each task's id, status, and progress travel with the task.
+/// position, while each task's id and status travel with the task.
 ///
 /// `ArchiveJob` is a value type with full structural equality: it derives both
 /// `PartialEq` and `Eq`.
@@ -98,7 +98,7 @@ impl ArchiveJob {
     ///
     /// Items are numbered 1-based in the order given: item at index `i` gets
     /// `TaskId(i + 1)`, its output name `rule.resolve(SequenceNumber::new(i + 1))`,
-    /// and starts `Pending` with zero progress. The `SequenceNumber` is a transient
+    /// and starts `Pending`. The `SequenceNumber` is a transient
     /// argument to name resolution — it is derived from position and is NOT stored
     /// on the task.
     ///
@@ -224,8 +224,8 @@ impl ArchiveJob {
     /// output name bound to that position.
     ///
     /// Reordering only changes which task object occupies a position; the output
-    /// name stays bound to the POSITION while the task's id, status, and progress
-    /// travel with the task. The implementation therefore (1) saves the current
+    /// name stays bound to the POSITION while the task's id and status travel
+    /// with the task. The implementation therefore (1) saves the current
     /// name at each position before the swap, (2) calls `self.tasks.swap(a, b)`
     /// to move the task objects, then (3) restores each position's saved name via
     /// `set_output_name`. This is infallible — it never calls `rule.resolve` and

--- a/crates/core/src/domain/archive_job.rs
+++ b/crates/core/src/domain/archive_job.rs
@@ -279,7 +279,6 @@ mod tests {
     use super::*;
     use crate::domain::file_name::{FileStem, OutputFileName};
     use crate::domain::source_item::SourceItem;
-    use crate::domain::task_progress::TaskProgress;
     use crate::domain::task_status::TaskStatus;
     use std::path::PathBuf;
 
@@ -336,11 +335,10 @@ mod tests {
     }
 
     #[test]
-    fn plan_starts_every_task_pending_with_zero_progress() {
+    fn plan_starts_every_task_pending() {
         let job = ArchiveJob::plan(sources(3), rule("file{n}"), out_dir()).unwrap();
         for task in job.tasks() {
             assert_eq!(task.status(), &TaskStatus::Pending);
-            assert_eq!(task.progress(), &TaskProgress::zero());
         }
     }
 
@@ -452,10 +450,9 @@ mod tests {
             ]
         );
 
-        // The moved task's status/progress are preserved.
+        // The moved task's status is preserved.
         let moved = job.tasks().iter().find(|t| t.id().get() == 3).unwrap();
         assert_eq!(moved.status(), &TaskStatus::Pending);
-        assert_eq!(moved.progress(), &TaskProgress::zero());
     }
 
     #[test]
@@ -634,7 +631,7 @@ mod tests {
         }
     }
 
-    // ── swap_and_rebind preserves status/progress, rebinds name to position ──
+    // ── swap_and_rebind preserves status, rebinds name to position ──
 
     #[test]
     fn status_survives_reorder_and_output_name_rebinds_to_new_position() {
@@ -650,9 +647,8 @@ mod tests {
         job.move_up(id2).unwrap();
 
         let moved = job.tasks().iter().find(|t| t.id().get() == 2).unwrap();
-        // Status and progress travel with the task object.
+        // Status travels with the task object.
         assert_eq!(moved.status(), &TaskStatus::Extracting);
-        assert_eq!(moved.progress(), &TaskProgress::zero());
         // The name is rebound to the new position (index 0 → "file1.zip").
         assert_eq!(moved.output_name().as_str(), "file1.zip");
 

--- a/crates/core/src/domain/archive_task.rs
+++ b/crates/core/src/domain/archive_task.rs
@@ -2,7 +2,6 @@
 
 use crate::domain::file_name::OutputFileName;
 use crate::domain::source_item::SourceItem;
-use crate::domain::task_progress::TaskProgress;
 use crate::domain::task_status::{IllegalTransition, TaskEvent, TaskStatus};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -46,12 +45,10 @@ pub struct ArchiveTask {
     source: SourceItem,
     output_name: OutputFileName,
     status: TaskStatus,
-    progress: TaskProgress,
 }
 
 impl ArchiveTask {
-    /// Create a new `ArchiveTask` in the [`TaskStatus::Pending`] state with
-    /// zero progress.
+    /// Create a new `ArchiveTask` in the [`TaskStatus::Pending`] state.
     ///
     /// This constructor is crate-internal; only `ArchiveJob` builds tasks.
     pub(crate) fn new(id: TaskId, source: SourceItem, output_name: OutputFileName) -> Self {
@@ -60,7 +57,6 @@ impl ArchiveTask {
             source,
             output_name,
             status: TaskStatus::Pending,
-            progress: TaskProgress::zero(),
         }
     }
 
@@ -84,11 +80,6 @@ impl ArchiveTask {
     /// Return a reference to the current lifecycle status.
     pub fn status(&self) -> &TaskStatus {
         &self.status
-    }
-
-    /// Return a reference to the current byte-level progress.
-    pub fn progress(&self) -> &TaskProgress {
-        &self.progress
     }
 
     // ── Crate-internal mutators ───────────────────────────────────────────────
@@ -205,12 +196,6 @@ mod tests {
     fn new_task_status_is_pending() {
         let task = make_task(1);
         assert_eq!(task.status(), &TaskStatus::Pending);
-    }
-
-    #[test]
-    fn new_task_progress_is_zero() {
-        let task = make_task(1);
-        assert_eq!(task.progress(), &TaskProgress::zero());
     }
 
     #[test]
@@ -376,12 +361,5 @@ mod tests {
         task.apply_event(TaskEvent::StartExtracting).unwrap();
         task.set_output_name(make_output_name("other"));
         assert_eq!(task.status(), &TaskStatus::Extracting);
-    }
-
-    #[test]
-    fn set_output_name_leaves_progress_unchanged() {
-        let mut task = make_task(1);
-        task.set_output_name(make_output_name("other"));
-        assert_eq!(task.progress(), &TaskProgress::zero());
     }
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,11 +27,13 @@ Toolchain is pinned via `mise.toml` (rust / node / pnpm / cargo-nextest). The pa
 ```bash
 # Rust — pure core (the TDD battleground; -p keeps Tauri out)
 cargo nextest run -p simple-archiver-core   # run tests (use nextest, not `cargo test`)
+cargo nextest run -p simple-archiver-core --release  # release-only tests for #[cfg(not(debug_assertions))] paths (debug run skips them; see testing policy)
 cargo clippy -p simple-archiver-core --all-targets -- -D warnings  # lint, zero warnings
 cargo fmt                                    # format (whole workspace)
 cargo llvm-cov nextest -p simple-archiver-core --lcov --output-path lcov.info  # coverage (CI uploads to Codecov)
 
 # loom concurrency verification (target tests only; kept separate from normal runs)
+RUSTFLAGS="--cfg loom" cargo clippy -p simple-archiver-core --features loom -- -D warnings  # loom-clippy (CI's loom job runs this too)
 RUSTFLAGS="--cfg loom" cargo nextest run -p simple-archiver-core --features loom
 
 # Rust — presentation crate (Tauri commands, IPC layer; requires the Tauri toolchain)
@@ -61,6 +63,7 @@ pnpm tauri build
 
 This project is designed around TDD. **Write tests before implementation.**
 
+- **Removal / deletion refactors are also TDD — adjust tests first, then delete (HARNESS — PR-12b).** When deleting a field/accessor/concept, edit the tests to the new expected end-state *first* — while the symbol still exists — and confirm green; only then delete the field/accessor; then re-run and confirm the meaningful invariants stay green. This keeps the safety net live across the removal instead of deleting code and tests in one untested leap. **Sweep EVERY textual reference, not just code and tests:** grep the whole tree for the removed name and update PRODUCTION doc comments too, not only call sites. (PR-12b removed `ArchiveTask::progress` — a dead field always equal to `TaskProgress::zero()` with no write path; the plan's file-by-file enumeration missed 3 stale production doc comments in `archive_job.rs` that review caught. A reference list assembled by hand is not a substitute for a final `rg <name>` across `crates/ src-tauri/ docs/ .claude/`.)
 - **Domain**: pure unit tests. Cover `NamingRule` resolution, `ArchiveJob.plan`/`reorder` invariants, and name-uniqueness boundary cases. For any **state machine** (e.g. `TaskStatus`), test every `(state × event)` pair: legal transitions assert the resulting state, illegal ones assert the typed error, and terminal states reject all events.
   - **HARNESS — `debug_assert` + release-clamp invariants need cfg-split tests AND a `--release` gate.** A value object that asserts an invariant in debug and clamps it in release (e.g. `TaskProgress::new`; see conventions.md "debug_assert + release clamp for caller-bug invariants") needs two cfg-gated tests: `#[cfg(debug_assertions)] #[should_panic(expected = "…")]` for the loud debug path, and `#[cfg(not(debug_assertions))]` asserting the clamped value for the release path. **Critical:** the default `cargo nextest run` is a debug build and never executes the `#[cfg(not(debug_assertions))]` test, so the verification gate MUST also include a `cargo nextest run --release` pass to exercise release-only tests — otherwise the clamp path is silently never run.
 - **Application**: verify parallelism and error tallying **deterministically**. PR-5a uses **hand-written fakes** (`FakeArchiver` / `FixedClock` / `RecordingSink`), not `mockall`: the evolved `Archiver` returns `impl Future + Send` (RPITIT), which `mockall` cannot mock cleanly, and a purpose-built fake gives the control the timing assertions need — a `tokio::sync::Barrier(N)` + `timeout` proves N workers run concurrently, and the **cap** is proven by running *more* tasks than the limit and asserting peak liveness `== N` (sampled at the barrier rendezvous). `mockall` stays declared in dev-dependencies for a future PR that mocks the ports; PR-5b's cancel-path tests use the hand-written `FakeArchiver`, not mockall. `Clock` is faked with a fixed `Instant` so `elapsed` is deterministic.


### PR DESCRIPTION
## Summary

Removes the dead `progress: TaskProgress` field (its initializer, accessor, and unused import) from the domain entity `ArchiveTask`, making the application-layer `Aggregator` (`HashMap<TaskId, TaskProgress>`) the single source of truth for live progress (YAGNI). The `TaskProgress` type, the aggregator path, and the DTO conversion are kept intact.

Closes #44

## Changes

### Domain entity (`archive_task.rs`)

- Remove `progress` field, its initializer, and accessor from `ArchiveTask`.
- Drop unused `TaskProgress` import.
- Trim constructor doc comment that referenced the now-gone field.
- Delete two progress-only tests that were testing an always-zero value.

### Application layer (`archive_job.rs`)

- Drop 3 progress assertions from reorder/plan tests (id/status/name invariants retained).
- Trim stale progress mentions from production doc comments.
- Remove the now-unused `TaskProgress` import.

### Docs (`.claude/domain-model.md`, `.claude/conventions.md`, `docs/development.md`)

- Record the zero-information-field rule (YAGNI: don't mirror state that is owned by another layer).
- Record deletion-refactor verification gates for future contributors.

## Testing

| Gate | Result |
|---|---|
| `cargo nextest run --workspace` (246 tests) | green |
| `cargo nextest run` — release-mode core (180 tests) | green |
| loom tests (141) | green |
| `pnpm run test` — Vitest (162 tests) | green |
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets -D warnings` | clean |
| `pnpm fmt:check` (oxfmt) | clean |
| `pnpm lint:ci` (oxlint `--deny-warnings`) | clean |

## Test plan

- [ ] CI `core` job is green: `cargo nextest run -p simple-archiver-core`, `cargo clippy`, and `cargo fmt --check` all pass.
- [ ] CI `loom` job is green (loom concurrency tests pass).
- [ ] CI `app` matrix is green on both `macos-latest` and `windows-latest`.
- [ ] CI `frontend` job is green: oxfmt, oxlint, Vitest, and `pnpm build` all pass.
- [ ] `ArchiveTask` no longer has a `progress` field or accessor — any call site that referenced it fails to compile (regression: this is expected to be zero such sites).
- [ ] `Aggregator` (`HashMap<TaskId, TaskProgress>`) remains the sole owner of live progress — ts-rs-generated bindings that include `TaskProgressDto` are byte-for-byte identical to pre-PR state.
- [ ] The two deleted tests no longer exist in `archive_task.rs`; the remaining tests (id, status, name, event ordering) still pass.
