### PR TITLE
refactor(domain): single source of truth for archive extension->format (#75)

### DIFF
--- a/crates/core/src/domain/archive_format.rs
+++ b/crates/core/src/domain/archive_format.rs
@@ -1,0 +1,80 @@
+//! The single source of truth for the archive extension -> format mapping (no IO).
+//!
+//! `.rar`/`.zip` classification lives here so that both `SourceItem::classify`
+//! (domain) and the `ArchiveExtractor` router (infrastructure) consume one rule
+//! instead of hand-syncing duplicated extension lists.
+
+/// Supported archive container formats (extension-classified).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArchiveFormat {
+    Rar,
+    Zip,
+}
+
+impl ArchiveFormat {
+    /// Classify by file extension (ASCII case-insensitive); `None` if unsupported.
+    pub fn from_extension(ext: &str) -> Option<ArchiveFormat> {
+        if ext.eq_ignore_ascii_case("rar") {
+            Some(ArchiveFormat::Rar)
+        } else if ext.eq_ignore_ascii_case("zip") {
+            Some(ArchiveFormat::Zip)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_extension_rar_lowercase_is_rar() {
+        assert_eq!(
+            ArchiveFormat::from_extension("rar"),
+            Some(ArchiveFormat::Rar)
+        );
+    }
+
+    #[test]
+    fn from_extension_rar_uppercase_is_rar() {
+        assert_eq!(
+            ArchiveFormat::from_extension("RAR"),
+            Some(ArchiveFormat::Rar)
+        );
+    }
+
+    #[test]
+    fn from_extension_zip_lowercase_is_zip() {
+        assert_eq!(
+            ArchiveFormat::from_extension("zip"),
+            Some(ArchiveFormat::Zip)
+        );
+    }
+
+    #[test]
+    fn from_extension_zip_uppercase_is_zip() {
+        assert_eq!(
+            ArchiveFormat::from_extension("ZIP"),
+            Some(ArchiveFormat::Zip)
+        );
+    }
+
+    #[test]
+    fn from_extension_zip_mixed_case_is_zip() {
+        assert_eq!(
+            ArchiveFormat::from_extension("Zip"),
+            Some(ArchiveFormat::Zip)
+        );
+    }
+
+    #[test]
+    fn from_extension_unknown_is_none() {
+        assert_eq!(ArchiveFormat::from_extension("txt"), None);
+    }
+
+    #[test]
+    fn from_extension_empty_is_none() {
+        assert_eq!(ArchiveFormat::from_extension(""), None);
+    }
+}

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -2,6 +2,7 @@
 //! Naming rules, sequence numbers, output-filename value objects (PR3, issue #3),
 //! and the ArchiveJob aggregate with reordering (PR4, issue #4).
 
+pub mod archive_format;
 pub mod archive_job;
 pub mod archive_task;
 pub mod file_name;

--- a/crates/core/src/domain/source_item.rs
+++ b/crates/core/src/domain/source_item.rs
@@ -1,5 +1,6 @@
 //! The source item to archive — a rar file, a zip file, or a folder (no IO).
 
+use crate::domain::archive_format::ArchiveFormat;
 use std::path::PathBuf;
 
 /// Error returned when a path is neither a `.rar`/`.zip` archive nor a directory.
@@ -36,9 +37,12 @@ impl SourceItem {
             return Ok(SourceItem::Folder(path));
         }
         match path.extension().and_then(|ext| ext.to_str()) {
-            Some(e) if e.eq_ignore_ascii_case("rar") => Ok(SourceItem::RarFile(path)),
-            Some(e) if e.eq_ignore_ascii_case("zip") => Ok(SourceItem::ZipFile(path)),
-            _ => Err(UnsupportedSourceItem(path)),
+            Some(e) => match ArchiveFormat::from_extension(e) {
+                Some(ArchiveFormat::Rar) => Ok(SourceItem::RarFile(path)),
+                Some(ArchiveFormat::Zip) => Ok(SourceItem::ZipFile(path)),
+                None => Err(UnsupportedSourceItem(path)),
+            },
+            None => Err(UnsupportedSourceItem(path)),
         }
     }
 

--- a/crates/core/src/infrastructure/archive_extractor.rs
+++ b/crates/core/src/infrastructure/archive_extractor.rs
@@ -4,6 +4,7 @@
 //! ASCII-case-insensitive so `.ZIP`/`.Rar` are accepted.
 
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
+use crate::domain::archive_format::ArchiveFormat;
 use crate::infrastructure::unrar_extractor::UnrarExtractor;
 use crate::infrastructure::zip_extractor::ZipExtractor;
 use std::path::Path;
@@ -24,14 +25,14 @@ impl ArchiveExtractor {
 
 impl Extractor for ArchiveExtractor {
     async fn extract(&self, src_archive: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
-        // TODO: keep this `"rar"`/`"zip"` extension list in sync with
-        // `SourceItem::classify` when a new format is added. The compiler enforces
-        // the domain side (an exhaustive `SourceItem` match) but NOT this router,
-        // so adding a format requires updating both places by hand.
-        match src_archive.extension().and_then(|e| e.to_str()) {
-            Some(e) if e.eq_ignore_ascii_case("rar") => self.rar.extract(src_archive).await,
-            Some(e) if e.eq_ignore_ascii_case("zip") => self.zip.extract(src_archive).await,
-            _ => Err(ExtractError::Backend(format!(
+        match src_archive
+            .extension()
+            .and_then(|e| e.to_str())
+            .and_then(ArchiveFormat::from_extension)
+        {
+            Some(ArchiveFormat::Rar) => self.rar.extract(src_archive).await,
+            Some(ArchiveFormat::Zip) => self.zip.extract(src_archive).await,
+            None => Err(ExtractError::Backend(format!(
                 "unsupported archive: {}",
                 src_archive.display()
             ))),


### PR DESCRIPTION
## Summary

Establishes a single source of truth for the archive extension -> format mapping in the pure domain, removing the duplicated `"rar"`/`"zip"` extension knowledge that was previously encoded twice. Adds a new domain module `ArchiveFormat` with `from_extension(&str) -> Option<ArchiveFormat>` (ASCII case-insensitive), and rewires both consumers to it: `SourceItem::classify` (domain) and the `ArchiveExtractor` router (infrastructure). The router's hand-sync `TODO` is deleted, so adding a format becomes a single domain edit and the router gains a compiler-checked match. Routing behavior is unchanged.

Closes #75

## Background / Motivation

- The extension -> format rule (`"rar"`/`"zip"`, ASCII case-insensitive) lived in two places: `SourceItem::classify` mapped `.rar` -> `RarFile` / `.zip` -> `ZipFile`, and `ArchiveExtractor::extract` re-derived the same set by matching `src_archive.extension()` to dispatch to the rar/zip adapters.
- The compiler enforced only the domain side (an exhaustive `SourceItem` match); the router was guarded solely by a `TODO` asking a human to keep the two lists in sync, so adding a format silently required editing both places by hand.

## Changes

### Domain — new single source of truth (`crates/core/src/domain/archive_format.rs`)

- New module defining `pub enum ArchiveFormat { Rar, Zip }` (`Clone, Copy, Debug, PartialEq, Eq`) with `pub fn from_extension(ext: &str) -> Option<ArchiveFormat>`, classifying by extension ASCII-case-insensitively and returning `None` for unsupported. Pure — no IO/async, loom-safe.
- `#[cfg(test)] mod tests` covering `rar`/`RAR` => `Some(Rar)`, `zip`/`ZIP`/`Zip` => `Some(Zip)`, and `txt`/`""` => `None`.

### Domain — module registration (`crates/core/src/domain/mod.rs`)

- Add `pub mod archive_format;`.

### Domain — rewire classifier (`crates/core/src/domain/source_item.rs`)

- `SourceItem::classify` now routes its extension arm through `ArchiveFormat::from_extension` (`Rar => RarFile`, `Zip => ZipFile`, `None => UnsupportedSourceItem`). The `is_dir` precedence branch and the non-UTF-8 / no-extension fallthrough are unchanged. Adds `use crate::domain::archive_format::ArchiveFormat;`.

### Infrastructure — rewire router (`crates/core/src/infrastructure/archive_extractor.rs`)

- `ArchiveExtractor::extract` now matches `ArchiveFormat::from_extension(...)` (`Rar` => rar adapter, `Zip` => zip adapter, `None` => the unchanged `"unsupported archive: <path>"` `Backend` error). The hand-sync `TODO` is deleted. Adds `use crate::domain::archive_format::ArchiveFormat;`.

## Testing

| Gate | Result |
|---|---|
| `cargo nextest run -p simple-archiver-core` (210 tests) | green |
| `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |

## Test plan

- [ ] CI `core` job is green: `cargo nextest run -p simple-archiver-core`, `cargo clippy`, and `cargo fmt --check` all pass.
- [ ] The new `from_extension_*` tests appear in the nextest output and pass.
- [ ] The mapping now lives once in `domain` (`ArchiveFormat::from_extension`); both `SourceItem::classify` and `ArchiveExtractor::extract` consume it.
- [ ] `domain` stays pure: `archive_format.rs` adds no IO/async (loom build keeps compiling).
- [ ] Behavior unchanged: `.rar`/`.zip` routing, ASCII case-insensitivity, and `is_dir` precedence are identical; error strings stay `"unsupported archive: <path>"` (router) and `"unsupported item: <path>"` (`UnsupportedSourceItem`).
- [ ] The existing `classify_*` and `archive_extractor` tests stay green unchanged.
- [ ] The hand-sync `TODO` in `archive_extractor.rs` is gone; adding a hypothetical third format requires only one domain edit and the router match becomes a compiler error until updated.
