### PR TITLE
refactor(frontend): dedupe output-name preview into the store (#78)

### DIFF
--- a/src/components/NamingRuleForm.tsx
+++ b/src/components/NamingRuleForm.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { DEFAULT_TEMPLATE } from "@/lib/naming";
 import { useJobStore } from "@/store/jobStore";
 
-// The naming template the form seeds with. Exported so OutputSettings can use
-// the same default when the store has not yet been given a template, keeping a
-// single source of truth for the starting template.
-export const DEFAULT_TEMPLATE = "photo_{n:03}";
+// Re-export so existing importers (and tests) keep a stable entry point while
+// the constant itself lives in lib (shared with the store, no import cycle).
+export { DEFAULT_TEMPLATE };
 
 // Wait this long after the last keystroke before pushing the template into the
 // store, so we make one store/IPC round-trip per typing pause rather than one

--- a/src/components/OutputSettings.test.tsx
+++ b/src/components/OutputSettings.test.tsx
@@ -1,9 +1,8 @@
 import { open } from "@tauri-apps/plugin-dialog";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_TEMPLATE } from "@/components/NamingRuleForm";
 import { previewOutputName } from "@/lib/archive";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
@@ -14,8 +13,9 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
 }));
 
-// The preview filename is owned by the backend; mock the wrapper so the
-// full-path preview is deterministic without a Tauri runtime.
+// previewOutputName is owned by the store now; mock the wrapper only so the
+// child NamingRuleForm's debounced store push cannot reach a real backend.
+// OutputSettings itself no longer calls it: it reads the store's firstPreview.
 vi.mock("@/lib/archive", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/archive")>();
   return { ...actual, previewOutputName: vi.fn() };
@@ -40,141 +40,137 @@ describe("OutputSettings", () => {
     expect(screen.getByText("Name")).toBeDefined();
   });
 
-  it("shows the filename only and a hint when no destination is selected", async () => {
+  it("shows the filename only and a hint when no destination is selected", () => {
     useJobStore.setState({
       draft: { items: [], namingTemplate: "photo_{n:03}", outputDir: null },
+      firstPreview: "photo_001.zip",
     });
     render(<OutputSettings />);
 
-    // The bare filename appears once the debounced preview resolves.
-    await screen.findByText("photo_001.zip");
+    // The bare filename appears from the store's firstPreview.
+    expect(screen.getByText("photo_001.zip")).toBeDefined();
     // The hint nudges the user to pick a destination for the full path.
     expect(
       screen.getByText("Select a destination to preview the full path."),
     ).toBeDefined();
   });
 
-  it("shows the joined full path once a destination is selected", async () => {
+  it("shows the joined full path once a destination is selected", () => {
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
         outputDir: "~/Archives",
       },
+      firstPreview: "photo_001.zip",
     });
     render(<OutputSettings />);
 
-    await screen.findByText("~/Archives/photo_001.zip");
+    expect(screen.getByText("~/Archives/photo_001.zip")).toBeDefined();
     // The destination-required hint must be gone once a destination exists.
     expect(
       screen.queryByText("Select a destination to preview the full path."),
     ).toBeNull();
   });
 
-  it("surfaces a template error from the preview as an alert", async () => {
-    vi.mocked(previewOutputName).mockRejectedValue(
-      "invalid naming template: stray or malformed brace",
-    );
+  it("surfaces a template error from the store preview as an alert", () => {
     useJobStore.setState({
       draft: { items: [], namingTemplate: "photo_{n", outputDir: null },
+      firstPreview: "",
+      previewError: "invalid naming template: stray or malformed brace",
     });
     render(<OutputSettings />);
 
-    const alert = await screen.findByRole("alert");
+    const alert = screen.getByRole("alert");
     expect(alert.textContent ?? "").toMatch(/invalid naming template/i);
   });
 
-  it("clears the alert and restores the preview after a previously failing template becomes valid", async () => {
-    // Start with a bad template so the alert fires.
-    vi.mocked(previewOutputName).mockRejectedValue(
-      "invalid naming template: stray or malformed brace",
-    );
+  it("clears the alert and restores the preview after the store recovers", () => {
+    // Start in an error state so the alert fires.
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n",
         outputDir: "~/Archives",
       },
+      firstPreview: "",
+      previewError: "invalid naming template: stray or malformed brace",
     });
     render(<OutputSettings />);
 
-    // Wait for the initial error alert to appear.
-    const alert = await screen.findByRole("alert");
+    const alert = screen.getByRole("alert");
     expect(alert.textContent ?? "").toMatch(/invalid naming template/i);
 
-    // Switch to a good template: the mock now resolves successfully.
-    vi.mocked(previewOutputName).mockResolvedValue("photo_001.zip");
+    // The store recovers: a good template resolves to a preview, error cleared.
     act(() => {
       useJobStore.setState((s) => ({
         draft: { ...s.draft, namingTemplate: "photo_{n:03}" },
+        firstPreview: "photo_001.zip",
+        previewError: null,
       }));
     });
 
-    // The alert must disappear and the resolved full path must appear.
-    await waitFor(() => {
-      expect(screen.queryByRole("alert")).toBeNull();
-    });
-    await screen.findByText("~/Archives/photo_001.zip");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText("~/Archives/photo_001.zip")).toBeDefined();
   });
 
-  it("computes the preview from the current template via previewOutputName(seq=1)", async () => {
+  // Pinning regression (issue #78 step 1): OutputSettings shows the store's
+  // first preview joined with the directory, and re-renders when it changes.
+  it("renders the store firstPreview joined with the directory and tracks changes", () => {
     useJobStore.setState({
       draft: {
-        items: [],
-        namingTemplate: "img_{n:02}",
+        items: [{ path: "/a.rar", kind: "rar" }],
+        namingTemplate: "photo_{n:03}",
         outputDir: "~/Archives",
       },
+      firstPreview: "photo_001.zip",
     });
     render(<OutputSettings />);
 
-    await waitFor(() => {
-      expect(vi.mocked(previewOutputName)).toHaveBeenCalledWith(
-        "img_{n:02}",
-        1,
-      );
+    expect(screen.getByText("~/Archives/photo_001.zip")).toBeDefined();
+
+    // When the store's firstPreview changes, the rendered hero follows.
+    act(() => {
+      useJobStore.setState({ firstPreview: "photo_999.zip" });
     });
+    expect(screen.getByText("~/Archives/photo_999.zip")).toBeDefined();
+    expect(screen.queryByText("~/Archives/photo_001.zip")).toBeNull();
   });
 
-  // Regression: when the template preview rejects and outputDir is set, the
+  // Regression: when the store preview errors and outputDir is set, the
   // component must not render the directory path alone (e.g. "~/Archives/")
   // in the full-path preview area. The alert itself is still shown; only
   // the isolated directory must be absent from the monospace preview span.
-  it("does not render directory-only path after a preview error with outputDir set", async () => {
-    vi.mocked(previewOutputName).mockRejectedValue(
-      "invalid naming template: stray or malformed brace",
-    );
+  it("does not render directory-only path after a preview error with outputDir set", () => {
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n",
         outputDir: "~/Archives",
       },
+      firstPreview: "",
+      previewError: "invalid naming template: stray or malformed brace",
     });
     render(<OutputSettings />);
 
-    // Wait for the alert to appear to confirm the error path was reached.
-    const alert = await screen.findByRole("alert");
+    const alert = screen.getByRole("alert");
     expect(alert.textContent ?? "").toMatch(/invalid naming template/i);
 
     // The full-path preview span (font-mono) must not exist in the DOM.
-    // queryAllByText with the exact trailing-slash string checks the specific
-    // rendered output; the destination picker shows "~/Archives" without the
-    // slash so a queryByText for the slash-terminated form is unambiguous.
     expect(screen.queryByText("~/Archives/")).toBeNull();
   });
 
-  // Regression: while the preview is still loading (previewName === null), the
+  // Regression: while the preview is still loading (firstPreview === null), the
   // hero must render neither a full path nor a bare filename, so the directory
-  // is never shown in isolation during the debounce window.
+  // is never shown in isolation during the recompute window.
   it("does not render the hero path while the preview is still loading", () => {
-    // A pending promise keeps previewName null for the duration of the test.
-    vi.mocked(previewOutputName).mockReturnValue(new Promise<string>(() => {}));
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
         outputDir: "~/Archives",
       },
+      firstPreview: null,
     });
     render(<OutputSettings />);
 
@@ -182,20 +178,18 @@ describe("OutputSettings", () => {
     expect(screen.queryByText("photo_001.zip")).toBeNull();
   });
 
-  // Regression: when the preview rejects and no destination is set, the hero
+  // Regression: when the preview errors and no destination is set, the hero
   // must not render the filename-only line; only the alert and the
   // destination-required hint remain.
-  it("does not render the filename-only hero after a preview error with no destination", async () => {
-    vi.mocked(previewOutputName).mockRejectedValue(
-      "invalid naming template: stray or malformed brace",
-    );
+  it("does not render the filename-only hero after a preview error with no destination", () => {
     useJobStore.setState({
       draft: { items: [], namingTemplate: "photo_{n", outputDir: null },
+      firstPreview: "",
+      previewError: "invalid naming template: stray or malformed brace",
     });
     render(<OutputSettings />);
 
-    // Wait for the alert to confirm the error path was reached.
-    const alert = await screen.findByRole("alert");
+    const alert = screen.getByRole("alert");
     expect(alert.textContent ?? "").toMatch(/invalid naming template/i);
 
     // The hint renders independently of the alert: both must appear together
@@ -209,17 +203,18 @@ describe("OutputSettings", () => {
 
   // The hero must show the full path with a leading arrow once a destination is
   // set; the arrow is absent in the filename-only (no-destination) state.
-  it("renders the hero arrow only when a destination joins the filename", async () => {
+  it("renders the hero arrow only when a destination joins the filename", () => {
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
         outputDir: "~/Archives",
       },
+      firstPreview: "photo_001.zip",
     });
     render(<OutputSettings />);
 
-    await screen.findByText("~/Archives/photo_001.zip");
+    expect(screen.getByText("~/Archives/photo_001.zip")).toBeDefined();
     // The ArrowRight icon carries data-testid="hero-path-arrow"; this assertion
     // is specific to the arrow icon (not any arbitrary SVG in the tree).
     expect(screen.getByTestId("hero-path-arrow")).toBeDefined();
@@ -230,35 +225,19 @@ describe("OutputSettings", () => {
   // test would still pass, but if the condition were inverted (always rendered)
   // this test would fail. It pairs with the positive test above to guard both
   // directions of the conditional.
-  it("does not render the hero arrow when no destination is selected", async () => {
+  it("does not render the hero arrow when no destination is selected", () => {
     useJobStore.setState({
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
         outputDir: null,
       },
+      firstPreview: "photo_001.zip",
     });
     render(<OutputSettings />);
 
-    // Wait for the preview to resolve so we know the hero has rendered.
-    await screen.findByText("photo_001.zip");
+    expect(screen.getByText("photo_001.zip")).toBeDefined();
     // The arrow must be absent in the filename-only state.
     expect(screen.queryByTestId("hero-path-arrow")).toBeNull();
-  });
-
-  // When the store has not pushed a namingTemplate yet (null), OutputSettings
-  // must fall back to DEFAULT_TEMPLATE when calling previewOutputName.
-  it("falls back to DEFAULT_TEMPLATE when store namingTemplate is null", async () => {
-    useJobStore.setState({
-      draft: { items: [], namingTemplate: null, outputDir: "~/Archives" },
-    });
-    render(<OutputSettings />);
-
-    await waitFor(() => {
-      expect(vi.mocked(previewOutputName)).toHaveBeenCalledWith(
-        DEFAULT_TEMPLATE,
-        1,
-      );
-    });
   });
 });

--- a/src/components/OutputSettings.tsx
+++ b/src/components/OutputSettings.tsx
@@ -1,20 +1,9 @@
 import { ArrowRight } from "lucide-react";
-import { useEffect, useState } from "react";
 
-import {
-  DEBOUNCE_MS,
-  DEFAULT_TEMPLATE,
-  NamingRuleForm,
-} from "@/components/NamingRuleForm";
+import { NamingRuleForm } from "@/components/NamingRuleForm";
 import { OutputDirPicker } from "@/components/OutputDirPicker";
-import { previewOutputName } from "@/lib/archive";
-import { messageFromReason } from "@/lib/errors";
 import { joinOutputPath } from "@/lib/path";
-import { useJobStore } from "@/store/jobStore";
-
-// The live preview always uses the first (1-based) sequence number, matching the
-// backend's naming contract.
-const PREVIEW_SEQ = 1;
+import { selectFirstPreview, useJobStore } from "@/store/jobStore";
 
 /**
  * OutputSettings is the OUTPUT group organism. It binds the Destination
@@ -29,70 +18,31 @@ const PREVIEW_SEQ = 1;
  *                            of the Destination row only.
  *
  * The preview is derived state: the backend remains the single source of truth
- * for the filename. OutputSettings reads the store's naming template (falling
- * back to DEFAULT_TEMPLATE before NamingRuleForm has pushed one), debounces a
- * single previewOutputName(template, 1) call, then joins the result with the
- * output directory for display. The sub-controls keep their own concerns
+ * for the filename, and the store is the single source of truth for the preview.
+ * OutputSettings only reads the store's hero preview (firstPreview) and joins it
+ * with the output directory for display — it runs no debounce or previewOutputName
+ * call of its own. The store's recomputePreviews owns the debounce/race guard and
+ * the DEFAULT_TEMPLATE first-paint fallback, so the per-item previewNames and this
+ * hero can never disagree mid-flight. The sub-controls keep their own concerns
  * (input + store push, directory picking); OutputSettings only joins them for
  * display.
- *
- * Note on preview state: this component holds one local previewName string
- * (the single filename resolved from the store template). This is distinct from
- * the store's per-item previewNames array consumed by TaskList/RunSummary; the
- * two never overlap.
  */
 export function OutputSettings() {
-  const template = useJobStore((s) => s.draft.namingTemplate);
   const outputDir = useJobStore((s) => s.draft.outputDir);
 
-  // null  = still loading (debounce pending or first async call in flight).
-  // ""    = preview could not be resolved (error path); the hero path is
-  //         suppressed the same way as for null, so the directory is never
-  //         shown in isolation.
-  // <str> = resolved filename ready for display.
-  const [previewName, setPreviewName] = useState<string | null>(null);
-  const [error, setError] = useState("");
-
-  // The effective template: the store value once NamingRuleForm has pushed it,
-  // otherwise the shared default so the preview is meaningful on first paint.
-  const effectiveTemplate = template ?? DEFAULT_TEMPLATE;
-
-  useEffect(() => {
-    // Mark preview as loading so the UI shows nothing while the debounce window
-    // is open and the async call is in flight. This prevents the directory path
-    // alone from briefly appearing when the template has not yet resolved.
-    setPreviewName(null);
-
-    // Guard against out-of-order async results: only the latest effect run may
-    // commit state, so a slow call for an older template cannot overwrite a
-    // newer preview/error.
-    let active = true;
-    const handle = setTimeout(() => {
-      previewOutputName(effectiveTemplate, PREVIEW_SEQ)
-        .then((name) => {
-          if (!active) return;
-          setPreviewName(name);
-          setError("");
-        })
-        .catch((reason) => {
-          if (!active) return;
-          setPreviewName("");
-          setError(
-            messageFromReason(
-              reason,
-              "Could not generate a preview. Please try again.",
-            ),
-          );
-        });
-    }, DEBOUNCE_MS);
-    return () => {
-      active = false;
-      clearTimeout(handle);
-    };
-  }, [effectiveTemplate]);
+  // The single source of preview truth. firstPreview is tri-state:
+  //   null  = still loading (a recompute is pending / in flight),
+  //   ""    = preview could not be resolved (error path); the hero path is
+  //           suppressed the same way as for null, so the directory is never
+  //           shown in isolation,
+  //   <str> = resolved filename ready for display.
+  const previewName = useJobStore(selectFirstPreview);
+  // The preview error from the store; coalesced to "" so the alert is hidden
+  // unless a preview resolution actually failed.
+  const error = useJobStore((s) => s.previewError) ?? "";
 
   // The hero path is only shown when previewName is a non-empty string. Both
-  // null (still loading) and "" (error path, set by .catch) suppress it, so the
+  // null (still loading) and "" (the store's error path) suppress it, so the
   // output directory is never displayed in isolation, which would mislead the
   // user about the actual destination. joinOutputPath already returns the bare
   // filename when outputDir is null, so the same value drives both the full

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -1,0 +1,7 @@
+/**
+ * The naming template the UI seeds with and falls back to before a template has
+ * been pushed into the store. Kept in lib (presentation-agnostic) so both the
+ * store and the NamingRuleForm can share one source of truth for the starting
+ * template without a presentation -> store import cycle.
+ */
+export const DEFAULT_TEMPLATE = "photo_{n:03}";

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/archive", () => ({
 vi.mock("@/lib/output-dir-default", () => ({ persistOutputDir: vi.fn() }));
 
 import * as archive from "@/lib/archive";
+import { DEFAULT_TEMPLATE } from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
 
 import { resetJobStore, useJobStore } from "./jobStore";
@@ -83,15 +84,21 @@ describe("addItems", () => {
     expect(useJobStore.getState().error).toBeNull();
   });
 
-  it("recomputes previews after adding (empty when template is null)", async () => {
+  it("recomputes previews after adding (empty per-item names when template is null)", async () => {
     const draft = makeDraft(2, null);
     mockArchive.addItems.mockResolvedValue(draft);
 
     await useJobStore.getState().addItems(["/a.rar", "/b.rar"]);
 
-    // namingTemplate is null in the returned snapshot, so no preview calls and
-    // previewNames is empty.
-    expect(mockArchive.previewOutputName).not.toHaveBeenCalled();
+    // namingTemplate is null in the returned snapshot, so there are no per-item
+    // preview calls and previewNames is empty. The single hero preview still
+    // resolves from DEFAULT_TEMPLATE at seq 1 (the OUTPUT group always shows a
+    // representative filename, even before a template is pushed).
+    expect(mockArchive.previewOutputName).toHaveBeenCalledTimes(1);
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
+      DEFAULT_TEMPLATE,
+      1,
+    );
     expect(useJobStore.getState().previewNames).toEqual([]);
   });
 
@@ -196,27 +203,29 @@ describe("setNamingRule", () => {
     await useJobStore.getState().setNamingRule("photo_{n:03}");
 
     expect(mockArchive.setNamingRule).toHaveBeenCalledWith("photo_{n:03}");
-    expect(mockArchive.previewOutputName).toHaveBeenCalledTimes(3);
-    expect(mockArchive.previewOutputName).toHaveBeenNthCalledWith(
-      1,
+    // Three per-item previews (seq 1..3) plus one hero preview (seq 1) = four
+    // calls. Each per-item sequence is requested with the template.
+    expect(mockArchive.previewOutputName).toHaveBeenCalledTimes(4);
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
       "photo_{n:03}",
       1,
     );
-    expect(mockArchive.previewOutputName).toHaveBeenNthCalledWith(
-      2,
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
       "photo_{n:03}",
       2,
     );
-    expect(mockArchive.previewOutputName).toHaveBeenNthCalledWith(
-      3,
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
       "photo_{n:03}",
       3,
     );
+    // previewNames stays index-aligned with the three items.
     expect(useJobStore.getState().previewNames).toEqual([
       "photo_001.zip",
       "photo_002.zip",
       "photo_003.zip",
     ]);
+    // The hero preview is the seq-1 filename for the same template.
+    expect(useJobStore.getState().firstPreview).toBe("photo_001.zip");
   });
 
   it("sets error and leaves the draft unchanged on failure", async () => {
@@ -309,9 +318,11 @@ describe("recomputePreviews", () => {
     expect(useJobStore.getState().error).toBe("invalid template");
   });
 
-  it("resolves to empty previews for an empty draft even with a template", async () => {
-    // No items means no preview calls, but a non-null template must not skip the
-    // success bookkeeping: previewNames is [] and error is cleared.
+  it("resolves to empty per-item previews for an empty draft even with a template", async () => {
+    // No items means no per-item preview calls, but a non-null template must not
+    // skip the success bookkeeping: previewNames is [] and error is cleared. The
+    // single hero preview (seq 1) still resolves so the OUTPUT group renders.
+    mockArchive.previewOutputName.mockResolvedValue("photo_001.zip");
     useJobStore.setState({
       draft: { items: [], namingTemplate: "photo_{n}", outputDir: null },
       error: "stale error",
@@ -319,15 +330,20 @@ describe("recomputePreviews", () => {
 
     await useJobStore.getState().recomputePreviews();
 
-    expect(mockArchive.previewOutputName).not.toHaveBeenCalled();
+    // Only the hero call fires (no items => no per-item calls).
+    expect(mockArchive.previewOutputName).toHaveBeenCalledTimes(1);
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith("photo_{n}", 1);
     expect(useJobStore.getState().previewNames).toEqual([]);
+    expect(useJobStore.getState().firstPreview).toBe("photo_001.zip");
     expect(useJobStore.getState().error).toBeNull();
   });
 
   it("ignores a stale recompute that resolves after a newer one (generation guard)", async () => {
     // Drive two overlapping recomputes with manually-controlled promises so we
     // can resolve the newer batch (B) before the older one (A). The stale A
-    // result must NOT overwrite B's previews.
+    // result must NOT overwrite B's previews. Each recompute now issues two
+    // calls (the hero seq-1 preview and the single per-item preview), so the
+    // resolvers accumulate in call order and are released per run.
     const resolvers: Array<(value: string) => void> = [];
     mockArchive.previewOutputName.mockImplementation(
       () =>
@@ -336,7 +352,7 @@ describe("recomputePreviews", () => {
         }),
     );
 
-    // Run A: one item.
+    // Run A: one item. Pulls its two resolvers (hero + per-item) off the queue.
     useJobStore.setState({
       draft: {
         items: makeDraft(1).items,
@@ -345,7 +361,8 @@ describe("recomputePreviews", () => {
       },
     });
     const runA = useJobStore.getState().recomputePreviews();
-    const resolveA = resolvers.shift();
+    const resolveAItem = resolvers.shift();
+    const resolveAHero = resolvers.shift();
 
     // Run B: one item, started after A so it has the newer generation.
     useJobStore.setState({
@@ -356,14 +373,17 @@ describe("recomputePreviews", () => {
       },
     });
     const runB = useJobStore.getState().recomputePreviews();
-    const resolveB = resolvers.shift();
+    const resolveBItem = resolvers.shift();
+    const resolveBHero = resolvers.shift();
 
     // Resolve B first (the winner), then the stale A.
-    resolveB?.("B.zip");
+    resolveBItem?.("B.zip");
+    resolveBHero?.("B.zip");
     await runB;
     expect(useJobStore.getState().previewNames).toEqual(["B.zip"]);
 
-    resolveA?.("A.zip");
+    resolveAItem?.("A.zip");
+    resolveAHero?.("A.zip");
     await runA;
 
     // A is stale and must not clobber B's result.

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -7,6 +7,7 @@ import type { ProgressEvent } from "@/bindings/ProgressEvent";
 // which share names (addItems, reorder, setNamingRule, ...).
 import * as archive from "@/lib/archive";
 import { messageFromReason } from "@/lib/errors";
+import { DEFAULT_TEMPLATE } from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
 
 // Monotonic counter tagging each recomputePreviews run. A run only commits its
@@ -40,6 +41,24 @@ export interface JobState {
    * (no template, or a recompute in flight) or exactly items.length long.
    */
   previewNames: string[];
+  /**
+   * The single hero preview filename for the OUTPUT group, computed from the
+   * effective template (the draft template, or DEFAULT_TEMPLATE before one has
+   * been pushed) at sequence 1. Independent of draft.items so the OUTPUT group
+   * shows a representative filename even with an empty queue. This is the single
+   * source of truth for OutputSettings' full-path hero — it does not run its own
+   * preview pipeline. Tri-state mirroring the old component-local convention:
+   *   null  = loading (a recompute is pending / in flight),
+   *   ""    = the preview could not be resolved (error path),
+   *   <str> = the resolved filename ready for display.
+   */
+  firstPreview: string | null;
+  /**
+   * The error message for the hero preview, or null on success. Distinct from
+   * `error` (general action errors) so the OUTPUT alert reflects only preview
+   * resolution failures, matching the previous component-local `error` state.
+   */
+  previewError: string | null;
   /** The latest progress snapshot received during a job, if any. */
   progress: ProgressEvent | null;
   /** The summary of the most recently finished job, if any. */
@@ -87,6 +106,8 @@ export interface JobState {
 export const useJobStore = create<JobState>()((set, get) => ({
   draft: { items: [], namingTemplate: null, outputDir: null },
   previewNames: [],
+  firstPreview: null,
+  previewError: null,
   progress: null,
   summary: null,
   taskIdByIndex: [],
@@ -172,29 +193,60 @@ export const useJobStore = create<JobState>()((set, get) => ({
   },
 
   recomputePreviews: async () => {
-    // Tag this run; a later run bumps the counter and supersedes us.
+    // Tag this run; a later run bumps the counter and supersedes us. The same
+    // guard covers both the per-item previewNames and the single hero preview,
+    // so they can never disagree mid-flight (the bug F7 collapsed: there is now
+    // one debounce + one race guard, not two).
     const generation = ++previewGeneration;
     const { draft } = get();
     const template = draft.namingTemplate;
-    if (template === null) {
-      // No await before this set, so no newer run can have started yet.
-      set({ previewNames: [] });
-      return;
-    }
+    // The hero always shows a representative filename: fall back to the shared
+    // default before NamingRuleForm has pushed a template, so the OUTPUT group
+    // is meaningful on first paint even with an empty queue.
+    const heroTemplate = template ?? DEFAULT_TEMPLATE;
+    // Mark the hero as loading; firstPreview === null suppresses the hero path
+    // while the recompute is in flight, mirroring the old component-local guard.
+    set({ firstPreview: null });
     try {
       // Sequence numbers are 1-based, matching the backend's naming contract.
-      const names = await Promise.all(
-        draft.items.map((_item, i) =>
-          archive.previewOutputName(template, i + 1),
-        ),
-      );
+      // The hero preview uses sequence 1; per-item previews use i + 1.
+      const [heroName, names] = await Promise.all([
+        archive.previewOutputName(heroTemplate, 1),
+        // previewNames stays index-aligned with draft.items and empty for a null
+        // template (no items, or no template => no per-item names).
+        template === null
+          ? Promise.resolve<string[]>([])
+          : Promise.all(
+              draft.items.map((_item, i) =>
+                archive.previewOutputName(template, i + 1),
+              ),
+            ),
+      ]);
       // Bail if a newer recompute superseded this one while awaiting.
       if (generation !== previewGeneration) return;
-      set({ previewNames: names, error: null });
+      set({
+        previewNames: names,
+        firstPreview: heroName,
+        previewError: null,
+        // Preserve the pre-refactor general-error semantics exactly: only a real
+        // per-item recompute (non-null template) cleared the top-level `error`;
+        // a null-template recompute left it untouched. The hero preview drives
+        // only `previewError`, never App's top banner.
+        ...(template !== null ? { error: null } : {}),
+      });
     } catch (reason) {
       // Same staleness check on the failure path.
       if (generation !== previewGeneration) return;
-      set({ previewNames: [], error: messageFromReason(reason) });
+      const message = messageFromReason(reason);
+      set({
+        previewNames: [],
+        firstPreview: "",
+        previewError: message,
+        // Parity with the success path: a null-template recompute never touched
+        // the general `error` before (it returned early), so a hero-only failure
+        // must not raise the top-level banner.
+        ...(template !== null ? { error: message } : {}),
+      });
     }
   },
 
@@ -210,8 +262,10 @@ export const useJobStore = create<JobState>()((set, get) => ({
         summary: null,
         progress: null,
         error: null,
+        previewError: null,
         taskIdByIndex: [],
         previewNames: [],
+        firstPreview: null,
       });
     } catch (reason) {
       set({ error: messageFromReason(reason) });
@@ -227,3 +281,12 @@ export const useJobStore = create<JobState>()((set, get) => ({
 export function resetJobStore(): void {
   useJobStore.setState(useJobStore.getInitialState(), true);
 }
+
+/**
+ * Select the single hero preview filename for the OUTPUT group. This is the one
+ * source of preview truth OutputSettings reads (it no longer runs its own
+ * debounced previewOutputName pipeline). Tri-state: null = loading, "" = error,
+ * <str> = resolved filename.
+ */
+export const selectFirstPreview = (s: JobState): string | null =>
+  s.firstPreview;


### PR DESCRIPTION
## Summary

`OutputSettings` ran its own debounced `previewOutputName` pipeline (a `setTimeout` debounce, an `active` staleness guard, and local `previewName`/`error` state) that duplicated the store's `recomputePreviews` machinery, so the two could disagree mid-debounce. This collapses the preview to a single source of truth in the store: `recomputePreviews` now computes both the per-item `previewNames` and a dedicated items-independent hero `firstPreview` under one `previewGeneration` race guard, and `OutputSettings` becomes a pure reader via a `selectFirstPreview` selector. The rendered output is unchanged.

## Background / Motivation

- Two independent debounce + race-guard implementations of the same `previewOutputName` computation existed (one in the component, one in the store), which could render disagreeing previews mid-flight.
- The hero preview is items-independent (it must render even with an empty queue), so it cannot be `previewNames[0]`; it needs its own store-held value computed at sequence 1.
- The component's `DEFAULT_TEMPLATE` first-paint fallback had to be preserved while removing its local pipeline, without introducing a store→presentation import.

## Changes

### `src/store/jobStore.ts` — single source of preview truth

- `recomputePreviews` now computes the hero preview (`previewOutputName(template ?? DEFAULT_TEMPLATE, 1)`) and the per-item `previewNames` together under one `previewGeneration` guard, exposing `firstPreview` (tri-state `null`/`""`/`<str>`) and `previewError`.
- Adds the `selectFirstPreview` selector.
- The general top-level `error` field keeps its exact pre-refactor semantics — only a non-null-template recompute writes it, and a null-template recompute leaves it untouched; preview-specific failures surface via the new `previewError`.

### `src/lib/naming.ts` — shared `DEFAULT_TEMPLATE`

- New pure module holding `DEFAULT_TEMPLATE` so both the store and `NamingRuleForm` import it (avoids a store→component dependency). `NamingRuleForm` re-exports it to keep its public entry point stable.

### `src/components/OutputSettings.tsx` — pure store reader

- Removes the local `setTimeout` debounce, the `active` staleness guard, the local `previewName`/`error` state, and the direct `previewOutputName` call. Reads `selectFirstPreview` + `previewError` from the store. The JSX render block is byte-identical.

### Tests

- `OutputSettings.test.tsx`: rewritten to drive the store's `firstPreview`/`previewError` directly; adds 3 cases (renders the store hero joined with the directory and tracks changes; clears the alert after recovery; surfaces a template error as an alert).
- `jobStore.test.ts`: 4 existing tests reconciled for the one added hero call per recompute; every per-item `previewNames` assertion is preserved.

## Verification

Run the frontend lane checks locally and confirm all pass:

```
pnpm test       # 267 tests, 31 files — all green
pnpm lint:ci    # oxlint --deny-warnings — no errors
pnpm fmt:check  # oxfmt --check — no drift
pnpm build      # tsc + vite type gate
pnpm knip       # no unused exports
```

## Test plan

- [ ] `pnpm test` — 267 tests green, incl. the new OutputSettings store-reader cases and the reconciled jobStore cases
- [ ] `pnpm lint:ci` passes with no oxlint errors
- [ ] `pnpm fmt:check` passes — no formatting drift
- [ ] `pnpm build` completes without TypeScript errors
- [ ] `pnpm knip` reports no unused exports
- [ ] Manual: with no naming rule set, the OUTPUT hero still shows a `DEFAULT_TEMPLATE`-based filename on first paint
- [ ] Manual: type a naming template — the hero and per-item previews update together (no mid-debounce disagreement)
- [ ] Regression: an invalid template surfaces the preview error in the OUTPUT alert and clears it on a valid one; the top-level error banner behavior is unchanged

Closes #78
