### PR TITLE
refactor(frontend): move task display helpers into lib/status

### DIFF
--- a/src/components/RunSummary.tsx
+++ b/src/components/RunSummary.tsx
@@ -1,18 +1,5 @@
-import { statusVisual } from "@/lib/status";
+import { outputNameForTask, statusVisual } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
-
-// Map a failed task id back to its output preview name via the positional
-// alignment invariant (taskIdByIndex[i] <-> previewNames[i]); fall back to the
-// raw id when alignment is unavailable.
-function outputNameForTask(
-  taskId: number,
-  previewNames: string[],
-  taskIdByIndex: number[],
-): string {
-  const index = taskIdByIndex.indexOf(taskId);
-  const name = index >= 0 ? previewNames[index] : undefined;
-  return name ?? `task ${taskId}`;
-}
 
 /**
  * RunSummary is the completion panel shown after a job finishes. It is a pure

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,17 +1,11 @@
 import { memo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
-import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
-import type { ProgressEvent } from "@/bindings/ProgressEvent";
+import type { SourceKind } from "@/bindings/SourceKind";
 import { Progress } from "@/components/ui/progress";
-import {
-  formatByteProgress,
-  formatBytes,
-  formatEta,
-  progressPercent,
-} from "@/lib/format";
+import { formatBytes, formatEta, progressPercent } from "@/lib/format";
 import { basename } from "@/lib/path";
-import { statusVisual, taskOutcomeFor } from "@/lib/status";
+import { computeStatus } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
 
 // ---------------------------------------------------------------------------
@@ -21,78 +15,15 @@ import { useJobStore } from "@/store/jobStore";
 // Base styling shared by every kind badge; the per-kind colors are appended.
 const KIND_BADGE_BASE =
   "inline-block rounded px-1.5 py-0.5 text-xs font-medium";
-const KIND_BADGE_COLORS = {
+const KIND_BADGE_COLORS: Record<SourceKind, string> = {
   folder: "bg-category-folder-subtle text-category-folder-foreground",
   rar: "bg-category-archive-subtle text-category-archive-foreground",
   zip: "bg-category-archive-subtle text-category-archive-foreground",
-} as const;
+};
 
 // Styling shared by both reorder buttons (Move up / Move down).
 const REORDER_BUTTON_CLASS =
   "rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Compute the text display status for a single task at position `index`.
- *
- * Priority:
- * 1. running=true  → bytes from perTask[index], else "Processing". NOTE: when a
- *    per-task entry exists this returns a "<done> / <total> bytes" string, but
- *    the row renders the live progress bar (not text) whenever an entry exists,
- *    so that bytes string is only displayed in the transient window where
- *    `running` is true yet this row's per-task entry has not arrived — i.e. in
- *    practice only the "Processing" fallback of this branch is ever shown.
- * 2. summary≠null  → maps row `index` → taskId via taskIdByIndex[index], then
- *    membership-tests that id against summary.succeeded / summary.cancelled /
- *    summary.failed. This relies on the positional-alignment invariant:
- *    taskIdByIndex is index-aligned with draft.items (position 0 in
- *    taskIdByIndex corresponds to position 0 in draft.items, etc.).
- * 3. default        → "Waiting"
- */
-function computeStatus(
-  index: number,
-  running: boolean,
-  progress: ProgressEvent | null,
-  summary: JobSummaryDto | null,
-  taskIdByIndex: number[],
-): string {
-  if (running) {
-    const entry = progress?.perTask[index];
-    if (entry !== undefined) {
-      return formatByteProgress(entry.bytesDone, entry.bytesTotal);
-    }
-    return "Processing";
-  }
-
-  if (summary !== null) {
-    const taskId = taskIdByIndex[index];
-    if (taskId === undefined) {
-      return "Done";
-    }
-    // Delegate the summary → outcome rule to the shared lib/status helper so
-    // the membership-testing lives in exactly one place; this branch only maps
-    // the resolved outcome back to its rendered string.
-    const outcome = taskOutcomeFor(taskId, summary);
-    switch (outcome.kind) {
-      case "succeeded":
-        return statusVisual("succeeded").label;
-      case "cancelled":
-        return statusVisual("cancelled").label;
-      case "failed":
-        return `${statusVisual("failed").label}: ${outcome.reason}`;
-      default:
-        // `done` (id in no bucket) and `pending` (no summary) — neither is
-        // reachable here (summary is non-null and taskId is defined), but both
-        // map to the same "Done" string the original linear scan produced.
-        return "Done";
-    }
-  }
-
-  return "Waiting";
-}
 
 // ---------------------------------------------------------------------------
 // Component

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  formatByteProgress,
-  formatBytes,
-  formatEta,
-  progressPercent,
-} from "./format";
+import { formatBytes, formatEta, progressPercent } from "./format";
 
 describe("formatEta", () => {
   it("returns an em dash for unknown (null) ETA", () => {
@@ -57,21 +52,5 @@ describe("formatBytes", () => {
   });
   it("clamps negative inputs to zero", () => {
     expect(formatBytes(-5, -10)).toBe("0 / 0 B");
-  });
-});
-
-describe("formatByteProgress", () => {
-  it("formats done and total as raw integers with a 'bytes' suffix", () => {
-    expect(formatByteProgress(512, 1024)).toBe("512 / 1024 bytes");
-  });
-
-  it("formats zero values", () => {
-    expect(formatByteProgress(0, 0)).toBe("0 / 0 bytes");
-  });
-
-  it("passes through large numbers without scaling", () => {
-    expect(formatByteProgress(13_002_342, 19_922_944)).toBe(
-      "13002342 / 19922944 bytes",
-    );
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -52,13 +52,3 @@ export function formatBytes(done: number, total: number): string {
   };
   return `${render(done)} / ${render(total)} ${BYTE_UNITS[unitIndex]}`;
 }
-
-/**
- * Format a byte-progress pair as "<done> / <total> bytes" using raw integer
- * counts (no unit scaling). Matches the status string emitted by computeStatus
- * in TaskRow. Use formatBytes for a human-scaled alternative.
- * TODO: unify onto formatBytes in a follow-up.
- */
-export function formatByteProgress(done: number, total: number): string {
-  return `${done} / ${total} bytes`;
-}

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+import type { ProgressEvent } from "@/bindings/ProgressEvent";
 
-import { statusVisual, taskOutcomeFor } from "./status";
+import {
+  computeStatus,
+  outputNameForTask,
+  statusVisual,
+  taskOutcomeFor,
+} from "./status";
 
 describe("statusVisual", () => {
   it("maps succeeded to the unified 'Succeeded' label and the success tokens", () => {
@@ -58,5 +64,91 @@ describe("taskOutcomeFor", () => {
 
   it("resolves to pending when there is no summary yet", () => {
     expect(taskOutcomeFor(1, null)).toEqual({ kind: "pending" });
+  });
+});
+
+describe("computeStatus", () => {
+  const progressWith = (perTask: ProgressEvent["perTask"]): ProgressEvent => ({
+    overall: { bytesDone: 0, bytesTotal: 0 },
+    overallEtaMs: null,
+    perTask,
+    elapsedMs: 0,
+  });
+
+  it("returns the human-scaled byte string while running with a per-task entry", () => {
+    const progress = progressWith([
+      { taskId: 10, bytesDone: 512, bytesTotal: 2048, etaMs: null },
+    ]);
+    expect(computeStatus(0, true, progress, null, [10])).toBe("0.5 / 2 KB");
+  });
+
+  it("returns 'Processing' while running before this row's per-task entry arrives", () => {
+    expect(computeStatus(0, true, null, null, [10])).toBe("Processing");
+    expect(computeStatus(1, true, progressWith([]), null, [10])).toBe(
+      "Processing",
+    );
+  });
+
+  it("maps a succeeded id to its label once finished", () => {
+    const summary: JobSummaryDto = {
+      succeeded: [10],
+      cancelled: [],
+      failed: [],
+    };
+    expect(computeStatus(0, false, null, summary, [10])).toBe("Succeeded");
+  });
+
+  it("maps a cancelled id to its label once finished", () => {
+    const summary: JobSummaryDto = {
+      succeeded: [],
+      cancelled: [10],
+      failed: [],
+    };
+    expect(computeStatus(0, false, null, summary, [10])).toBe("Cancelled");
+  });
+
+  it("maps a failed id to its label plus the verbatim reason", () => {
+    const summary: JobSummaryDto = {
+      succeeded: [],
+      cancelled: [],
+      failed: [{ taskId: 10, reason: "boom" }],
+    };
+    expect(computeStatus(0, false, null, summary, [10])).toBe("Failed: boom");
+  });
+
+  it("returns 'Done' when a summary exists but the row has no mapped task id", () => {
+    const summary: JobSummaryDto = {
+      succeeded: [],
+      cancelled: [],
+      failed: [],
+    };
+    expect(computeStatus(5, false, null, summary, [10])).toBe("Done");
+  });
+
+  it("returns 'Done' when a summary exists but the id is in no bucket", () => {
+    const summary: JobSummaryDto = {
+      succeeded: [],
+      cancelled: [],
+      failed: [],
+    };
+    expect(computeStatus(0, false, null, summary, [10])).toBe("Done");
+  });
+
+  it("returns 'Waiting' when not running and no summary yet", () => {
+    expect(computeStatus(0, false, null, null, [10])).toBe("Waiting");
+  });
+});
+
+describe("outputNameForTask", () => {
+  it("maps a task id to its output preview name via the positional invariant", () => {
+    expect(outputNameForTask(4, ["a.zip", "b.zip"], [3, 4])).toBe("b.zip");
+  });
+
+  it("falls back to a 'task <id>' label when the id is not aligned", () => {
+    expect(outputNameForTask(99, ["a.zip", "b.zip"], [3, 4])).toBe("task 99");
+  });
+
+  it("falls back when the aligned preview name is missing", () => {
+    expect(outputNameForTask(4, ["a.zip"], [3, 4])).toBe("task 4");
   });
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -10,6 +10,8 @@
  * mapping in exactly one location.
  */
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+import type { ProgressEvent } from "@/bindings/ProgressEvent";
+import { formatBytes } from "@/lib/format";
 
 // The three members MUST stay in sync with the keys of the backend `JobSummaryDto`
 // (`succeeded` | `cancelled` | `failed`). RunSummary/TaskList pass these as string
@@ -87,4 +89,81 @@ export function taskOutcomeFor(
     return { kind: "failed", reason: failedEntry.reason };
   }
   return { kind: "done" };
+}
+
+/**
+ * Compute the text display status for a single task at position `index`.
+ *
+ * Priority:
+ * 1. running=true  → bytes from perTask[index], else "Processing". NOTE: when a
+ *    per-task entry exists this returns a "<done> / <total> <unit>" string, but
+ *    the row renders the live progress bar (not text) whenever an entry exists,
+ *    so that bytes string is only displayed in the transient window where
+ *    `running` is true yet this row's per-task entry has not arrived — i.e. in
+ *    practice only the "Processing" fallback of this branch is ever shown.
+ * 2. summary≠null  → maps row `index` → taskId via taskIdByIndex[index], then
+ *    membership-tests that id against summary.succeeded / summary.cancelled /
+ *    summary.failed. This relies on the positional-alignment invariant:
+ *    taskIdByIndex is index-aligned with draft.items (position 0 in
+ *    taskIdByIndex corresponds to position 0 in draft.items, etc.).
+ * 3. default        → "Waiting"
+ *
+ * Pure: no React/Tauri. Lives here so the per-row task list selects a flat
+ * status string rather than the progress/summary/taskIdByIndex collections.
+ */
+export function computeStatus(
+  index: number,
+  running: boolean,
+  progress: ProgressEvent | null,
+  summary: JobSummaryDto | null,
+  taskIdByIndex: number[],
+): string {
+  if (running) {
+    const entry = progress?.perTask[index];
+    if (entry !== undefined) {
+      return formatBytes(entry.bytesDone, entry.bytesTotal);
+    }
+    return "Processing";
+  }
+
+  if (summary !== null) {
+    const taskId = taskIdByIndex[index];
+    if (taskId === undefined) {
+      return "Done";
+    }
+    // Delegate the summary → outcome rule to the shared taskOutcomeFor helper so
+    // the membership-testing lives in exactly one place; this branch only maps
+    // the resolved outcome back to its rendered string.
+    const outcome = taskOutcomeFor(taskId, summary);
+    switch (outcome.kind) {
+      case "succeeded":
+        return statusVisual("succeeded").label;
+      case "cancelled":
+        return statusVisual("cancelled").label;
+      case "failed":
+        return `${statusVisual("failed").label}: ${outcome.reason}`;
+      default:
+        // `done` (id in no bucket) and `pending` (no summary) — neither is
+        // reachable here (summary is non-null and taskId is defined), but both
+        // map to the same "Done" string the original linear scan produced.
+        return "Done";
+    }
+  }
+
+  return "Waiting";
+}
+
+/**
+ * Map a failed task id back to its output preview name via the positional
+ * alignment invariant (taskIdByIndex[i] <-> previewNames[i]); fall back to the
+ * raw id when alignment is unavailable. Pure: no React/Tauri.
+ */
+export function outputNameForTask(
+  taskId: number,
+  previewNames: string[],
+  taskIdByIndex: number[],
+): string {
+  const index = taskIdByIndex.indexOf(taskId);
+  const name = index >= 0 ? previewNames[index] : undefined;
+  return name ?? `task ${taskId}`;
 }


### PR DESCRIPTION
## Summary

`computeStatus` and `outputNameForTask` were pure functions stranded inside `TaskRow` and `RunSummary`, untestable without rendering, and `format.ts` carried a `formatByteProgress` duplicate of `formatBytes`. This moves both helpers into `lib/status.ts`, deletes the duplicate formatter, and tightens the badge-color map's typing.

## Background / Motivation

- `computeStatus` (≈40 lines, no React deps) and `outputNameForTask` lived in component files, so their branches could only be exercised via full component renders.
- `formatByteProgress` was a self-admitted (`TODO`) duplicate of `formatBytes` with a single caller inside `computeStatus`.
- `KIND_BADGE_COLORS` was inferred, so a future `SourceKind` variant would silently miss a color and return `undefined` at runtime.

## Changes

### Display helpers → `lib/status.ts`

- Move `computeStatus` (from `TaskRow`) and `outputNameForTask` (from `RunSummary`) into `lib/status.ts` and re-import them; the inline `useShallow` selector in `TaskRow` is unchanged.

### Formatter dedup

- Remove `formatByteProgress` and its tests from `lib/format.ts`; `computeStatus`'s single call site now uses `formatBytes` (the transient pre-perTask byte string renders human-scaled, e.g. `0.5 / 2 KB`).

### Typing

- Type `KIND_BADGE_COLORS` as `Record<SourceKind, string>` (importing `SourceKind` from `@/bindings/SourceKind`) so a new variant fails at compile time.

### Tests

- Add `computeStatus` / `outputNameForTask` unit tests in `lib/status.test.ts` (written first, failing), covering the Processing / done-outcome / Done / Waiting branches.

## Verification

- `rg -n "formatByteProgress" src` returns no matches.
- `pnpm build` (tsc) passes with the `Record<SourceKind, string>` annotation; `pnpm knip` reports no unused exports for the moved/removed functions.

## Test plan

- [x] `pnpm fmt:check`
- [x] `pnpm lint:ci`
- [x] `pnpm knip`
- [x] `pnpm run test:coverage` (281 tests green)
- [x] `pnpm build`
