### PR TITLE
refactor(application): extract per-task pipeline out of run_one (#77)

### DIFF
--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::application::compress_context::{CompressContext, TaskProgressReport};
 use crate::application::eta_estimator::{EtaTracker, ETA_WINDOW};
-use crate::application::format_registry::FormatRegistry;
+use crate::application::format_registry::{FormatRegistry, Prepared};
 use crate::application::ports::{ArchiveError, Archiver, Clock, Extractor};
 use crate::application::progress::ProgressSink;
 use crate::application::progress_aggregator::{Aggregator, JobSummary, WorkerMsg};
@@ -159,20 +159,59 @@ async fn run_one<A: Archiver, E: Extractor>(
     tx: mpsc::UnboundedSender<WorkerMsg>,
     cancellation_token: CancellationToken,
 ) {
-    // Best-effort `Status` sends (here and below): every one of these carries a
-    // terminal/load-bearing event. A failed send means the aggregator already tore
-    // down during teardown; the dropped terminal status is then reconstructed by
-    // `into_summary`'s state reconciliation (a non-terminal task is classified from
-    // its final `TaskStatus`), so `succeeded + cancelled + failed` stays whole.
+    // Top-down pipeline: checkpoint -> extract -> compress -> emit terminal.
+    if cancel_before_start(&item, &tx, &cancellation_token) {
+        return;
+    }
+    let Some(prepared) = extract_phase(&item, registry, &tx).await else {
+        return;
+    };
+    let _ = tx.send(WorkerMsg::Status {
+        task: item.task,
+        event: TaskEvent::StartCompressing,
+    });
+    let reporter = Arc::new(ChannelReporter { tx: tx.clone() });
+    let ctx = CompressContext::new(item.task, reporter, cancellation_token);
+    let event = map_archive_result(archiver.compress(prepared.dir(), &item.dest, &ctx).await);
+    let _ = tx.send(WorkerMsg::Status {
+        task: item.task,
+        event,
+    });
+    // `prepared` drops here — an extracted rar/zip's temp directory is removed.
+}
+
+/// Returns `true` and emits `Cancel` if the token is already tripped, so the
+/// caller can early-return before any extraction/compression starts.
+fn cancel_before_start(
+    item: &WorkItem,
+    tx: &mpsc::UnboundedSender<WorkerMsg>,
+    token: &CancellationToken,
+) -> bool {
+    // Best-effort `Status` sends (here and in the rest of the pipeline): every one
+    // of these carries a terminal/load-bearing event. A failed send means the
+    // aggregator already tore down during teardown; the dropped terminal status is
+    // then reconstructed by `into_summary`'s state reconciliation (a non-terminal
+    // task is classified from its final `TaskStatus`), so `succeeded + cancelled +
+    // failed` stays whole.
     // Not-started cancellation checkpoint: cancel before any extraction/compression.
-    if cancellation_token.is_cancelled() {
+    if token.is_cancelled() {
         let _ = tx.send(WorkerMsg::Status {
             task: item.task,
             event: TaskEvent::Cancel,
         });
-        return;
+        return true;
     }
+    false
+}
 
+/// Emits `StartExtracting` for sources that require extraction (folders skip it),
+/// then resolves the source to a prepared directory. On extract failure, emits
+/// `Fail` and returns `None` so the caller early-returns.
+async fn extract_phase<E: Extractor>(
+    item: &WorkItem,
+    registry: &FormatRegistry<E>,
+    tx: &mpsc::UnboundedSender<WorkerMsg>,
+) -> Option<Prepared> {
     // rar/zip files extract first; folders compress directly. Emit the extraction
     // status only for sources that actually extract, so the task walks the legal
     // Pending -> Extracting -> Compressing path (folders take the fast-path).
@@ -183,8 +222,8 @@ async fn run_one<A: Archiver, E: Extractor>(
         });
     }
 
-    let prepared = match registry.prepare(&item.source).await {
-        Ok(prepared) => prepared,
+    match registry.prepare(&item.source).await {
+        Ok(prepared) => Some(prepared),
         Err(e) => {
             let _ = tx.send(WorkerMsg::Status {
                 task: item.task,
@@ -192,28 +231,21 @@ async fn run_one<A: Archiver, E: Extractor>(
                     reason: e.to_string(),
                 },
             });
-            return;
+            None
         }
-    };
+    }
+}
 
