### PR TITLE
fix(frontend): align run readiness with isValidOutputDir for blank dirs (#74)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,10 +36,16 @@ vi.mock("@/lib/archive", () => ({
 }));
 
 // Mock the smart-default output-dir resolver so the mount effect can be driven
-// deterministically without a Tauri backend.
-vi.mock("@/lib/output-dir-default", () => ({
-  resolveInitialOutputDir: vi.fn(() => Promise.resolve(null)),
-}));
+// deterministically without a Tauri backend. Spread the real module so all
+// other exports (e.g. isValidOutputDir) behave normally in tests.
+vi.mock("@/lib/output-dir-default", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/output-dir-default")>();
+  return {
+    ...actual,
+    resolveInitialOutputDir: vi.fn(() => Promise.resolve(null)),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/lib/readiness.test.ts
+++ b/src/lib/readiness.test.ts
@@ -12,6 +12,12 @@ describe("readinessFor", () => {
     expect(readinessFor(1, null)).toBe("choose-destination");
   });
 
+  it("reports choose-destination for a whitespace-only output directory", () => {
+    expect(readinessFor(1, "   ")).toBe("choose-destination");
+    expect(readinessFor(1, "\t")).toBe("choose-destination");
+    expect(readinessFor(1, "")).toBe("choose-destination");
+  });
+
   it("reports ready when items exist and a destination is set", () => {
     expect(readinessFor(1, "/out")).toBe("ready");
   });

--- a/src/lib/readiness.ts
+++ b/src/lib/readiness.ts
@@ -10,6 +10,8 @@
  * `readinessFor`.
  */
 
+import { isValidOutputDir } from "./output-dir-default";
+
 /**
  * What the user still needs to do before a run is possible. `"ready"` is the
  * only state in which Run is enabled.
@@ -25,7 +27,7 @@ export function readinessFor(
   outputDir: string | null,
 ): Readiness {
   if (itemCount === 0) return "add-files";
-  if (!outputDir) return "choose-destination";
+  if (!isValidOutputDir(outputDir)) return "choose-destination";
   return "ready";
 }
 


### PR DESCRIPTION
## Summary

`readinessFor` in `src/lib/readiness.ts` was gating on `!outputDir` (bare truthiness check), which let a whitespace-only string like `"   "` pass as a valid destination and return `"ready"`, enabling the Run button. `persistOutputDir` in `src/lib/output-dir-default.ts` already rejects whitespace-only values via `isValidOutputDir` (`.trim().length > 0`), so the two validity checks were divergent. This fix imports and delegates to `isValidOutputDir` inside `readinessFor` so both checks agree.

## Changes

### `src/lib/readiness.ts` — delegate to `isValidOutputDir`

- Imports `isValidOutputDir` from `./output-dir-default`.
- Replaces `if (!outputDir)` with `if (!isValidOutputDir(outputDir))` so a whitespace-only string returns `"choose-destination"` instead of `"ready"`.

### `src/lib/readiness.test.ts` — failing-first whitespace tests

- Adds `describe` case: `readinessFor(1, "   ")`, `readinessFor(1, "\t")`, and `readinessFor(1, "")` must all return `"choose-destination"`.
- Written before the fix (TDD red → green).

### `src/App.test.tsx` — mock alignment

- Updates the `@/lib/output-dir-default` `vi.mock` to use `importOriginal` so the real `isValidOutputDir` is included in the mock and integrated render tests don't throw `No export defined`.

## Verification

Run the frontend lane checks locally and confirm all pass:

```
pnpm test       # 260 tests, 31 files — all green
pnpm lint:ci    # oxlint — no errors
pnpm fmt:check  # oxfmt — no formatting issues
pnpm build      # Vite + tsc type gate — built successfully
pnpm knip       # no unused exports
```

## Test plan

- [ ] `pnpm test` passes — all 260 tests green, including the new `"reports choose-destination for a whitespace-only output directory"` case
- [ ] `pnpm lint:ci` passes with no oxlint errors
- [ ] `pnpm fmt:check` passes — no formatting drift
- [ ] `pnpm build` completes without TypeScript errors (primary type gate)
- [ ] `pnpm knip` reports no unused exports
- [ ] Regression: enter a valid path in the destination field — Run button still enables correctly
- [ ] Manual: enter only spaces in the destination field — Run button remains disabled and the readiness chip shows "Choose an output directory"

Closes #74
