### PR TITLE
fix(ci): skip directory bundles and normalize Windows paths on release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,13 @@ jobs:
           printf '%s' "$ARTIFACT_PATHS" \
             | jq -r '.[]' \
             | while IFS= read -r path; do
+                # Normalize Windows backslash paths so Git Bash and gh both resolve them.
+                path="${path//\\//}"
+                # tauri lists the macOS .app bundle (a directory) next to the .dmg; upload regular files only.
+                if [ ! -f "$path" ]; then
+                  echo "Skipping non-file artifact: $path"
+                  continue
+                fi
                 echo "Uploading: $path"
                 gh release upload "$TAG" "$path" --clobber
               done


### PR DESCRIPTION
## Summary

Fixes the `Upload bundles to the release` step in `release.yml`, which failed on both runners during the first dispatch for `v0.1.0` ([run 26715035265](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/26715035265)). CI-only change.

## Root causes

The step looped over `tauri-action`'s `artifactPaths` and called `gh release upload` on each, which broke in two ways:

- **macOS** — `artifactPaths` lists both `…_universal.dmg` (a file) and `simple-archiver.app` (a **directory**; `.app` bundles are folders). `gh release upload` rejected the directory with `read …/simple-archiver.app: is a directory` → exit 1. The `.dmg` had already uploaded successfully.
- **Windows** — paths come through as backslash form (`D:\a\…\…msi`). Under the Git Bash shell, passing them to `gh` failed with `no matches found for D:\a\…` (MSYS path/glob mangling) → exit 1.

## Fix

In the upload loop:

- **Normalize backslashes** to forward slashes (`path="${path//\\//}"`) so Git Bash and `gh` both resolve Windows paths.
- **Upload regular files only** (`[ -f "$path" ]`), skipping directories — this drops the redundant macOS `.app` (the `.dmg` already carries the app) with a log line.

Net result per platform: macOS uploads the `.dmg`; Windows uploads the `.msi` and the NSIS `.exe`.

## Testing

| Gate | Result |
|---|---|
| `actionlint .github/workflows/release.yml` | green (exit 0) |
| Local loop simulation (file→upload, dir→skip, backslash→forward-slash) | matches intended behavior |

End-to-end verification: after merge, re-run `gh workflow run release.yml -f tag=v0.1.0` and confirm the `.dmg`, `.msi`, and `.exe` are all attached.