-    let _ = tx.send(WorkerMsg::Status {
-        task: item.task,
-        event: TaskEvent::StartCompressing,
-    });
-    let reporter = Arc::new(ChannelReporter { tx: tx.clone() });
-    let ctx = CompressContext::new(item.task, reporter, cancellation_token);
-    let event = match archiver.compress(prepared.dir(), &item.dest, &ctx).await {
+/// Maps a compress result to the terminal `TaskEvent`: `Ok -> Complete`,
+/// `Cancelled -> Cancel`, any other error -> `Fail { reason }`.
+fn map_archive_result(result: Result<(), ArchiveError>) -> TaskEvent {
+    match result {
         Ok(()) => TaskEvent::Complete,
         Err(ArchiveError::Cancelled) => TaskEvent::Cancel,
         Err(e) => TaskEvent::Fail {
             reason: e.to_string(),
         },
-    };
-    let _ = tx.send(WorkerMsg::Status {
-        task: item.task,
-        event,
-    });
-    // `prepared` drops here — an extracted rar/zip's temp directory is removed.
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`run_one` (the per-work-item worker in the run engine) resolved a task end-to-end inline, interleaving four responsibilities in one long async fn: the not-started cancellation checkpoint, the extract-or-skip step plus `StartExtracting`/`StartCompressing` emission, the compress call, and the `ArchiveError` -> `TaskEvent` mapping. This splits those into focused private fns so `run_one` reads top-down as `checkpoint -> extract -> compress -> emit`; emitted `WorkerMsg::Status` events, their order, and `prepared`'s drop timing are byte-for-byte identical.

## Background / Motivation

- `run_one` read as a flat wall of best-effort `tx.send(...)` calls rather than a top-down pipeline, mixing cancellation, extraction, compression, and error mapping in one body.
- The four phases had no names, so the legal status walk (`Pending -> Extracting -> Compressing -> terminal`) and the cancel/extract-fail early returns were only legible by reading the whole fn.
- This is a cohesion-only cleanup: behavior, event ordering, cancellation paths, and error mapping must stay exactly as they were, with the existing test suite as the safety net.

## Changes

### `cancel_before_start` — not-started checkpoint

- Extracts the pre-extraction cancellation checkpoint into `fn cancel_before_start(item, tx, token) -> bool`: emits `Cancel` and returns `true` when the token is already tripped, so the caller early-returns before any extraction/compression. Call site: `if cancel_before_start(&item, &tx, &cancellation_token) { return; }`.
- Carries the best-effort-`Status`-send rationale comment verbatim.

### `extract_phase` — extract-or-skip + status emission

- Extracts the extraction step into `async fn extract_phase<E: Extractor>(item, registry, tx) -> Option<Prepared>`: emits `StartExtracting` only for sources that require extraction (folders skip it), resolves the source to a `Prepared` directory, and on extract failure emits `Fail { reason }` and returns `None`. Call site: `let Some(prepared) = extract_phase(&item, registry, &tx).await else { return; };`.
- `prepared` stays bound in `run_one`, so the extracted rar/zip temp directory still drops at the end of the worker — no change to drop timing.
- Imports `Prepared` from `format_registry` for the return type; carries the extraction-status / fast-path comment verbatim.

### `map_archive_result` — terminal event mapping

- Extracts the compress-result mapping into `fn map_archive_result(result) -> TaskEvent`: `Ok -> Complete`, `Cancelled -> Cancel`, any other error -> `Fail { reason }`. Call site: `let event = map_archive_result(archiver.compress(prepared.dir(), &item.dest, &ctx).await);`.

### Scope notes

- The optional `compress_phase` wrapper is intentionally skipped: wrapping the remaining `StartCompressing` send + `CompressContext` build + compress call would force a clone or ownership change of `cancellation_token`/`prepared`, which the issue forbids.
- No existing test assertion changed; all load-bearing comments move verbatim with their blocks.

## Verification

Run the core lane checks locally and confirm all pass:

```
cargo nextest run -p simple-archiver-core            # 203 tests — all green
cargo clippy -p simple-archiver-core --all-targets -- -D warnings   # clean
cargo fmt --check                                     # clean
```

## Test plan

- [ ] CI `core` job is green: `cargo nextest run -p simple-archiver-core`, `cargo clippy`, and `cargo fmt --check` all pass.
- [ ] No existing test assertion changed; all 203 tests stay green, proving behavior is identical.
- [ ] `run_one`'s public behavior is unchanged: identical `WorkerMsg::Status` events in identical order for every path (cancel-before-start, folder fast-path, rar/zip extract, extract failure, compress success/cancel/fail).
- [ ] The extracted fns are verbatim moves — no added clones, no changed ownership of `prepared`/`cancellation_token`, no altered drop timing.
- [ ] `domain` stays pure: the change is application-layer only; no IO/async added to domain.

Closes #77
