### PR TITLE
refactor(presentation): split dto wire-types from From-mapping impls (#79)

### DIFF
--- a/src-tauri/src/presentation/dto.rs
+++ b/src-tauri/src/presentation/dto.rs
@@ -8,13 +8,11 @@
 //! below are the Rust half of the contract and guard against silent drift.
 
 use serde::Serialize;
-use std::time::Duration;
 use ts_rs::TS;
 
-use simple_archiver_core::application::progress::JobProgress;
-use simple_archiver_core::application::progress_aggregator::JobSummary;
-use simple_archiver_core::domain::source_item::SourceItem;
-use simple_archiver_core::domain::task_progress::TaskProgress;
+// Re-export the draft mapping helper from `dto_map` so callers resolve it via
+// `crate::presentation::dto::draft_item_from_source` unchanged.
+pub(crate) use super::dto_map::draft_item_from_source;
 
 /// Tauri event channel name used to stream [`ProgressEvent`] payloads.
 pub const PROGRESS_EVENT: &str = "archive://progress";
@@ -148,78 +146,6 @@ pub enum SourceKind {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Mapping helpers (presentation only)
-// ─────────────────────────────────────────────────────────────────────────────
-
-impl From<&TaskProgress> for ProgressCounts {
-    fn from(progress: &TaskProgress) -> Self {
-        Self {
-            bytes_done: progress.bytes_done(),
-            bytes_total: progress.bytes_total(),
-        }
-    }
-}
-
-/// Convert a `Duration` to whole milliseconds, saturating at `u64::MAX`
-/// (~585 million years) instead of silently truncating the upper bits.
-fn duration_to_millis_u64(d: Duration) -> u64 {
-    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
-}
-
-impl From<&JobProgress> for ProgressEvent {
-    fn from(job_progress: &JobProgress) -> Self {
-        Self {
-            overall: ProgressCounts::from(&job_progress.overall()),
-            overall_eta_ms: job_progress.overall_eta.map(duration_to_millis_u64),
-            per_task: job_progress
-                .per_task
-                .iter()
-                .map(|e| TaskProgressDto {
-                    task_id: e.id.get(),
-                    bytes_done: e.progress.bytes_done(),
-                    bytes_total: e.progress.bytes_total(),
-                    eta_ms: e.eta.map(duration_to_millis_u64),
-                })
-                .collect(),
-            elapsed_ms: duration_to_millis_u64(job_progress.elapsed),
-        }
-    }
-}
-
-impl From<JobSummary> for JobSummaryDto {
-    fn from(summary: JobSummary) -> Self {
-        Self {
-            succeeded: summary.succeeded.iter().map(|id| id.get()).collect(),
-            cancelled: summary.cancelled.iter().map(|id| id.get()).collect(),
-            failed: summary
-                .failed
-                .into_iter()
-                .map(|(id, reason)| FailedTaskDto {
-                    task_id: id.get(),
-                    reason,
-                })
-                .collect(),
-        }
-    }
-}
-
-/// Build a [`DraftItemDto`] from a [`SourceItem`] (lossy path string + kind).
-///
-/// Used by later waves when projecting the draft to the frontend; provided and
-/// tested here so the mapping lives next to the DTO it produces.
-pub(crate) fn draft_item_from_source(item: &SourceItem) -> DraftItemDto {
-    let (path, kind) = match item {
-        SourceItem::Folder(p) => (p, SourceKind::Folder),
-        SourceItem::RarFile(p) => (p, SourceKind::Rar),
-        SourceItem::ZipFile(p) => (p, SourceKind::Zip),
-    };
-    DraftItemDto {
-        path: path.to_string_lossy().into_owned(),
-        kind,
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -227,8 +153,6 @@ pub(crate) fn draft_item_from_source(item: &SourceItem) -> DraftItemDto {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::path::PathBuf;
-    use std::time::Duration;
     use ts_rs::TS;
 
     // ── TypeScript binding export (regenerates `src/bindings/*.ts`) ────────────
@@ -427,131 +351,5 @@ mod tests {
         );
         assert_eq!(serde_json::to_value(SourceKind::Rar).unwrap(), json!("rar"));
         assert_eq!(serde_json::to_value(SourceKind::Zip).unwrap(), json!("zip"));
-    }
-
-    // ── Mapping helpers ───────────────────────────────────────────────────────
-
-    #[test]
-    fn task_progress_maps_to_progress_counts() {
-        let progress = TaskProgress::new(3, 8);
-        let counts = ProgressCounts::from(&progress);
-        assert_eq!(
-            counts,
-            ProgressCounts {
-                bytes_done: 3,
-                bytes_total: 8,
-            }
-        );
-    }
-
-    #[test]
-    fn job_progress_maps_overall_and_elapsed() {
-        // `TaskId` cannot be constructed from outside the core crate (its
-        // constructor is `pub(crate)`), so `per_task` is exercised here with an
-        // empty vec. With an empty `per_task`, `overall()` returns {0, 0}.
-        // The overall_eta and elapsed conversions are the primary checks here.
-        let job_progress = JobProgress {
-            overall_eta: Some(Duration::from_millis(2500)),
-            per_task: Vec::new(),
-            elapsed: Duration::from_millis(1234),
-        };
-        let event = ProgressEvent::from(&job_progress);
-        // overall() == {0, 0} when per_task is empty (TaskId is pub(crate)).
-        assert_eq!(
-            event.overall,
-            ProgressCounts {
-                bytes_done: 0,
-                bytes_total: 0,
-            }
-        );
-        assert!(event.per_task.is_empty());
-        assert_eq!(event.elapsed_ms, 1234);
-        assert_eq!(event.overall_eta_ms, Some(2500));
-    }
-
-    #[test]
-    fn job_progress_elapsed_converts_to_u64_millis() {
-        let job_progress = JobProgress {
-            overall_eta: None,
-            per_task: Vec::new(),
-            elapsed: Duration::from_secs(2),
-        };
-        let event = ProgressEvent::from(&job_progress);
-        assert_eq!(event.elapsed_ms, 2000);
-    }
-
-    #[test]
-    fn job_summary_maps_to_dto() {
-        // As above, `TaskId` values cannot be built outside core, so the
-        // task-id-bearing collections are empty here; their `TaskId::get`
-        // mapping and camelCase shape are covered by the serde-shape test.
-        let summary = JobSummary {
-            succeeded: Vec::new(),
-            cancelled: Vec::new(),
-            failed: Vec::new(),
-        };
-        let dto = JobSummaryDto::from(summary);
-        assert_eq!(
-            dto,
-            JobSummaryDto {
-                succeeded: Vec::new(),
-                cancelled: Vec::new(),
-                failed: Vec::new(),
-            }
-        );
-    }
-
-    #[test]
-    fn draft_item_from_folder_source() {
-        let item = SourceItem::Folder(PathBuf::from("/some/folder"));
-        let dto = draft_item_from_source(&item);
-        assert_eq!(
-            dto,
-            DraftItemDto {
-                path: "/some/folder".to_string(),
-                kind: SourceKind::Folder,
-            }
-        );
-    }
-
-    #[test]
-    fn draft_item_from_rar_source() {
-        let item = SourceItem::RarFile(PathBuf::from("/some/file.rar"));
-        let dto = draft_item_from_source(&item);
-        assert_eq!(
-            dto,
-            DraftItemDto {
-                path: "/some/file.rar".to_string(),
-                kind: SourceKind::Rar,
-            }
-        );
-    }
-
-    #[test]
-    fn draft_item_from_zip_source() {
-        let item = SourceItem::ZipFile(PathBuf::from("/some/file.zip"));
-        let dto = draft_item_from_source(&item);
-        assert_eq!(
-            dto,
-            DraftItemDto {
-                path: "/some/file.zip".to_string(),
-                kind: SourceKind::Zip,
-            }
-        );
-    }
-
-    #[test]
-    fn duration_to_millis_u64_converts_exactly() {
-        assert_eq!(duration_to_millis_u64(Duration::from_millis(1234)), 1234);
-    }
-
-    #[test]
-    fn duration_to_millis_u64_saturates_instead_of_truncating() {
-        // as_millis() here exceeds u64::MAX, so the conversion saturates rather
-        // than silently returning the low bits.
-        assert_eq!(
-            duration_to_millis_u64(Duration::from_secs(u64::MAX)),
-            u64::MAX
-        );
     }
 }

--- a/src-tauri/src/presentation/dto_map.rs
+++ b/src-tauri/src/presentation/dto_map.rs
@@ -1,0 +1,219 @@
+//! Application -> wire mapping for the presentation DTOs.
+//!
+//! This module answers "how core maps onto the wire," keeping that translation
+//! layer separate from the wire-contract declarations in [`super::dto`], which
+//! answer "what the wire contract is." The `From` impls are defined on the DTO
+//! target types, so they remain visible wherever those types are in scope; the
+//! free function [`draft_item_from_source`] is re-exported from `dto` so callers
+//! resolve it unchanged.
+
+use std::time::Duration;
+
+use simple_archiver_core::application::progress::JobProgress;
+use simple_archiver_core::application::progress_aggregator::JobSummary;
+use simple_archiver_core::domain::source_item::SourceItem;
+use simple_archiver_core::domain::task_progress::TaskProgress;
+
+use super::dto::{
+    DraftItemDto, FailedTaskDto, JobSummaryDto, ProgressCounts, ProgressEvent, SourceKind,
+    TaskProgressDto,
+};
+
+impl From<&TaskProgress> for ProgressCounts {
+    fn from(progress: &TaskProgress) -> Self {
+        Self {
+            bytes_done: progress.bytes_done(),
+            bytes_total: progress.bytes_total(),
+        }
+    }
+}
+
+/// Convert a `Duration` to whole milliseconds, saturating at `u64::MAX`
+/// (~585 million years) instead of silently truncating the upper bits.
+fn duration_to_millis_u64(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+impl From<&JobProgress> for ProgressEvent {
+    fn from(job_progress: &JobProgress) -> Self {
+        Self {
+            overall: ProgressCounts::from(&job_progress.overall()),
+            overall_eta_ms: job_progress.overall_eta.map(duration_to_millis_u64),
+            per_task: job_progress
+                .per_task
+                .iter()
+                .map(|e| TaskProgressDto {
+                    task_id: e.id.get(),
+                    bytes_done: e.progress.bytes_done(),
+                    bytes_total: e.progress.bytes_total(),
+                    eta_ms: e.eta.map(duration_to_millis_u64),
+                })
+                .collect(),
+            elapsed_ms: duration_to_millis_u64(job_progress.elapsed),
+        }
+    }
+}
+
+impl From<JobSummary> for JobSummaryDto {
+    fn from(summary: JobSummary) -> Self {
+        Self {
+            succeeded: summary.succeeded.iter().map(|id| id.get()).collect(),
+            cancelled: summary.cancelled.iter().map(|id| id.get()).collect(),
+            failed: summary
+                .failed
+                .into_iter()
+                .map(|(id, reason)| FailedTaskDto {
+                    task_id: id.get(),
+                    reason,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Build a [`DraftItemDto`] from a [`SourceItem`] (lossy path string + kind).
+///
+/// Used by later waves when projecting the draft to the frontend; provided and
+/// tested here so the mapping lives next to the DTO it produces.
+pub(crate) fn draft_item_from_source(item: &SourceItem) -> DraftItemDto {
+    let (path, kind) = match item {
+        SourceItem::Folder(p) => (p, SourceKind::Folder),
+        SourceItem::RarFile(p) => (p, SourceKind::Rar),
+        SourceItem::ZipFile(p) => (p, SourceKind::Zip),
+    };
+    DraftItemDto {
+        path: path.to_string_lossy().into_owned(),
+        kind,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    #[test]
+    fn task_progress_maps_to_progress_counts() {
+        let progress = TaskProgress::new(3, 8);
+        let counts = ProgressCounts::from(&progress);
+        assert_eq!(
+            counts,
+            ProgressCounts {
+                bytes_done: 3,
+                bytes_total: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn job_progress_maps_overall_and_elapsed() {
+        // `TaskId` cannot be constructed from outside the core crate (its
+        // constructor is `pub(crate)`), so `per_task` is exercised here with an
+        // empty vec. With an empty `per_task`, `overall()` returns {0, 0}.
+        // The overall_eta and elapsed conversions are the primary checks here.
+        let job_progress = JobProgress {
+            overall_eta: Some(Duration::from_millis(2500)),
+            per_task: Vec::new(),
+            elapsed: Duration::from_millis(1234),
+        };
+        let event = ProgressEvent::from(&job_progress);
+        // overall() == {0, 0} when per_task is empty (TaskId is pub(crate)).
+        assert_eq!(
+            event.overall,
+            ProgressCounts {
+                bytes_done: 0,
+                bytes_total: 0,
+            }
+        );
+        assert!(event.per_task.is_empty());
+        assert_eq!(event.elapsed_ms, 1234);
+        assert_eq!(event.overall_eta_ms, Some(2500));
+    }
+
+    #[test]
+    fn job_progress_elapsed_converts_to_u64_millis() {
+        let job_progress = JobProgress {
+            overall_eta: None,
+            per_task: Vec::new(),
+            elapsed: Duration::from_secs(2),
+        };
+        let event = ProgressEvent::from(&job_progress);
+        assert_eq!(event.elapsed_ms, 2000);
+    }
+
+    #[test]
+    fn job_summary_maps_to_dto() {
+        // As above, `TaskId` values cannot be built outside core, so the
+        // task-id-bearing collections are empty here; their `TaskId::get`
+        // mapping and camelCase shape are covered by the serde-shape test.
+        let summary = JobSummary {
+            succeeded: Vec::new(),
+            cancelled: Vec::new(),
+            failed: Vec::new(),
+        };
+        let dto = JobSummaryDto::from(summary);
+        assert_eq!(
+            dto,
+            JobSummaryDto {
+                succeeded: Vec::new(),
+                cancelled: Vec::new(),
+                failed: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn draft_item_from_folder_source() {
+        let item = SourceItem::Folder(PathBuf::from("/some/folder"));
+        let dto = draft_item_from_source(&item);
+        assert_eq!(
+            dto,
+            DraftItemDto {
+                path: "/some/folder".to_string(),
+                kind: SourceKind::Folder,
+            }
+        );
+    }
+
+    #[test]
+    fn draft_item_from_rar_source() {
+        let item = SourceItem::RarFile(PathBuf::from("/some/file.rar"));
+        let dto = draft_item_from_source(&item);
+        assert_eq!(
+            dto,
+            DraftItemDto {
+                path: "/some/file.rar".to_string(),
+                kind: SourceKind::Rar,
+            }
+        );
+    }
+
+    #[test]
+    fn draft_item_from_zip_source() {
+        let item = SourceItem::ZipFile(PathBuf::from("/some/file.zip"));
+        let dto = draft_item_from_source(&item);
+        assert_eq!(
+            dto,
+            DraftItemDto {
+                path: "/some/file.zip".to_string(),
+                kind: SourceKind::Zip,
+            }
+        );
+    }
+
+    #[test]
+    fn duration_to_millis_u64_converts_exactly() {
+        assert_eq!(duration_to_millis_u64(Duration::from_millis(1234)), 1234);
+    }
+
+    #[test]
+    fn duration_to_millis_u64_saturates_instead_of_truncating() {
+        // as_millis() here exceeds u64::MAX, so the conversion saturates rather
+        // than silently returning the low bits.
+        assert_eq!(
+            duration_to_millis_u64(Duration::from_secs(u64::MAX)),
+            u64::MAX
+        );
+    }
+}

--- a/src-tauri/src/presentation/mod.rs
+++ b/src-tauri/src/presentation/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod commands;
 pub mod dto;
+pub(crate) mod dto_map;
 pub mod events;
 pub mod state;


### PR DESCRIPTION
## Summary

`src-tauri/src/presentation/dto.rs` is documented as "the single authored source of the Rust↔TS contract," but it also carried the application→wire translation layer (`From` impls + helpers) — a separate responsibility that answers "how core maps onto the wire," not "what the wire contract is." This lifts that layer verbatim into a new sibling module `dto_map.rs`, leaving `dto.rs` to hold only the `#[derive(TS)]` declarations and their serde-shape / TS-binding contract tests. Pure cohesion refactor: items and tests are moved (copy-then-delete, not rewritten), behaviour is unchanged, and the generated bindings under `src/bindings/` are byte-for-byte identical.

## Background / Motivation

- `dto.rs` (557 lines) conflated the wire-contract declarations with the mapping layer, reducing cohesion and making the module harder to skim against its own doc-comment.
- The mapping items (`impl From<&TaskProgress> for ProgressCounts`, `impl From<&JobProgress> for ProgressEvent`, `impl From<JobSummary> for JobSummaryDto`, the private `duration_to_millis_u64`, and `draft_item_from_source`) are presentation-only translation glue, distinct from the wire shape the contract tests guard.
- Callers in `events.rs`, `commands.rs`, and `state.rs` reference these items through `crate::presentation::dto::…` and must keep resolving unchanged — the split has to be call-site-transparent.

## Changes

### `dto_map.rs` — new mapping module

- Holds the five moved items verbatim: `impl From<&TaskProgress> for ProgressCounts`, `fn duration_to_millis_u64`, `impl From<&JobProgress> for ProgressEvent`, `impl From<JobSummary> for JobSummaryDto`, and `pub(crate) fn draft_item_from_source`.
- Explicit `use` imports for the core types (`JobProgress`, `JobSummary`, `SourceItem`, `TaskProgress`) and the DTO types from `super::dto`.
- The nine mapping tests move here verbatim into a `#[cfg(test)] mod tests`: `task_progress_maps_to_progress_counts`, `job_progress_maps_overall_and_elapsed`, `job_progress_elapsed_converts_to_u64_millis`, `job_summary_maps_to_dto`, `draft_item_from_{folder,rar,zip}_source`, `duration_to_millis_u64_converts_exactly`, `duration_to_millis_u64_saturates_instead_of_truncating`.

### `dto.rs` — wire-contract declarations only

- Removes the `// Mapping helpers` section and the nine mapping tests.
- Drops the now-unused core-type imports (`JobProgress` / `JobSummary` / `SourceItem` / `TaskProgress`), the top-level `std::time::Duration`, and the `PathBuf` / `Duration` test imports.
- Re-exports the free fn via `pub(crate) use super::dto_map::draft_item_from_source;` so `crate::presentation::dto::draft_item_from_source` resolves unchanged. (`From` impls are inherent to their target DTO types, so they stay visible wherever the type is in scope — no re-export needed.)
- The wire-contract tests stay: `export_typescript_bindings`, the `u64`-emits-`number`-not-`bigint` guard, and the serde-shape tests.

### `mod.rs` — wire the module

- Adds `pub(crate) mod dto_map;`. No edits in `events.rs`, `commands.rs`, or `state.rs`.

## Verification

- The PR diff touches only `dto.rs`, `dto_map.rs`, and `mod.rs` — `src/bindings/*.ts` has no diff (the `#[derive(TS)]` structs are untouched, so the regenerated TypeScript is byte-for-byte identical).
- The nine mapping tests now appear under `presentation::dto_map::tests::*` in `cargo nextest list -p simple-archiver`; the wire-contract tests remain under `presentation::dto::*`. Total presentation test count is unchanged at 67.

## Test plan

- [ ] `cargo nextest run -p simple-archiver` — 67 tests green (mapping tests moved to `dto_map::tests`, none deleted).
- [ ] `cargo nextest run -p simple-archiver-core` — 203 tests green.
- [ ] `cargo clippy -p simple-archiver --all-targets -- -D warnings` and `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` — clean.
- [ ] `cargo fmt --check` — clean.
- [ ] No call-site changes required in `events.rs`, `state.rs`, or `commands.rs`.
- [ ] `git diff` shows no change under `src/bindings/`.

Closes #79
