### PR TITLE
refactor(infrastructure): dedupe zip cancel-cleanup & path walking

### DIFF
--- a/crates/core/src/infrastructure/mod.rs
+++ b/crates/core/src/infrastructure/mod.rs
@@ -9,6 +9,8 @@
 // Loom-tested concurrency code lives in application/loom_nucleus.rs (PR-5b).
 #[cfg(not(loom))]
 pub mod archive_extractor;
+#[cfg(not(loom))]
+mod path_utils;
 pub mod system_clock;
 #[cfg(not(loom))]
 pub mod temp_workspace;

--- a/crates/core/src/infrastructure/path_utils.rs
+++ b/crates/core/src/infrastructure/path_utils.rs
@@ -1,0 +1,89 @@
+//! Shared path-component classification for the zip adapters.
+//!
+//! Both the archiver (`zip_entry_name`) and the extractor (`safe_relative_path`)
+//! walk a path's `Component`s and sort each one into the same three buckets, but
+//! they apply DIVERGING policies to the result: the archiver silently filters
+//! anything that is not a normal component, while the extractor rejects unsafe
+//! components with an error. This module owns ONLY the shared classification +
+//! iteration primitive; each caller keeps its own policy.
+
+use std::ffi::OsStr;
+use std::path::{Component, Path};
+
+/// Classification of a single path `Component` into the buckets the zip adapters
+/// care about. The borrowed `OsStr` in `Normal` ties the lifetime to the path.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PathPart<'a> {
+    /// A normal path segment (a real file/directory name).
+    Normal(&'a OsStr),
+    /// A component that contributes nothing to a relative path (`.`).
+    Ignorable,
+    /// A component that could escape the destination root: `..`, an absolute
+    /// root, or a Windows drive/UNC prefix.
+    Unsafe,
+}
+
+/// Classify a single `Component` into a `PathPart`.
+///
+/// The mapping mirrors the (previously duplicated) `match` arms in the two
+/// adapters, so callers can reuse one classification and layer their own policy
+/// on top (filter vs. reject).
+pub(crate) fn classify(component: Component<'_>) -> PathPart<'_> {
+    match component {
+        Component::Normal(part) => PathPart::Normal(part),
+        Component::CurDir => PathPart::Ignorable,
+        Component::ParentDir | Component::RootDir | Component::Prefix(_) => PathPart::Unsafe,
+    }
+}
+
+/// Iterate the classified components of `path` in order.
+///
+/// This is the single shared traversal primitive: `path.components()` mapped
+/// through [`classify`]. Callers decide what to do with each `PathPart`.
+pub(crate) fn classified_components(path: &Path) -> impl Iterator<Item = PathPart<'_>> {
+    path.components().map(classify)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_each_component_kind() {
+        // `./b/../c` keeps a leading `.` (CurDir) that `Path::components()` does
+        // NOT collapse, so this input exercises all three arms: Ignorable (`.`),
+        // Normal (`b`, `c`), and Unsafe (`..`).
+        let parts: Vec<PathPart<'_>> = classified_components(Path::new("./b/../c")).collect();
+        assert_eq!(
+            parts,
+            vec![
+                PathPart::Ignorable,
+                PathPart::Normal(OsStr::new("b")),
+                PathPart::Unsafe,
+                PathPart::Normal(OsStr::new("c")),
+            ]
+        );
+    }
+
+    #[test]
+    fn absolute_root_is_unsafe() {
+        // The leading `/` is a RootDir component and must classify as unsafe so
+        // the extractor can reject absolute entry names.
+        let parts: Vec<PathPart<'_>> = classified_components(Path::new("/etc/passwd")).collect();
+        assert_eq!(parts.first(), Some(&PathPart::Unsafe));
+        assert!(parts.contains(&PathPart::Normal(OsStr::new("etc"))));
+        assert!(parts.contains(&PathPart::Normal(OsStr::new("passwd"))));
+    }
+
+    #[test]
+    fn plain_relative_path_is_all_normal() {
+        let parts: Vec<PathPart<'_>> = classified_components(Path::new("sub/file.txt")).collect();
+        assert_eq!(
+            parts,
+            vec![
+                PathPart::Normal(OsStr::new("sub")),
+                PathPart::Normal(OsStr::new("file.txt")),
+            ]
+        );
+    }
+}

