### PR TITLE
refactor(frontend): centralize Tauri dialog calls in lib/dialog

### DIFF
--- a/src/components/AddSourceButtons.test.tsx
+++ b/src/components/AddSourceButtons.test.tsx
@@ -1,22 +1,28 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { pickFiles, pickFolders } from "@/lib/dialog";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 import { AddSourceButtons } from "./AddSourceButtons";
 
-vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+// Mock the dialog lib so tests run without a native Tauri runtime; the lib
+// itself centralizes the plugin open() calls (asserted in lib/dialog.test.ts).
+vi.mock("@/lib/dialog", () => ({
+  pickFiles: vi.fn(),
+  pickFolders: vi.fn(),
+}));
 
 describe("AddSourceButtons", () => {
   beforeEach(() => {
     resetJobStore();
-    vi.mocked(open).mockReset();
+    vi.mocked(pickFiles).mockReset();
+    vi.mocked(pickFolders).mockReset();
   });
 
   it("opens the archive file dialog (rar/zip) and adds the picked files", async () => {
-    vi.mocked(open).mockResolvedValue(["/x.rar"]);
+    vi.mocked(pickFiles).mockResolvedValue(["/x.rar"]);
     const addItems = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ addItems });
 
@@ -24,16 +30,12 @@ describe("AddSourceButtons", () => {
     render(<AddSourceButtons />);
     await user.click(screen.getByRole("button", { name: /add files/i }));
 
-    expect(vi.mocked(open)).toHaveBeenCalledWith({
-      multiple: true,
-      directory: false,
-      filters: [{ name: "Archives", extensions: ["rar", "zip"] }],
-    });
+    expect(vi.mocked(pickFiles)).toHaveBeenCalled();
     await waitFor(() => expect(addItems).toHaveBeenCalledWith(["/x.rar"]));
   });
 
   it("opens the folder dialog and adds the picked folder", async () => {
-    vi.mocked(open).mockResolvedValue(["/my/folder"]);
+    vi.mocked(pickFolders).mockResolvedValue(["/my/folder"]);
     const addItems = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ addItems });
 
@@ -41,15 +43,12 @@ describe("AddSourceButtons", () => {
     render(<AddSourceButtons />);
     await user.click(screen.getByRole("button", { name: /add folder/i }));
 
-    expect(vi.mocked(open)).toHaveBeenCalledWith({
-      directory: true,
-      multiple: true,
-    });
+    expect(vi.mocked(pickFolders)).toHaveBeenCalled();
     await waitFor(() => expect(addItems).toHaveBeenCalledWith(["/my/folder"]));
   });
 
-  it("does not add when the dialog is cancelled (open returns null)", async () => {
-    vi.mocked(open).mockResolvedValue(null);
+  it("does not add when the dialog is cancelled (pick returns empty)", async () => {
+    vi.mocked(pickFiles).mockResolvedValue([]);
     const addItems = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ addItems });
 
@@ -60,7 +59,7 @@ describe("AddSourceButtons", () => {
   });
 
   it("surfaces a dialog/IPC error to the store", async () => {
-    vi.mocked(open).mockRejectedValue(new Error("permission denied"));
+    vi.mocked(pickFolders).mockRejectedValue(new Error("permission denied"));
     const addItems = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ addItems });
 
@@ -77,7 +76,7 @@ describe("AddSourceButtons", () => {
   it("surfaces a string-typed dialog rejection on the files button", async () => {
     // Tauri command errors can arrive as raw strings, not wrapped in Error objects.
     // This test ensures that messageFromReason handles string-type rejections.
-    vi.mocked(open).mockRejectedValue("boom");
+    vi.mocked(pickFiles).mockRejectedValue("boom");
     const addItems = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ addItems });
 

--- a/src/components/AddSourceButtons.tsx
+++ b/src/components/AddSourceButtons.tsx
@@ -1,20 +1,21 @@
-import { type OpenDialogOptions, open } from "@tauri-apps/plugin-dialog";
 import { FilePlus, FolderPlus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { pickFiles, pickFolders } from "@/lib/dialog";
 import { messageFromReason } from "@/lib/errors";
 import { useJobStore } from "@/store/jobStore";
 
 // Shared logic for both browse buttons: open the picker, then add the selected
-// paths. open() rejects only on a real dialog/IPC failure; cancellation
-// resolves to null (handled by the Array.isArray guard). The native browse
-// dialog is mode-exclusive (files XOR folders), which is why there are two
-// buttons — drag-and-drop is the single affordance that accepts both kinds.
-async function browseAndAdd(options: OpenDialogOptions) {
+// paths. The picker wrappers reject only on a real dialog/IPC failure;
+// cancellation resolves to an empty array (handled by the length guard). The
+// native browse dialog is mode-exclusive (files XOR folders), which is why
+// there are two buttons — drag-and-drop is the single affordance that accepts
+// both kinds.
+async function browseAndAdd(pick: () => Promise<string[]>) {
   try {
-    const result = await open(options);
-    if (Array.isArray(result) && result.length > 0) {
-      useJobStore.getState().addItems(result as string[]);
+    const paths = await pick();
+    if (paths.length > 0) {
+      useJobStore.getState().addItems(paths);
     }
   } catch (reason) {
     useJobStore.setState({ error: messageFromReason(reason) });
@@ -22,15 +23,11 @@ async function browseAndAdd(options: OpenDialogOptions) {
 }
 
 function handleAddFiles() {
-  return browseAndAdd({
-    multiple: true,
-    directory: false,
-    filters: [{ name: "Archives", extensions: ["rar", "zip"] }],
-  });
+  return browseAndAdd(pickFiles);
 }
 
 function handleAddFolder() {
-  return browseAndAdd({ directory: true, multiple: true });
+  return browseAndAdd(pickFolders);
 }
 
 interface AddSourceButtonsProps {

--- a/src/components/OutputDirPicker.test.tsx
+++ b/src/components/OutputDirPicker.test.tsx
@@ -1,21 +1,22 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { pickDirectory } from "@/lib/dialog";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 import { OutputDirPicker } from "./OutputDirPicker";
 
-// Mock the Tauri dialog plugin so tests run without a native Tauri runtime.
-vi.mock("@tauri-apps/plugin-dialog", () => ({
-  open: vi.fn(),
+// Mock the dialog lib so tests run without a native Tauri runtime; the lib
+// centralizes the plugin open() call (asserted in lib/dialog.test.ts).
+vi.mock("@/lib/dialog", () => ({
+  pickDirectory: vi.fn(),
 }));
 
 describe("OutputDirPicker", () => {
   beforeEach(() => {
     resetJobStore();
-    vi.mocked(open).mockReset();
+    vi.mocked(pickDirectory).mockReset();
   });
 
   it("renders the Destination heading", () => {
@@ -55,8 +56,8 @@ describe("OutputDirPicker", () => {
     expect(screen.queryByText("(not set)")).toBeNull();
   });
 
-  it("calls open with { directory: true } when the Choose button is clicked", async () => {
-    vi.mocked(open).mockResolvedValue(null);
+  it("invokes the directory picker when the Choose button is clicked", async () => {
+    vi.mocked(pickDirectory).mockResolvedValue(null);
     const user = userEvent.setup();
 
     render(<OutputDirPicker />);
@@ -64,12 +65,12 @@ describe("OutputDirPicker", () => {
     await user.click(screen.getByRole("button", { name: /choose/i }));
 
     await waitFor(() => {
-      expect(vi.mocked(open)).toHaveBeenCalledWith({ directory: true });
+      expect(vi.mocked(pickDirectory)).toHaveBeenCalled();
     });
   });
 
-  it("calls setOutputDir with the picked path when open resolves a string", async () => {
-    vi.mocked(open).mockResolvedValue("/picked/dir");
+  it("calls setOutputDir with the picked path when pickDirectory resolves a string", async () => {
+    vi.mocked(pickDirectory).mockResolvedValue("/picked/dir");
     const setOutputDir = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ setOutputDir });
     const user = userEvent.setup();
@@ -83,8 +84,8 @@ describe("OutputDirPicker", () => {
     });
   });
 
-  it("does NOT call setOutputDir when open resolves null (user cancelled)", async () => {
-    vi.mocked(open).mockResolvedValue(null);
+  it("does NOT call setOutputDir when pickDirectory resolves null (user cancelled)", async () => {
+    vi.mocked(pickDirectory).mockResolvedValue(null);
     const setOutputDir = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ setOutputDir });
     const user = userEvent.setup();
@@ -94,14 +95,14 @@ describe("OutputDirPicker", () => {
     await user.click(screen.getByRole("button", { name: /choose/i }));
 
     await waitFor(() => {
-      expect(vi.mocked(open)).toHaveBeenCalled();
+      expect(vi.mocked(pickDirectory)).toHaveBeenCalled();
     });
 
     expect(setOutputDir).not.toHaveBeenCalled();
   });
 
   it("surfaces a real dialog error via the store without crashing or calling setOutputDir", async () => {
-    vi.mocked(open).mockRejectedValue("disk fail");
+    vi.mocked(pickDirectory).mockRejectedValue("disk fail");
     const setOutputDir = vi.fn().mockResolvedValue(undefined);
     useJobStore.setState({ setOutputDir });
     const user = userEvent.setup();

--- a/src/components/OutputDirPicker.tsx
+++ b/src/components/OutputDirPicker.tsx
@@ -1,6 +1,5 @@
-import { open } from "@tauri-apps/plugin-dialog";
-
 import { Button } from "@/components/ui/button";
+import { pickDirectory } from "@/lib/dialog";
 import { messageFromReason } from "@/lib/errors";
 import { useJobStore } from "@/store/jobStore";
 
@@ -19,14 +18,13 @@ export function OutputDirPicker() {
 
   async function handleChoose() {
     try {
-      // directory: true requests a folder picker, not a file picker.
-      const picked = await open({ directory: true });
+      const picked = await pickDirectory();
       if (typeof picked === "string") {
         await setOutputDir(picked);
       }
       // null means the user cancelled — do nothing.
     } catch (reason) {
-      // open() rejects only on a real dialog/IPC failure; cancellation resolves to null.
+      // pickDirectory rejects only on a real dialog/IPC failure; cancellation resolves to null.
       useJobStore.setState({ error: messageFromReason(reason) });
     }
   }

--- a/src/lib/dialog.test.ts
+++ b/src/lib/dialog.test.ts
@@ -1,0 +1,71 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+
+// Import after the mock is registered.
+import { pickDirectory, pickFiles, pickFolders } from "./dialog";
+
+describe("dialog client", () => {
+  beforeEach(() => {
+    vi.mocked(open).mockReset();
+  });
+
+  describe("pickFiles", () => {
+    it("opens a multi-select archive (rar/zip) file picker", async () => {
+      vi.mocked(open).mockResolvedValue(["/a.rar", "/b.zip"]);
+
+      const result = await pickFiles();
+
+      expect(vi.mocked(open)).toHaveBeenCalledWith({
+        multiple: true,
+        directory: false,
+        filters: [{ name: "Archives", extensions: ["rar", "zip"] }],
+      });
+      expect(result).toEqual(["/a.rar", "/b.zip"]);
+    });
+
+    it("normalizes a cancelled pick (null) to an empty array", async () => {
+      vi.mocked(open).mockResolvedValue(null);
+
+      expect(await pickFiles()).toEqual([]);
+    });
+  });
+
+  describe("pickFolders", () => {
+    it("opens a multi-select folder picker", async () => {
+      vi.mocked(open).mockResolvedValue(["/one", "/two"]);
+
+      const result = await pickFolders();
+
+      expect(vi.mocked(open)).toHaveBeenCalledWith({
+        directory: true,
+        multiple: true,
+      });
+      expect(result).toEqual(["/one", "/two"]);
+    });
+
+    it("normalizes a cancelled pick (null) to an empty array", async () => {
+      vi.mocked(open).mockResolvedValue(null);
+
+      expect(await pickFolders()).toEqual([]);
+    });
+  });
+
+  describe("pickDirectory", () => {
+    it("opens a single-select directory picker", async () => {
+      vi.mocked(open).mockResolvedValue("/picked/dir");
+
+      const result = await pickDirectory();
+
+      expect(vi.mocked(open)).toHaveBeenCalledWith({ directory: true });
+      expect(result).toBe("/picked/dir");
+    });
+
+    it("returns null when the user cancels", async () => {
+      vi.mocked(open).mockResolvedValue(null);
+
+      expect(await pickDirectory()).toBeNull();
+    });
+  });
+});

--- a/src/lib/dialog.ts
+++ b/src/lib/dialog.ts
@@ -1,0 +1,39 @@
+import { open } from "@tauri-apps/plugin-dialog";
+
+// Thin wrapper around the Tauri dialog plugin, mirroring how lib/archive.ts
+// centralizes all invoke IPC. Keeping every open() call here gives the app a
+// single, typed surface for native pickers (and a single mock point in tests).
+//
+// open() rejects only on a real dialog/IPC failure; cancellation resolves to
+// null, which these wrappers normalize per their documented return type.
+
+/**
+ * Open a multi-select file picker filtered to rar/zip archives.
+ * Returns the selected paths, or an empty array when the user cancels.
+ */
+export async function pickFiles(): Promise<string[]> {
+  const result = await open({
+    multiple: true,
+    directory: false,
+    filters: [{ name: "Archives", extensions: ["rar", "zip"] }],
+  });
+  return result ?? [];
+}
+
+/**
+ * Open a multi-select folder picker.
+ * Returns the selected folder paths, or an empty array when the user cancels.
+ */
+export async function pickFolders(): Promise<string[]> {
+  const result = await open({ directory: true, multiple: true });
+  return result ?? [];
+}
+
+/**
+ * Open a single-select directory picker.
+ * Returns the chosen directory, or null when the user cancels.
+ */
+export function pickDirectory(): Promise<string | null> {
+  // directory: true requests a folder picker, not a file picker.
+  return open({ directory: true });
+}


### PR DESCRIPTION
## Summary

`AddSourceButtons` and `OutputDirPicker` each imported and called the Tauri dialog plugin directly, scattering IPC and its mock surface across components. This centralizes the dialog calls behind a typed `src/lib/dialog.ts`, mirroring how `lib/archive.ts` already wraps all `invoke` IPC.

## Background / Motivation

- Two components imported `open` from `@tauri-apps/plugin-dialog` and inlined the option objects (filters, `multiple`, `directory`), so every test rendering them mocked the plugin independently and any new dialog option had to change in two places.
- `lib/archive.ts` already establishes the thin typed-IPC-client pattern; the dialog was the outlier.

## Changes

### New `lib/dialog.ts`

- New `src/lib/dialog.ts` wraps the plugin `open()` behind typed helpers: `pickFiles()` (rar/zip filters), `pickFolders()` (`{ directory: true, multiple: true }`, used by AddSourceButtons' multi-folder picker), and `pickDirectory()` (single-select `{ directory: true }`, used by OutputDirPicker) — preserving each call site's distinct options and null/empty handling.

### Component + test rewiring

- `AddSourceButtons.tsx` and `OutputDirPicker.tsx` call the lib helpers and drop their direct `@tauri-apps/plugin-dialog` imports.
- Tests now mock `@/lib/dialog`; new `src/lib/dialog.test.ts` mocks the plugin and asserts `open` is called with the correct options (written first, watched fail on the unresolved import).

## Verification

- `rg -n "plugin-dialog" src/components` returns no matches — only `src/lib/dialog.ts` imports the plugin.
- `pnpm knip` reports `lib/dialog.ts` as used (no unused-file finding).

## Test plan

- [x] `pnpm fmt:check`
- [x] `pnpm lint:ci`
- [x] `pnpm knip`
- [x] `pnpm run test:coverage` (279 tests green)
- [x] `pnpm build`
