### PR TITLE
chore(tauri): set About-dialog copyright and crate metadata

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "simple-archiver"
 version = "0.3.0"
-description = "A Tauri App"
-authors = ["you"]
+description = "Simple Archiver"
+authors = ["Yasuyuki Takeo"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,6 +24,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "copyright": "© 2026 Yasuyuki Takeo",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

The macOS standard About panel showed no copyright line, and the `src-tauri` crate still carried the `create-tauri-app` scaffold placeholders. This sets `bundle.copyright` so the About panel renders an attribution line, and replaces the `Cargo.toml` placeholder `description` / `authors` with real values. No source or icon files change.

## Background / Motivation

- The standard macOS About panel renders `NSHumanReadableCopyright`, which Tauri populates from `bundle.copyright`. That key was unset, so the panel showed only the product name and version with no attribution.
- `src-tauri/Cargo.toml` still carried the scaffold placeholders `description = "A Tauri App"` and `authors = ["you"]`.
- The app icon was reported as a generic folder, but the repo's icon set (including `src-tauri/icons/icon.icns`) is already the correct cube logo. That symptom is a stale build / macOS icon cache, not a repo defect, so no icon files are touched here.

## Changes

### About-dialog copyright

- Add `"copyright": "© 2026 Yasuyuki Takeo"` to the `bundle` block in `src-tauri/tauri.conf.json`. Tauri maps it to `NSHumanReadableCopyright` on macOS (and `LegalCopyright` on Windows).

### Crate metadata

- `src-tauri/Cargo.toml`: `description` → `"Simple Archiver"`, `authors` → `["Yasuyuki Takeo"]` (were the scaffold placeholders).

## Verification

- After a fresh macOS bundle build, the standard About panel (app menu → About simple-archiver) shows a `© 2026 Yasuyuki Takeo` line below the version.
- `python3 -c "import json;print(json.load(open('src-tauri/tauri.conf.json'))['bundle']['copyright'])"` prints `© 2026 Yasuyuki Takeo`.
- `cargo metadata --no-deps --format-version 1 | jq '.packages[]|select(.name=="simple-archiver")|{description,authors}'` reports the new values.

## Test plan

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run` (config-only; suite expected green, no behavior change)
- [ ] Build the macOS bundle and confirm the About panel shows the `© 2026 Yasuyuki Takeo` line