--- a/crates/core/src/infrastructure/zip_archiver.rs
+++ b/crates/core/src/infrastructure/zip_archiver.rs
@@ -2,9 +2,10 @@
 
 use crate::application::compress_context::CompressContext;
 use crate::application::ports::{ArchiveError, Archiver};
+use crate::infrastructure::path_utils::{classified_components, PathPart};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// Compresses directory trees into zip archives using `async_zip` with Deflate.
@@ -59,16 +60,7 @@ impl Archiver for ZipArchiver {
         let mut bytes_done: u64 = 0;
         for path in &files {
             if ctx.is_cancelled() {
-                // Cancel cleanup: finalize and drain the writer via `drain_to_disk`
-                // (close -> recover the file -> shutdown + sync_all) BEFORE removing
-                // it, so the common cancel path does not leave a partial zip racing
-                // the delete. Best-effort: if `close()` errors the file is dropped
-                // without an explicit drain and we still fall through to the removal
-                // (a rare, platform-dependent window; see `drain_to_disk`).
-                if let Ok(mut file) = writer.close().await.map(|w| w.into_inner()) {
-                    let _ = drain_to_disk(&mut file).await;
-                }
-                remove_partial_output(dest_zip).await;
+                close_and_remove(writer, dest_zip).await;
                 return Err(ArchiveError::Cancelled);
             }
 
@@ -83,16 +75,7 @@ impl Archiver for ZipArchiver {
             ctx.report(bytes_done, bytes_total);
 
             if ctx.is_cancelled() {
-                // Cancel cleanup: finalize and drain the writer via `drain_to_disk`
-                // (close -> recover the file -> shutdown + sync_all) BEFORE removing
-                // it, so the common cancel path does not leave a partial zip racing
-                // the delete. Best-effort: if `close()` errors the file is dropped
-                // without an explicit drain and we still fall through to the removal
-                // (a rare, platform-dependent window; see `drain_to_disk`).
-                if let Ok(mut file) = writer.close().await.map(|w| w.into_inner()) {
-                    let _ = drain_to_disk(&mut file).await;
-                }
-                remove_partial_output(dest_zip).await;
+                close_and_remove(writer, dest_zip).await;
                 return Err(ArchiveError::Cancelled);
             }
         }
@@ -119,6 +102,22 @@ impl Archiver for ZipArchiver {
         drain_to_disk(&mut file).await?;
         Ok(())
     }
+}
+
+/// Cancel cleanup shared by both cancel checkpoints: finalize and drain the
+/// writer via `drain_to_disk` (close -> recover the file -> shutdown + sync_all)
+/// BEFORE removing it, so the common cancel path does not leave a partial zip
+/// racing the delete. Best-effort: if `close()` errors the file is dropped
+/// without an explicit drain and we still fall through to the removal (a rare,
+/// platform-dependent window; see `drain_to_disk`).
+async fn close_and_remove(
+    writer: async_zip::tokio::write::ZipFileWriter<tokio::fs::File>,
+    dest_zip: &Path,
+) {
+    if let Ok(mut file) = writer.close().await.map(|w| w.into_inner()) {
+        let _ = drain_to_disk(&mut file).await;
+    }
+    remove_partial_output(dest_zip).await;
 }
 
 /// Flush and fsync a recovered zip file so all queued blocking writes complete
@@ -181,10 +180,11 @@ pub(crate) fn zip_entry_name(root: &Path, path: &Path) -> Result<String, Archive
             root.display()
         ))
     })?;
