### PR TITLE
feat(ci): sign macOS bundles at build time with self-signed certificate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,64 @@ jobs:
         with:
           key: release-${{ matrix.platform }}
       - run: pnpm install --frozen-lockfile
+      # macOS-only: fail fast if signing secrets are missing, so we never
+      # publish an unsigned macOS release by accident. Secret values are never
+      # printed — only the names of any that are empty.
+      - name: Preflight macOS signing secrets
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -z "${APPLE_CERTIFICATE:-}" ] && missing+=(APPLE_CERTIFICATE)
+          [ -z "${APPLE_CERTIFICATE_PASSWORD:-}" ] && missing+=(APPLE_CERTIFICATE_PASSWORD)
+          [ -z "${KEYCHAIN_PASSWORD:-}" ] && missing+=(KEYCHAIN_PASSWORD)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required macOS signing secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "All macOS signing secrets are present."
       - name: Build bundles
         id: tauri
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         with:
           # No tagName/releaseId: build only and expose artifactPaths; do not create or edit a release.
           args: ${{ matrix.args }}
+        env:
+          # macOS-only signing (build-time). Tauri imports APPLE_CERTIFICATE into a
+          # temporary keychain and signs the .app (and .dmg) during the build.
+          # Windows receives empty strings, which tauri-action ignores.
+          APPLE_CERTIFICATE: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: "${{ runner.os == 'macOS' && 'Developer ID Application: Simple Archiver' || '' }}"
+          KEYCHAIN_PASSWORD: ${{ runner.os == 'macOS' && secrets.KEYCHAIN_PASSWORD || '' }}
+      # macOS-only: verify the signature of the shipped artifacts, INCLUDING the
+      # .app embedded in the .dmg (mounted by the script). NOT spctl.
+      - name: Verify macOS signatures
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          set -euo pipefail
+          bundle_dir="src-tauri/target/universal-apple-darwin/release/bundle"
+          app="$(find "$bundle_dir/macos" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n1 || true)"
+          if [ -z "$app" ]; then
+            app="$(printf '%s' "$ARTIFACT_PATHS" | jq -r '.[]' | sed 's/\r$//' | grep -E '\.app$' | head -n1 || true)"
+          fi
+          dmg="$(find "$bundle_dir/dmg" -maxdepth 1 -name '*.dmg' -type f 2>/dev/null | head -n1 || true)"
+          if [ -z "$dmg" ]; then
+            dmg="$(printf '%s' "$ARTIFACT_PATHS" | jq -r '.[]' | sed 's/\r$//' | grep -E '\.dmg$' | head -n1 || true)"
+          fi
+          if [ -z "$app" ]; then
+            echo "::error::Could not locate the .app under $bundle_dir/macos or in artifactPaths"
+            exit 1
+          fi
+          ./scripts/macos/verify-macos-bundles.sh "$app" "$dmg"
       - name: Upload bundles to the release
         shell: bash
         env:
@@ -58,19 +110,24 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
-          printf '%s' "$ARTIFACT_PATHS" \
-            | jq -r '.[]' \
-            | while IFS= read -r path; do
-                # Windows jq.exe emits CRLF, so each path keeps a trailing CR that
-                # breaks the file test and gh upload; strip it before anything else.
-                path="${path%$'\r'}"
-                # Normalize Windows backslash paths so Git Bash and gh both resolve them.
-                path="${path//\\//}"
-                # tauri lists the macOS .app bundle (a directory) next to the .dmg; upload regular files only.
-                if [ ! -f "$path" ]; then
-                  echo "Skipping non-file artifact: $path"
-                  continue
-                fi
-                echo "Uploading: $path"
-                gh release upload "$TAG" "$path" --clobber
-              done
+          set -euo pipefail
+          uploaded=0
+          while IFS= read -r path; do
+            # Windows jq.exe emits CRLF; strip the trailing CR before the file test.
+            path="${path%$'\r'}"
+            # Normalize Windows backslash paths so Git Bash and gh both resolve them.
+            path="${path//\\//}"
+            # tauri lists the .app bundle (a directory) next to the .dmg; upload regular files only.
+            if [ ! -f "$path" ]; then
+              echo "Skipping non-file artifact: $path"
+              continue
+            fi
+            echo "Uploading: $path"
+            gh release upload "$TAG" "$path" --clobber
+            uploaded=$((uploaded + 1))
+          done < <(printf '%s' "$ARTIFACT_PATHS" | jq -r '.[]')
+          if [ "$uploaded" -eq 0 ]; then
+            echo "::error::No bundle files were uploaded for $TAG"
+            exit 1
+          fi
+          echo "Uploaded $uploaded file(s) for $TAG"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ dist/
 
 # local git worktrees
 /.claude/worktrees/
