### PR TITLE
refactor(frontend): extract taskOutcomeFor into lib/status (#76)

### DIFF
--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -11,7 +11,7 @@ import {
   progressPercent,
 } from "@/lib/format";
 import { basename } from "@/lib/path";
-import { statusVisual } from "@/lib/status";
+import { statusVisual, taskOutcomeFor } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
 
 // ---------------------------------------------------------------------------
@@ -72,17 +72,23 @@ function computeStatus(
     if (taskId === undefined) {
       return "Done";
     }
-    if (summary.succeeded.includes(taskId)) {
-      return statusVisual("succeeded").label;
+    // Delegate the summary → outcome rule to the shared lib/status helper so
+    // the membership-testing lives in exactly one place; this branch only maps
+    // the resolved outcome back to its rendered string.
+    const outcome = taskOutcomeFor(taskId, summary);
+    switch (outcome.kind) {
+      case "succeeded":
+        return statusVisual("succeeded").label;
+      case "cancelled":
+        return statusVisual("cancelled").label;
+      case "failed":
+        return `${statusVisual("failed").label}: ${outcome.reason}`;
+      default:
+        // `done` (id in no bucket) and `pending` (no summary) — neither is
+        // reachable here (summary is non-null and taskId is defined), but both
+        // map to the same "Done" string the original linear scan produced.
+        return "Done";
     }
-    if (summary.cancelled.includes(taskId)) {
-      return statusVisual("cancelled").label;
-    }
-    const failedEntry = summary.failed.find((f) => f.taskId === taskId);
-    if (failedEntry !== undefined) {
-      return `${statusVisual("failed").label}: ${failedEntry.reason}`;
-    }
-    return "Done";
   }
 
   return "Waiting";

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { statusVisual } from "./status";
+import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+
+import { statusVisual, taskOutcomeFor } from "./status";
 
 describe("statusVisual", () => {
   it("maps succeeded to the unified 'Succeeded' label and the success tokens", () => {
@@ -25,5 +27,36 @@ describe("statusVisual", () => {
     expect(v.icon).toBe("✗");
     expect(v.className).toContain("bg-status-danger-subtle");
     expect(v.className).toContain("text-status-danger-foreground");
+  });
+});
+
+describe("taskOutcomeFor", () => {
+  const summary: JobSummaryDto = {
+    succeeded: [1, 2],
+    cancelled: [3],
+    failed: [{ taskId: 4, reason: "boom" }],
+  };
+
+  it("resolves a succeeded id to a succeeded outcome", () => {
+    expect(taskOutcomeFor(1, summary)).toEqual({ kind: "succeeded" });
+  });
+
+  it("resolves a cancelled id to a cancelled outcome", () => {
+    expect(taskOutcomeFor(3, summary)).toEqual({ kind: "cancelled" });
+  });
+
+  it("resolves a failed id to a failed outcome carrying its reason", () => {
+    expect(taskOutcomeFor(4, summary)).toEqual({
+      kind: "failed",
+      reason: "boom",
+    });
+  });
+
+  it("resolves an id in no bucket to a done outcome", () => {
+    expect(taskOutcomeFor(99, summary)).toEqual({ kind: "done" });
+  });
+
+  it("resolves to pending when there is no summary yet", () => {
+    expect(taskOutcomeFor(1, null)).toEqual({ kind: "pending" });
   });
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -9,6 +9,8 @@
  * panel and the per-row task list, and keeps the domain-state → visual-token
  * mapping in exactly one location.
  */
+import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+
 // The three members MUST stay in sync with the keys of the backend `JobSummaryDto`
 // (`succeeded` | `cancelled` | `failed`). RunSummary/TaskList pass these as string
 // literals, so a renamed or added DTO bucket would silently leave this union stale.
@@ -49,4 +51,40 @@ const STATUS_VISUALS: Record<TaskOutcome, StatusVisual> = {
 /** Resolve the presentation for a task outcome. */
 export function statusVisual(outcome: TaskOutcome): StatusVisual {
   return STATUS_VISUALS[outcome];
+}
+
+/**
+ * The resolved outcome of a single task once a job has finished.
+ *
+ * It widens the three terminal `TaskOutcome` buckets with two non-bucket
+ * states that only exist at the per-row level: `done` (a summary is present but
+ * the id is in no bucket) and `pending` (no summary yet — the job has not
+ * finished). The `failed` variant carries the verbatim backend reason.
+ */
+export type TaskOutcomeResult =
+  | { kind: "succeeded" }
+  | { kind: "cancelled" }
+  | { kind: "failed"; reason: string }
+  | { kind: "done" } // id not found in any summary bucket
+  | { kind: "pending" }; // no summary yet (job not finished)
+
+/**
+ * Resolve a finished task's outcome from the JobSummaryDto by membership-
+ * testing `taskId` against the succeeded/cancelled/failed buckets. Pure: no
+ * React/Tauri. `pending` = no summary; `done` = summary present but id in no
+ * bucket. This is the single owner of the summary → outcome rule, reused by the
+ * per-row task list and the run-summary panel.
+ */
+export function taskOutcomeFor(
+  taskId: number,
+  summary: JobSummaryDto | null,
+): TaskOutcomeResult {
+  if (summary === null) return { kind: "pending" };
+  if (summary.succeeded.includes(taskId)) return { kind: "succeeded" };
+  if (summary.cancelled.includes(taskId)) return { kind: "cancelled" };
+  const failedEntry = summary.failed.find((f) => f.taskId === taskId);
+  if (failedEntry !== undefined) {
+    return { kind: "failed", reason: failedEntry.reason };
+  }
+  return { kind: "done" };
 }


### PR DESCRIPTION
## Summary

`TaskRow.computeStatus` resolved a finished task's outcome inline by membership-testing the `taskId` against `summary.succeeded` / `.cancelled` / `.failed` and assembling the label. This lifts that rule into a pure, total helper `taskOutcomeFor(taskId, summary): TaskOutcomeResult` in `src/lib/status.ts` and has `TaskRow` delegate to it; rendered strings are byte-identical.

## Background / Motivation

- The summary → outcome resolution lived inline in a presentational component, mixing a domain-ish classification rule with rendering.
- The same membership shape risked being re-derived per consumer, so the rule belongs once in the pure `src/lib/` layer (no React/Tauri), where it is unit-testable in isolation.

## Changes

### `src/lib/status.ts` — new pure `taskOutcomeFor`

- Adds `taskOutcomeFor(taskId: number, summary: JobSummaryDto | null): TaskOutcomeResult`, a total classifier over the summary buckets: `succeeded` / `cancelled` / `failed` (carrying its reason) / `done` (id in no bucket) / `pending` (no summary yet).
- Adds the `TaskOutcomeResult` discriminated union, named distinctly to avoid colliding with the existing `TaskOutcome` string union.
- Stays pure: a single `import type { JobSummaryDto }` — no React/Tauri imports.

### `src/components/TaskRow.tsx` — consume the helper

- `computeStatus`' summary branch now switches on `taskOutcomeFor(...).kind` instead of re-deriving membership inline; the exact rendered strings (`Failed: <reason>`, `Done`, `Waiting`, `Processing`, and the `Succeeded`/`Cancelled` labels) are unchanged.

### Tests

- `src/lib/status.test.ts`: new `describe("taskOutcomeFor")` suite — 5 cases (succeeded / cancelled / failed-with-reason / not-found → `done` / no-summary → `pending`), written failing-first (TDD red → green).
- All pre-existing tests stay green, including the unchanged `TaskRow.test.tsx` and `RunSummary.test.tsx`.

Note: `RunSummary.tsx` is intentionally untouched — its `outputNameForTask` is a pure index→name lookup with no bucket membership test to route through the helper, so inventing one there was explicitly out of scope.

## Verification

Run the frontend lane checks locally and confirm all pass:

```
pnpm test       # 273 tests, 31 files — all green
pnpm lint:ci    # oxlint --deny-warnings — no errors
pnpm fmt:check  # oxfmt --check — no formatting drift
pnpm build      # tsc + vite type gate — built in ~0.7s
pnpm knip       # no unused exports
```

## Test plan

- [ ] `pnpm test` passes — 273 tests across 31 files, including the new `taskOutcomeFor` suite and the unchanged `TaskRow.test.tsx` / `RunSummary.test.tsx`
- [ ] `pnpm lint:ci` passes with no oxlint errors
- [ ] `pnpm fmt:check` passes — no formatting drift
- [ ] `pnpm build` completes without TypeScript errors (primary type gate)
- [ ] `pnpm knip` reports no unused exports
- [ ] Regression: run a job to completion with a mix of succeeded / failed / cancelled tasks and confirm each row's status text (`Succeeded`, `Cancelled`, `Failed: <reason>`, `Done`) renders exactly as before

Closes #76
