### PR TITLE
fix(frontend): seed NamingRuleForm input from stored draft template

### DIFF
--- a/src/components/NamingRuleForm.test.tsx
+++ b/src/components/NamingRuleForm.test.tsx
@@ -26,6 +26,36 @@ describe("NamingRuleForm", () => {
     expect(input.value).toBe(DEFAULT_TEMPLATE);
   });
 
+  it("seeds the input from a non-default store template", () => {
+    // Seed the store as if a prior session / test restored a custom template.
+    act(() => {
+      useJobStore.setState((s) => ({
+        draft: { ...s.draft, namingTemplate: "stored_{n}" },
+      }));
+    });
+
+    render(<NamingRuleForm />);
+
+    const input = screen.getByLabelText(/name/i) as HTMLInputElement;
+    expect(input.value).toBe("stored_{n}");
+  });
+
+  it("syncs the input when the store template changes from outside the form", () => {
+    render(<NamingRuleForm />);
+
+    const input = screen.getByLabelText(/name/i) as HTMLInputElement;
+    expect(input.value).toBe(DEFAULT_TEMPLATE);
+
+    // An external store update (not a keystroke) must flow into the field.
+    act(() => {
+      useJobStore.setState((s) => ({
+        draft: { ...s.draft, namingTemplate: "external_{n}" },
+      }));
+    });
+
+    expect(input.value).toBe("external_{n}");
+  });
+
   it("does not render an inline preview line (preview moved to OutputSettings)", () => {
     render(<NamingRuleForm />);
 

--- a/src/components/NamingRuleForm.tsx
+++ b/src/components/NamingRuleForm.tsx
@@ -26,7 +26,12 @@ export const DEBOUNCE_MS = 200;
  * button on this row), keeping its label/input association intact for a11y.
  */
 export function NamingRuleForm() {
-  const [template, setTemplate] = useState(DEFAULT_TEMPLATE);
+  // Source the initial value from the store so a non-default draft template
+  // (future session restore, or a seeded test) shows the correct value rather
+  // than always starting from the compile-time default. Fall back to the
+  // default when the store has no template yet (the common first-paint case).
+  const storedTemplate = useJobStore((s) => s.draft.namingTemplate);
+  const [template, setTemplate] = useState(storedTemplate ?? DEFAULT_TEMPLATE);
 
   useEffect(() => {
     const handle = setTimeout(() => {
@@ -38,6 +43,24 @@ export function NamingRuleForm() {
     }, DEBOUNCE_MS);
     return () => clearTimeout(handle);
   }, [template]);
+
+  // Sync the field when the store template changes from OUTSIDE this form
+  // (e.g. session restore). Depend only on `storedTemplate` so this reacts to
+  // external store changes, not to local keystrokes (which already drive the
+  // debounce push above). The functional updater reads the current field value
+  // without closing over `template`, so the dep array stays exhaustive AND the
+  // equality guard breaks the debounce push-back loop: when our own debounce
+  // pushes `template` into the store, the resolved value equals `current`, so
+  // this is a no-op and starts no update cycle. A null/default store value is
+  // skipped, leaving the initial state untouched, so behavior is unchanged when
+  // nothing is stored.
+  useEffect(() => {
+    if (storedTemplate !== null) {
+      setTemplate((current) =>
+        storedTemplate === current ? current : storedTemplate,
+      );
+    }
+  }, [storedTemplate]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

`NamingRuleForm` seeded its controlled input from the compile-time `DEFAULT_TEMPLATE` and never read `draft.namingTemplate` from the store, so any externally-set template (a future session restore) would be silently overwritten by the debounce. This seeds the field from the store and keeps it in sync without re-introducing the debounce push-back loop.

## Background / Motivation

- The input initialised via `useState(DEFAULT_TEMPLATE)` and ignored `draft.namingTemplate`; if the store held a non-default template the field showed the wrong value and the debounced setter pushed the stale default back to the backend.
- The fix must avoid an update cycle between the store→field sync effect and the field→store debounce.

## Changes

### Store-seeded template field

- Seed `useState` from `draft.namingTemplate ?? DEFAULT_TEMPLATE` via the existing zustand selector.
- Add a `useEffect` keyed on the stored template that syncs the field on external changes, using the functional `setTemplate` updater plus an equality guard so there is no `template` closure dependency (keeps oxlint `react-hooks/exhaustive-deps` clean with no disable directive) and the debounce push-back loop stays broken.

### Tests

- Add two tests: the store seeded with a non-default `namingTemplate` renders that value; an external store change syncs into the field (both failed before the fix).

## Verification

- Render `NamingRuleForm` with `draft.namingTemplate` set to e.g. `img_{n:04}` — the text input shows `img_{n:04}`, not `DEFAULT_TEMPLATE`.
- With the store template `null`, the field still shows `DEFAULT_TEMPLATE` (behavior unchanged).

## Test plan

- [x] `pnpm fmt:check`
- [x] `pnpm lint:ci`
- [x] `pnpm knip`
- [x] `pnpm run test:coverage` (275 tests green)
- [x] `pnpm build`
