### PR TITLE
ci: add release workflow to build and attach macOS/Windows bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+# Build native bundles for macOS + Windows and attach them to the matching
+# GitHub release. Release notes are authored manually (gh release create); this
+# workflow only uploads binaries and never touches the release body.
+on:
+  push:
+    tags:
+      - 'v*'
+  # Manual run to (re)build and attach binaries to an existing tag/release,
+  # e.g. a tag that was published before this workflow existed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build and attach binaries to (e.g. v0.1.0)'
+        required: true
+
+jobs:
+  bundle:
+    name: bundle (${{ matrix.platform }})
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # One universal binary covers both Apple Silicon and Intel Macs.
+          - platform: macos-latest
+            args: '--target universal-apple-darwin'
+          - platform: windows-latest
+            args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # On workflow_dispatch, build the requested tag; on tag push, the ref is the tag.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      - uses: jdx/mise-action@v2
+      # The universal-apple-darwin build links both arch slices, so both targets are needed.
+      - name: Add macOS universal Rust targets
+        if: runner.os == 'macOS'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.platform }}
+      - run: pnpm install --frozen-lockfile
+      - name: Build bundles
+        id: tauri
+        uses: tauri-apps/tauri-action@v0
+        with:
+          # No tagName/releaseId: build only and expose artifactPaths; do not create or edit a release.
+          args: ${{ matrix.args }}
+      - name: Upload bundles to the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass interpolated values through env (never inline into the script) to avoid shell injection.
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          printf '%s' "$ARTIFACT_PATHS" \
+            | jq -r '.[]' \
+            | while IFS= read -r path; do
+                echo "Uploading: $path"
+                gh release upload "$TAG" "$path" --clobber
+              done


### PR DESCRIPTION
## Summary

Adds a GitHub Actions release workflow that builds the native bundles for **macOS** and **Windows** and attaches them to the matching GitHub release. CI / build-only changes — no app, Rust, frontend, or DTO changes.

The first release (`v0.1.0`) shipped without binaries because no `tauri build` had run; Windows bundles in particular cannot be produced from the maintainer's Mac (Tauri's Windows bundlers require a Windows host). This workflow closes that gap by building both targets on hosted runners.

## Changes

### `.github/workflows/release.yml` (new)

- **Triggers**: `push` of a `v*` tag (automatic for future releases) and `workflow_dispatch` with a `tag` input (to attach binaries to a tag/release that predates this workflow, e.g. `v0.1.0`).
- **Toolchain**: reuses `jdx/mise-action@v2` so the build uses the same pinned toolchain as CI (rust 1.96.0 / node 24.15.0 / pnpm 11.1.3), plus `Swatinem/rust-cache@v2`.
- **Matrix**: `macos-latest` (`--target universal-apple-darwin`, so one bundle covers Apple Silicon + Intel; both rustup targets are added) and `windows-latest`.
- **Build**: `tauri-apps/tauri-action@v0` in build-only mode (no `tagName`/`releaseId`), so it produces bundles and exposes `artifactPaths` without creating or editing any release.
- **Upload**: a `bash` step (works on the Windows runner too) reads `artifactPaths` via `jq` and runs `gh release upload "$TAG" "$path" --clobber`, so the manually authored release notes are never overwritten — only binaries are added.
- **Security**: interpolated values (`artifactPaths`, tag) are passed through `env:` and referenced as `"$VAR"` rather than inlined into the script, to avoid shell injection.

## Notes / follow-ups

- **Unsigned binaries**: no code-signing secrets are configured, so macOS triggers Gatekeeper and Windows triggers SmartScreen warnings. Acceptable for an early OSS release; signing/notarization would need an Apple Developer cert + Windows code-signing cert wired in via repository secrets.
- **Attaching to the existing `v0.1.0`**: after this merges to `main`, run `gh workflow run release.yml -f tag=v0.1.0` (the tag-push trigger does not fire retroactively for an already-pushed tag).

## Testing

| Gate | Result |
|---|---|
| `actionlint .github/workflows/release.yml` | green (exit 0) |

End-to-end verification requires the workflow to run on `main` (hosted macOS + Windows runners), which happens after merge.