+
+# Self-signed code-signing artifacts produced by scripts/macos/generate-self-signed-cert.sh
+cert-out/
+*.p12
+*.p12.base64

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Download a prebuilt installer from the [latest release](https://github.com/yasuf
 
 Installers are currently **unsigned**, so macOS Gatekeeper / Windows SmartScreen will warn on first launch — open it from the right-click *Open* menu (macOS) or *More info → Run anyway* (Windows).
 
+### macOS: first launch (self-signed build)
+
+The macOS app is **self-signed**, not notarized by Apple, so Gatekeeper shows a
+warning on first launch. To open it:
+
+1. In Finder, **right-click** the app and choose **Open**, then confirm; or
+2. Remove the quarantine attribute:
+   ```bash
+   xattr -dr com.apple.quarantine /Applications/simple-archiver.app
+   ```
+
 ## Getting started (from source)
 
 Prerequisites: a Rust toolchain, Node.js, and pnpm. The toolchain versions are pinned via [`mise.toml`](mise.toml) (run `mise install` to get them), and the Tauri prerequisites for your OS are listed in the [Tauri docs](https://v2.tauri.app/start/prerequisites/).

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,3 +176,34 @@ activated on codecov.io for reports to appear. Coverage config lives in
 - **Avoid duplicate affordances by swapping on state (PR11 follow-up).** `AddSourceButtons` lives in the `EmptyQueue` drop zone while the queue is empty and in the `SetupToolbar` action bar once it has items — exactly one instance is visible at a time (`SetupToolbar` gates them on `draft.items.length > 0`). Don't render the same affordance in two always-present places; pick the owner by state, keeping a persistent browse path once the hero drop zone is gone.
 
 For coding conventions (including the English-comment rule), see L3 [`/.claude/conventions.md`](../.claude/conventions.md).
+
+## macOS code signing (self-signed)
+
+Release `.app`/`.dmg` bundles are signed with a fixed self-signed certificate
+**by Tauri at build time** (`.github/workflows/release.yml` passes the signing
+env to the `tauri-action` Build step). Build-time signing is required so the
+`.app` embedded inside the `.dmg` — the artifact users actually run — is signed;
+post-build `codesign` cannot reach it. Notarization is intentionally not done.
+
+The certificate CN is `Developer ID Application: Simple Archiver` with an OU.
+The Apple-style prefix and OU are required only so Tauri's signing-identity
+discovery can find a self-signed cert; they assert no Apple relationship.
+
+### One-time admin setup
+
+1. Generate the certificate:
+   ```bash
+   P12_PASSWORD='<choose-a-password>' ./scripts/macos/generate-self-signed-cert.sh
+   ```
+   (Use Homebrew OpenSSL 3; the script handles the `-legacy` `.p12` flag.)
+2. Add three repository **Secrets**:
+   - `APPLE_CERTIFICATE` = contents of `cert-out/cert.p12.base64`
+   - `APPLE_CERTIFICATE_PASSWORD` = the `P12_PASSWORD` you chose
+   - `KEYCHAIN_PASSWORD` = any random string (temporary CI keychain password)
+3. The signing identity CN is set literally in `release.yml`; change it there if
+   you regenerate with a different CN.
+
+If the secrets are missing, the macOS release job fails at the Preflight step.
+Verify locally by mounting the produced `.dmg` and running
+`codesign --verify --deep --strict <App.app>` on the app inside it — never
+`spctl`, which always rejects a self-signed bundle.

--- a/scripts/macos/generate-self-signed-cert.sh
+++ b/scripts/macos/generate-self-signed-cert.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Generate a self-signed CODE-SIGNING certificate for macOS CI signing.
+# One-off helper for repo admins. Outputs cert.pem, key.pem, cert.p12, and the
+# base64 string to paste into the APPLE_CERTIFICATE GitHub Secret.
+#
+# The CN MUST start with an Apple prefix ("Developer ID Application: ") and the
+# cert MUST carry an OU, because Tauri's signing-identity discovery only matches
+# those prefixes and uses the OU as the Team id. This is a technical requirement
+# of Tauri's self-signed code path; it does not assert any Apple relationship
+# (the cert is self-signed and never notarized).
+#
+# Usage:
+#   P12_PASSWORD='choose-a-password' ./scripts/macos/generate-self-signed-cert.sh
+# Optional env:
+#   CERT_CN   signing identity Common Name (default: "Developer ID Application: Simple Archiver")
+#   CERT_OU   organizational unit / team    (default: "SELFSIGN")
+#   CERT_O    organization                  (default: "Simple Archiver")
+#   OUT_DIR   output directory              (default: ./cert-out)
+set -euo pipefail
+
+CN="${CERT_CN:-Developer ID Application: Simple Archiver}"
+OU="${CERT_OU:-SELFSIGN}"
+O="${CERT_O:-Simple Archiver}"
+P12_PASSWORD="${P12_PASSWORD:?set P12_PASSWORD to the .p12 export password}"
+OUT_DIR="${OUT_DIR:-./cert-out}"
+
+mkdir -p "$OUT_DIR"
+cd "$OUT_DIR"
+
+# Code Signing EKU + digitalSignature + an OU are all mandatory for Tauri to
+# discover and codesign to accept the cert.
+cat > codesign.ext <<EOF
+[req]
+distinguished_name = dn
+x509_extensions = codesign
+prompt = no
+
+[dn]
+CN = ${CN}
+OU = ${OU}
+O = ${O}
+
+[codesign]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+subjectKeyIdentifier = hash
+EOF
+
+# Prefer Homebrew OpenSSL 3 (its .p12 needs -legacy to be importable by macOS
+# `security`); fall back to system openssl/LibreSSL (which rejects -legacy).
+OPENSSL="$(command -v /opt/homebrew/bin/openssl || command -v openssl)"
+echo "Using OpenSSL: $OPENSSL ($("$OPENSSL" version))"
+
+"$OPENSSL" req -x509 -newkey rsa:2048 -nodes \
+  -keyout key.pem -out cert.pem -days 3650 \
+  -config codesign.ext
+
+# OpenSSL 3.x requires -legacy for a macOS-importable .p12; LibreSSL must omit it.
+LEGACY=""
+if "$OPENSSL" version | grep -qiE '^OpenSSL 3'; then
+  LEGACY="-legacy"
+fi
+
+# shellcheck disable=SC2086  # $LEGACY is intentionally word-split (empty or -legacy).
+"$OPENSSL" pkcs12 -export $LEGACY \
+  -inkey key.pem -in cert.pem \
+  -name "$CN" \
+  -out cert.p12 -passout pass:"$P12_PASSWORD"
+
+base64 -i cert.p12 | tr -d '\n' > cert.p12.base64
+
+echo "---"
+echo "Generated: $OUT_DIR/cert.p12"
+echo "Signing identity (CN): $CN"
+echo "APPLE_CERTIFICATE secret   = contents of $OUT_DIR/cert.p12.base64"
+echo "APPLE_CERTIFICATE_PASSWORD = the P12_PASSWORD you chose"
+echo "KEYCHAIN_PASSWORD          = choose any random string for the CI keychain"

--- a/scripts/macos/test-verify-macos-bundles.sh
+++ b/scripts/macos/test-verify-macos-bundles.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Local test for verify-macos-bundles.sh. Signs a minimal .app with a throwaway
+# self-signed cert, builds a .dmg around it, and asserts the verifier passes;
+# then asserts it FAILS for a .dmg whose embedded .app is unsigned.
+# Run on macOS: ./scripts/macos/test-verify-macos-bundles.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d)"
+KC="$WORK/test.keychain-db"
+ORIG="$(security list-keychains -d user | sed 's/"//g')"
+cleanup() {
+  # shellcheck disable=SC2086
+  security list-keychains -d user -s $ORIG >/dev/null 2>&1 || true
+  security delete-keychain "$KC" >/dev/null 2>&1 || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+CN="Developer ID Application: Test Identity"
+P12_PASSWORD="test-p12-pass"
+
+# 1. Generate a throwaway cert via the admin generator (prefixed CN + OU).
+P12_PASSWORD="$P12_PASSWORD" CERT_CN="$CN" CERT_OU="TESTOU" CERT_O="Test" \
+  OUT_DIR="$WORK/cert-out" "$HERE/generate-self-signed-cert.sh" >/dev/null
+
+# 2. Import into a temp keychain and add to the user search list (so codesign
+#    can resolve the identity by name without trust).
+security create-keychain -p kcpass "$KC" >/dev/null
+security set-keychain-settings "$KC" >/dev/null
+security unlock-keychain -p kcpass "$KC" >/dev/null
+security import "$WORK/cert-out/cert.p12" -k "$KC" -P "$P12_PASSWORD" -T /usr/bin/codesign >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k kcpass "$KC" >/dev/null 2>&1
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$KC" $ORIG >/dev/null
+
+mk_app() { # $1 = .app path
+  mkdir -p "$1/Contents/MacOS"
+  cp /bin/echo "$1/Contents/MacOS/Sample"
+  printf '<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleExecutable</key><string>Sample</string><key>CFBundleIdentifier</key><string>com.simplearchiver.test</string></dict></plist>' > "$1/Contents/Info.plist"
+}
+
+# 3. POSITIVE: signed .app inside a .dmg -> verifier must pass.
+SDIR="$WORK/signed"; mkdir -p "$SDIR"; mk_app "$SDIR/Sample.app"
+codesign --force --deep --timestamp=none --keychain "$KC" --sign "$CN" "$SDIR/Sample.app" >/dev/null 2>&1
+hdiutil create -volname Sample -srcfolder "$SDIR" -ov -format UDZO "$WORK/signed.dmg" >/dev/null
+"$HERE/verify-macos-bundles.sh" "$SDIR/Sample.app" "$WORK/signed.dmg"
+echo "PASS: positive (embedded .app verifies)"
+
+# 4. NEGATIVE: unsigned .app inside a .dmg -> verifier must fail (nonzero).
+UDIR="$WORK/unsigned"; mkdir -p "$UDIR"; mk_app "$UDIR/Sample.app"
+hdiutil create -volname SampleU -srcfolder "$UDIR" -ov -format UDZO "$WORK/unsigned.dmg" >/dev/null
+if "$HERE/verify-macos-bundles.sh" "$SDIR/Sample.app" "$WORK/unsigned.dmg" >/dev/null 2>&1; then
+  echo "FAIL: verifier passed an unsigned embedded .app"; exit 1
+fi
+echo "PASS: negative (unsigned embedded .app rejected)"
+
+echo "ALL TESTS PASSED"

--- a/scripts/macos/verify-macos-bundles.sh
+++ b/scripts/macos/verify-macos-bundles.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Verify macOS bundle code signatures. Signing itself is done by Tauri at build
+# time; this script only verifies. Critically, it mounts the .dmg and verifies
+# the .app INSIDE it — the artifact users actually run — not just the external
+# .app and the dmg wrapper. Uses codesign only (never spctl: a self-signed
+# cert always fails Gatekeeper assessment).
+#
+# Args: <app-path> [dmg-path]
+set -euo pipefail
+
+app="${1:?usage: verify-macos-bundles.sh <app-path> [dmg-path]}"
+dmg="${2:-}"
+
+echo "Verifying standalone .app: $app"
+codesign --verify --deep --strict --verbose=2 "$app"
+codesign -dvv "$app" 2>&1 | grep -E 'Authority|Identifier=' || true
+
+if [ -n "$dmg" ]; then
+  echo "Verifying .dmg wrapper: $dmg"
+  codesign --verify --verbose=2 "$dmg" || echo "note: .dmg wrapper signature not present (continuing)"
+
+  echo "Mounting .dmg to verify the embedded .app (the shipped artifact)"
+  mount_point="$(mktemp -d)"
+  detach() { hdiutil detach "$mount_point" >/dev/null 2>&1 || true; rmdir "$mount_point" 2>/dev/null || true; }
+  trap detach EXIT
+  hdiutil attach -nobrowse -readonly -mountpoint "$mount_point" "$dmg" >/dev/null
+
+  inner_app="$(find "$mount_point" -maxdepth 1 -name '*.app' -type d | head -n1 || true)"
+  if [ -z "$inner_app" ]; then
+    echo "::error::No .app found inside the mounted .dmg"
+    exit 1
+  fi
+  echo "Verifying embedded .app: $inner_app"
+  codesign --verify --deep --strict --verbose=2 "$inner_app"
+  codesign -dvv "$inner_app" 2>&1 | grep -E 'Authority' || true
+fi
+
+echo "macOS signature verification complete."


### PR DESCRIPTION
## Summary

Sign the macOS release bundles with a self-signed certificate **applied by Tauri at build time**, so the `.app` shipped *inside* the `.dmg` is actually signed. Verify the signature in CI — including the `.app` inside the mounted `.dmg` — and fail the build if signing secrets are missing.

This supersedes the earlier post-build `codesign` approach, which signed the standalone `.app` after the `.dmg` was already assembled, leaving the in-dmg app (the artifact users run) unsigned while external `codesign --verify` stayed green.

Closes #68.

## Changes

- **`scripts/macos/generate-self-signed-cert.sh`** (new): one-off admin helper generating a self-signed code-signing cert (Apple-prefixed CN + OU + Code Signing EKU, required for Tauri's identity discovery; OpenSSL 3 `-legacy` `.p12` handled).
- **`scripts/macos/verify-macos-bundles.sh`** (new): verifies signatures, mounting the `.dmg` to check the embedded `.app`. Uses `codesign` only (never `spctl`).
- **`scripts/macos/test-verify-macos-bundles.sh`** (new): local TDD test — asserts the verifier passes for a signed in-dmg app and fails for an unsigned one.
- **`.github/workflows/release.yml`**: macOS-only Preflight (fail fast on missing secrets), build-time signing env on the `tauri-action` step, a post-build "Verify macOS signatures" step, and a hardened upload loop that fails if nothing was uploaded.
- **`.gitignore`**: ignore generated cert artifacts.
- **`README.md`** / **`docs/development.md`**: first-launch note and signing/admin docs.

## Verification (local, macOS)

- Cert generator: subject `CN=Developer ID Application: Simple Archiver, OU=SELFSIGN`, extensions `CA:FALSE / Digital Signature / Code Signing`. `shellcheck` clean.
- `test-verify-macos-bundles.sh`: RED (verifier missing) → GREEN (positive + negative cases pass). `shellcheck` clean.
- `release.yml`: `actionlint` clean.

## Notes

- `APPLE_SIGNING_IDENTITY` value is double-quoted in YAML because its embedded `: ` is otherwise parsed as a mapping (actionlint/PyYAML reject the unquoted form); GitHub Actions evaluates the `${{ }}` identically.
- Requires three repository Secrets before a release run: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD` (see `docs/development.md`).
- Full validation of the YAML wiring + Tauri actually signing the in-dmg app on a hosted runner requires a real `release.yml` run (`workflow_dispatch` against an existing tag).