-    let name = relative
-        .components()
-        .filter_map(|component| match component {
-            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+    // Policy: silently FILTER every non-normal component, keeping only normal
+    // segments joined with `/`.
+    let name = classified_components(relative)
+        .filter_map(|part| match part {
+            PathPart::Normal(segment) => Some(segment.to_string_lossy().into_owned()),
             _ => None,
         })
         .collect::<Vec<_>>()

--- a/crates/core/src/infrastructure/zip_extractor.rs
+++ b/crates/core/src/infrastructure/zip_extractor.rs
@@ -8,9 +8,10 @@
 //! absolute root, or a Windows drive/UNC prefix) rejects the whole extraction.
 
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
+use crate::infrastructure::path_utils::{classified_components, PathPart};
 use crate::infrastructure::temp_workspace::TempWorkspace;
 use async_zip::tokio::read::seek::ZipFileReader;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 /// Extracts zip archives into a temporary directory via `async_zip`.
 #[derive(Debug, Default)]
@@ -100,12 +101,14 @@ impl Extractor for ZipExtractor {
 /// absolute root, or a Windows drive/UNC prefix). Rejecting an unsafe name
 /// aborts the whole extraction so nothing escapes the workspace.
 fn safe_relative_path(name: &str) -> Result<Option<PathBuf>, ExtractError> {
+    // Policy: REJECT any non-normal component. `.` is dropped; everything else
+    // that is not a normal segment aborts the extraction (zip-slip guard).
     let mut rel = PathBuf::new();
-    for component in Path::new(name).components() {
-        match component {
-            Component::Normal(part) => rel.push(part),
-            Component::CurDir => {}
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+    for part in classified_components(Path::new(name)) {
+        match part {
+            PathPart::Normal(segment) => rel.push(segment),
+            PathPart::Ignorable => {}
+            PathPart::Unsafe => {
                 return Err(ExtractError::Backend(format!("unsafe entry path: {name}")));
             }
         }


### PR DESCRIPTION
## Summary

The zip archiver duplicated its cancel-cleanup block verbatim across two checkpoints, and the path-component walk used both for entry naming and for the zip-slip guard was reimplemented in two files. This extracts a shared cancel helper and a `path_utils` component classifier, keeping each call site's policy local and the zip-slip guarantees identical.

## Background / Motivation

- `zip_archiver.rs` had two byte-for-byte identical cancel checkpoints (close writer → `drain_to_disk` → `remove_partial_output` → return `Cancelled`); a future change to the cleanup protocol would have had to touch both.
- `zip_entry_name` (archiver) and `safe_relative_path` (extractor, the zip-slip guard) each walked `Path::components()` matching `Normal` / `CurDir` / unsafe variants — the same security-relevant classification implemented twice with diverging outcomes.

## Changes

### Cancel-cleanup dedup

- Extract a private `async fn close_and_remove(writer, dest_zip)` in `zip_archiver.rs`; both cancel checkpoints now call it.

### Shared path-component primitive

- New private module `crates/core/src/infrastructure/path_utils.rs` with a `PathPart` classifier plus a `classified_components(&Path)` primitive (3 unit tests), wired via `mod` in `infrastructure/mod.rs`.
- `zip_entry_name` (silent FILTER policy) and `safe_relative_path` (REJECT policy + zip-slip guard) both consume the primitive while keeping their diverging policy local.

## Verification

- The writer is named via the public alias `async_zip::tokio::write::ZipFileWriter<tokio::fs::File>`, so the compat wrapper is never named (matches the existing `.into_inner()` resolution).
- `cargo nextest run -p simple-archiver-core` — the 210 pre-existing tests pass unchanged; 213 total with the 3 new `path_utils` tests.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p simple-archiver-core --all-targets -- -D warnings`
- [x] `cargo nextest run -p simple-archiver-core` (213 tests green)
- [x] zip-slip guard behavior unchanged (existing extractor traversal tests green)
