### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,7 +3616,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
Bump the version from 0.1.0 to 0.2.0 across all version-tracking files ahead of the `v0.2.0` release tag.

- `package.json`, `src-tauri/Cargo.toml`, `crates/core/Cargo.toml`, `src-tauri/tauri.conf.json`
- `Cargo.lock` regenerated to match

No source code changes; the CI gate (clippy / fmt / nextest / oxlint / oxfmt / vitest) covers verification.
