### PR TITLE
refactor(domain): remove unused TaskStatus::is_terminal

### DIFF
--- a/crates/core/src/domain/task_status.rs
+++ b/crates/core/src/domain/task_status.rs
@@ -72,14 +72,6 @@ impl TaskStatus {
             (from, event) => Err(IllegalTransition { from, event }),
         }
     }
-
-    /// Returns `true` when no further transitions are possible.
-    pub fn is_terminal(&self) -> bool {
-        matches!(
-            self,
-            TaskStatus::Completed | TaskStatus::Failed { .. } | TaskStatus::Cancelled
-        )
-    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -299,41 +291,6 @@ mod tests {
         for event in all_events() {
             assert_illegal(TaskStatus::Cancelled, event);
         }
-    }
-
-    // ── is_terminal ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn pending_is_not_terminal() {
-        assert!(!TaskStatus::Pending.is_terminal());
-    }
-
-    #[test]
-    fn extracting_is_not_terminal() {
-        assert!(!TaskStatus::Extracting.is_terminal());
-    }
-
-    #[test]
-    fn compressing_is_not_terminal() {
-        assert!(!TaskStatus::Compressing.is_terminal());
-    }
-
-    #[test]
-    fn completed_is_terminal() {
-        assert!(TaskStatus::Completed.is_terminal());
-    }
-
-    #[test]
-    fn failed_is_terminal() {
-        assert!(TaskStatus::Failed {
-            reason: "err".to_string()
-        }
-        .is_terminal());
-    }
-
-    #[test]
-    fn cancelled_is_terminal() {
-        assert!(TaskStatus::Cancelled.is_terminal());
     }
 
     // ── IllegalTransition error message ──────────────────────────────────────


### PR DESCRIPTION
## Summary

`TaskStatus::is_terminal` was a public method with six dedicated unit tests but no production callers — the terminal/non-terminal decision is made directly inside `ArchiveJob::outcomes`. This removes the dead method and its tests so the domain surface only carries behavior the aggregate actually uses.

## Background / Motivation

- `is_terminal()` was `pub` and exercised by six tests, yet a repo-wide search found zero non-test references; `ArchiveJob::outcomes` re-derives terminality by matching variants directly rather than calling it.
- A dead public method plus its tests is pure carrying cost for a solo maintainer and falsely implies an abstraction the aggregate deliberately does not use.

## Changes

### Domain

- Delete `TaskStatus::is_terminal` and its section header in `crates/core/src/domain/task_status.rs`.
- Delete the six unit tests that guarded it (43 lines removed in total).

## Verification

- `rg -n 'is_terminal' crates/ src-tauri/` returns no matches — the definition and tests are fully gone and no production caller existed.
- `cargo nextest run -p simple-archiver-core` drops from 210 to 204 tests (only the six `is_terminal` tests removed; nothing else affected).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p simple-archiver-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p simple-archiver-core` (204 tests green)
