### PR TITLE
refactor(domain): lift requires_extraction() into SourceItem (#70)

### DIFF
--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -176,8 +176,7 @@ async fn run_one<A: Archiver, E: Extractor>(
     // rar/zip files extract first; folders compress directly. Emit the extraction
     // status only for sources that actually extract, so the task walks the legal
     // Pending -> Extracting -> Compressing path (folders take the fast-path).
-    let needs_extract = matches!(item.source, SourceItem::RarFile(_) | SourceItem::ZipFile(_));
-    if needs_extract {
+    if item.source.requires_extraction() {
         let _ = tx.send(WorkerMsg::Status {
             task: item.task,
             event: TaskEvent::StartExtracting,

--- a/crates/core/src/domain/source_item.rs
+++ b/crates/core/src/domain/source_item.rs
@@ -41,6 +41,19 @@ impl SourceItem {
             _ => Err(UnsupportedSourceItem(path)),
         }
     }
+
+    /// Returns `true` if this source item requires an extraction step before
+    /// compression. Archives (`RarFile`, `ZipFile`) extract first; a `Folder`
+    /// compresses directly.
+    ///
+    /// The exhaustive match ensures that adding a new variant is a compile error
+    /// until this method is updated.
+    pub fn requires_extraction(&self) -> bool {
+        match self {
+            SourceItem::RarFile(_) | SourceItem::ZipFile(_) => true,
+            SourceItem::Folder(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -229,5 +242,23 @@ mod tests {
             SourceItem::classify(p.clone(), true),
             Ok(SourceItem::Folder(p))
         );
+    }
+
+    #[test]
+    fn requires_extraction_is_true_for_rar() {
+        let item = SourceItem::RarFile(PathBuf::from("/a/b.rar"));
+        assert!(item.requires_extraction());
+    }
+
+    #[test]
+    fn requires_extraction_is_true_for_zip() {
+        let item = SourceItem::ZipFile(PathBuf::from("/a/b.zip"));
+        assert!(item.requires_extraction());
+    }
+
+    #[test]
+    fn requires_extraction_is_false_for_folder() {
+        let item = SourceItem::Folder(PathBuf::from("/a/b"));
+        assert!(!item.requires_extraction());
     }
 }


### PR DESCRIPTION
## Summary

Lifts the extraction predicate out of the run engine and into the domain layer. Adds `SourceItem::requires_extraction(&self) -> bool` backed by an exhaustive `match` so the compiler enforces completeness whenever a new `SourceItem` variant is added. The inline `matches!(item.source, SourceItem::RarFile(_) | SourceItem::ZipFile(_))` expression in `run_archive_job.rs` is replaced with a single call to this method; behaviour is unchanged.

Closes #70

## Changes

### Domain (`crates/core/src/domain/source_item.rs`)

- Add `pub fn requires_extraction(&self) -> bool` to `impl SourceItem`, placed immediately after `classify`.
- Doc comment explains the exhaustive-match invariant: adding a new variant without updating this method is a compile error.
- Add three `#[cfg(test)]` unit tests: `requires_extraction_is_true_for_rar`, `requires_extraction_is_true_for_zip`, `requires_extraction_is_false_for_folder`.

### Application (`crates/core/src/application/run_archive_job.rs`)

- Replace `let needs_extract = matches!(item.source, SourceItem::RarFile(_) | SourceItem::ZipFile(_)); if needs_extract {` with `if item.source.requires_extraction() {`.
- Remove the now-unused `needs_extract` binding; retain the explanatory comment on the `if` line.

## Testing

| Gate | Result |
|---|---|
| `cargo nextest run -p simple-archiver-core` (201 tests) | green |
| `cargo clippy -p simple-archiver-core --all-targets -D warnings` | clean |
| `cargo fmt` | clean |

## Test plan

- [ ] CI `core` job is green: `cargo nextest run -p simple-archiver-core`, `cargo clippy`, and `cargo fmt --check` all pass.
- [ ] Three new `requires_extraction_*` tests appear in the nextest output and pass.
- [ ] `run_archive_job.rs` no longer contains `matches!(item.source, SourceItem::RarFile(_) | SourceItem::ZipFile(_))`.
- [ ] Behaviour is unchanged: `TaskEvent::StartExtracting` is emitted for `RarFile` and `ZipFile`, not for `Folder`.
- [ ] Adding a hypothetical fourth `SourceItem` variant without updating `requires_extraction` produces a compiler error (exhaustive-match guarantee).
