### PR TITLE
feat(ui): output-mode toggle & conditional OUTPUT form (PR2)

### DIFF
--- a/src/components/OutputModeToggle.test.tsx
+++ b/src/components/OutputModeToggle.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { OutputModeToggle } from "@/components/OutputModeToggle";
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+afterEach(() => resetJobStore());
+
+it("renders .zip selected by default and switches to Folder on click", () => {
+  const spy = vi
+    .spyOn(useJobStore.getState(), "setOutputMode")
+    .mockResolvedValue();
+
+  render(<OutputModeToggle />);
+
+  const zip = screen.getByRole("radio", { name: /\.zip file/i });
+  const folder = screen.getByRole("radio", { name: /folder/i });
+  expect(zip.getAttribute("aria-checked")).toBe("true");
+  expect(folder.getAttribute("aria-checked")).toBe("false");
+
+  fireEvent.click(folder);
+  expect(spy).toHaveBeenCalledWith("folder");
+});

--- a/src/components/OutputModeToggle.tsx
+++ b/src/components/OutputModeToggle.tsx
@@ -33,6 +33,10 @@ export function OutputModeToggle() {
           <button
             key={opt.value}
             type="button"
+            // A segmented toggle of buttons in a radiogroup is the intended
+            // pattern here (a native radio input cannot host the segmented
+            // visual treatment); keep the explicit ARIA role.
+            // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
             role="radio"
             aria-checked={selected}
             onClick={() => choose(opt.value)}

--- a/src/components/OutputModeToggle.tsx
+++ b/src/components/OutputModeToggle.tsx
@@ -1,0 +1,52 @@
+import type { OutputMode } from "@/bindings/OutputMode";
+import { cn } from "@/lib/utils";
+import { useJobStore } from "@/store/jobStore";
+
+const OPTIONS: { value: OutputMode; label: string }[] = [
+  { value: "zip", label: ".zip file" },
+  { value: "folder", label: "Folder" },
+];
+
+/**
+ * The "Output as" segmented control at the top of the OUTPUT group. Selecting a
+ * mode pushes it into the store, which drives the conditional OUTPUT fields and
+ * the hero path. Two `role="radio"` buttons in a `role="radiogroup"` keep it
+ * keyboard- and screen-reader-friendly.
+ */
+export function OutputModeToggle() {
+  const mode = useJobStore((s) => s.draft.outputMode);
+
+  function choose(next: OutputMode) {
+    if (next === mode) return;
+    void useJobStore.getState().setOutputMode(next);
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Output as"
+      className="inline-flex overflow-hidden rounded-md border border-border"
+    >
+      {OPTIONS.map((opt) => {
+        const selected = opt.value === mode;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => choose(opt.value)}
+            className={cn(
+              "px-2.5 py-1 text-xs font-medium",
+              selected
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/OutputSettings.test.tsx
+++ b/src/components/OutputSettings.test.tsx
@@ -32,6 +32,29 @@ describe("OutputSettings", () => {
     useJobStore.setState({ setNamingRule: vi.fn() });
   });
 
+  it("hides the Name field and shows the extraction note in Folder mode", () => {
+    useJobStore.setState((s) => ({
+      draft: {
+        ...s.draft,
+        outputMode: "folder",
+        outputDir: "/Users/me/Downloads",
+      },
+    }));
+
+    render(<OutputSettings />);
+
+    expect(screen.queryByLabelText("Name")).toBeNull();
+    expect(screen.getByText(/each archive .* its own folder/i)).toBeDefined();
+  });
+
+  it("shows the Name field in zip mode", () => {
+    useJobStore.setState((s) => ({
+      draft: { ...s.draft, outputMode: "zip" },
+    }));
+    render(<OutputSettings />);
+    expect(screen.getByLabelText("Name")).toBeDefined();
+  });
+
   it("renders the OUTPUT group heading and Destination/Name child headings", () => {
     render(<OutputSettings />);
 

--- a/src/components/OutputSettings.tsx
+++ b/src/components/OutputSettings.tsx
@@ -2,6 +2,7 @@ import { ArrowRight } from "lucide-react";
 
 import { NamingRuleForm } from "@/components/NamingRuleForm";
 import { OutputDirPicker } from "@/components/OutputDirPicker";
+import { OutputModeToggle } from "@/components/OutputModeToggle";
 import { joinOutputPath } from "@/lib/path";
 import { selectFirstPreview, useJobStore } from "@/store/jobStore";
 
@@ -29,6 +30,7 @@ import { selectFirstPreview, useJobStore } from "@/store/jobStore";
  */
 export function OutputSettings() {
   const outputDir = useJobStore((s) => s.draft.outputDir);
+  const outputMode = useJobStore((s) => s.draft.outputMode);
 
   // The single source of preview truth. firstPreview is tri-state:
   //   null  = still loading (a recompute is pending / in flight),
@@ -41,25 +43,34 @@ export function OutputSettings() {
   // unless a preview resolution actually failed.
   const error = useJobStore((s) => s.previewError) ?? "";
 
-  // The hero path is only shown when previewName is a non-empty string. Both
-  // null (still loading) and "" (the store's error path) suppress it, so the
-  // output directory is never displayed in isolation, which would mislead the
-  // user about the actual destination. joinOutputPath already returns the bare
-  // filename when outputDir is null, so the same value drives both the full
-  // path (destination set) and the filename-only hero (no destination).
-  const heroPath = previewName ? joinOutputPath(outputDir, previewName) : null;
+  // Zip mode joins the destination with the previewed filename; Folder mode
+  // shows a representative per-archive folder path. heroPath stays null until a
+  // preview resolves (zip) so the directory is never shown in isolation. In
+  // folder mode the filename preview is irrelevant (no re-zip), so the hero
+  // shows the destination with a representative per-archive folder placeholder.
+  const heroPath =
+    outputMode === "folder"
+      ? outputDir
+        ? `${joinOutputPath(outputDir, "")}▸ <archive name>/`
+        : null
+      : previewName
+        ? joinOutputPath(outputDir, previewName)
+        : null;
 
   return (
     <section className="flex flex-col gap-3 rounded-md border border-border p-4">
-      <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">
-        OUTPUT
-      </span>
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">
+          OUTPUT
+        </span>
+        <OutputModeToggle />
+      </div>
 
       {/* Hero: the full landing path is the focal point of the group. It is
           only shown once the preview filename has resolved, so the user never
           sees the destination directory in isolation (which would mislead). The
           leading arrow only appears once a destination joins the filename into a
-          full path. */}
+          full path. heroPath is mode-aware. */}
       <div className="flex flex-col gap-1">
         {heroPath !== null ? (
           <p className="flex items-center gap-2 truncate text-base">
@@ -80,7 +91,7 @@ export function OutputSettings() {
             Select a destination to preview the full path.
           </p>
         ) : null}
-        {error ? (
+        {outputMode === "zip" && error ? (
           <p role="alert" className="text-sm text-destructive">
             {error}
           </p>
@@ -92,10 +103,19 @@ export function OutputSettings() {
           OutputDirPicker contributes three cells (label, path, Choose); the
           Choose button lands in the third/right column. NamingRuleForm
           contributes two cells (label, input) with the input spanning the
-          control + action columns. */}
+          control + action columns. In folder mode the Name field is irrelevant
+          (each archive is extracted into its own folder), so it is replaced by
+          an extraction note spanning the full grid width. */}
       <div className="grid grid-cols-[max-content_minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2.5">
         <OutputDirPicker />
-        <NamingRuleForm />
+        {outputMode === "zip" ? (
+          <NamingRuleForm />
+        ) : (
+          <p className="col-span-3 text-xs text-muted-foreground">
+            Each archive is extracted into its own folder named after the
+            archive.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/lib/archive.test.ts
+++ b/src/lib/archive.test.ts
@@ -19,6 +19,7 @@ import {
   runJob,
   setNamingRule,
   setOutputDir,
+  setOutputMode,
   subscribeProgress,
 } from "./archive";
 
@@ -89,6 +90,22 @@ describe("archive client", () => {
       expect(vi.mocked(invoke)).toHaveBeenCalledWith("set_output_dir", {
         dir: "/out",
       });
+    });
+  });
+
+  describe("setOutputMode", () => {
+    it("invokes set_output_mode with the mode", async () => {
+      vi.mocked(invoke).mockResolvedValue({
+        items: [],
+        namingTemplate: null,
+        outputDir: null,
+        outputMode: "folder",
+      });
+      const snap = await setOutputMode("folder");
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith("set_output_mode", {
+        mode: "folder",
+      });
+      expect(snap.outputMode).toBe("folder");
     });
   });
 

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -3,6 +3,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+import type { OutputMode } from "@/bindings/OutputMode";
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 
 /** Tauri event channel name emitted by the backend during an active archive job. */
@@ -38,6 +39,14 @@ export function setNamingRule(template: string): Promise<DraftSnapshot> {
  */
 export function setOutputDir(dir: string): Promise<DraftSnapshot> {
   return invoke<DraftSnapshot>("set_output_dir", { dir });
+}
+
+/**
+ * Set the batch output mode (re-zip vs extract-to-folder).
+ * Returns the updated draft snapshot.
+ */
+export function setOutputMode(mode: OutputMode): Promise<DraftSnapshot> {
+  return invoke<DraftSnapshot>("set_output_mode", { mode });
 }
 
 /**

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/archive", () => ({
   reorder: vi.fn(),
   setNamingRule: vi.fn(),
   setOutputDir: vi.fn(),
+  setOutputMode: vi.fn(),
   clearItems: vi.fn(),
   runJob: vi.fn(),
   cancelJob: vi.fn(),
@@ -305,6 +306,22 @@ describe("setOutputDir", () => {
     await useJobStore.getState().setOutputDir("/out");
 
     expect(useJobStore.getState().error).toBeNull();
+  });
+});
+
+describe("setOutputMode", () => {
+  it("setOutputMode pushes the mode and stores the returned draft", async () => {
+    const spy = vi.spyOn(archive, "setOutputMode").mockResolvedValue({
+      items: [],
+      namingTemplate: null,
+      outputDir: "/out",
+      outputMode: "folder",
+    });
+
+    await useJobStore.getState().setOutputMode("folder");
+
+    expect(spy).toHaveBeenCalledWith("folder");
+    expect(useJobStore.getState().draft.outputMode).toBe("folder");
   });
 });
 

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+import type { OutputMode } from "@/bindings/OutputMode";
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 // Namespace import to disambiguate the command wrappers from the store actions,
 // which share names (addItems, reorder, setNamingRule, ...).
@@ -82,6 +83,8 @@ export interface JobState {
   setNamingRule: (template: string) => Promise<void>;
   /** Set the output directory (does not affect preview filenames). */
   setOutputDir: (dir: string) => Promise<void>;
+  /** Set the output mode (re-zip vs extract-to-folder); stores the returned draft. */
+  setOutputMode: (mode: OutputMode) => Promise<void>;
   /** Start the archive job and store its summary when it finishes. */
   runJob: () => Promise<void>;
   /** Request cancellation of the running job (does not flip `running`). */
@@ -165,6 +168,17 @@ export const useJobStore = create<JobState>()((set, get) => ({
       persistOutputDir(dir);
     } catch (reason) {
       console.error("setOutputDir: persisting output dir failed", reason);
+    }
+  },
+
+  setOutputMode: async (mode) => {
+    try {
+      // A mode change drives what the OUTPUT group shows (re-zip vs extract),
+      // not the preview filenames, so no recompute is needed.
+      const draft = await archive.setOutputMode(mode);
+      set({ draft, error: null });
+    } catch (reason) {
+      set({ error: messageFromReason(reason) });
     }
   },
 


### PR DESCRIPTION
## Summary

Adds the frontend for the "simple extraction" output mode: an "Output as (`.zip` / `Folder`)" segmented control at the top of the OUTPUT card. In `Folder` mode the `Name` field is hidden, an extraction note appears, and the hero path becomes mode-aware. **Default mode is `.zip`, so existing behavior is unchanged.**

This is **PR2 of 3** (frontend skeleton). Closes #102.

## Background / Motivation

- PR1 (#105) threaded `OutputMode` through the backend and regenerated the binding contract, but shipped no UI to choose the mode — users cannot reach the new extract-to-folder path without a control.
- `Folder` mode has no naming rule, so the `Name` field is meaningless there and must be hidden; the hero path must reflect a per-archive folder rather than a single `.zip`.

## Changes

### Store / command wrapper
- `setOutputMode` wrapper (`src/lib/archive.ts`) invoking the `set_output_mode` command.
- jobStore `draft.outputMode` (initial `"zip"`) + `setOutputMode` action (no preview recompute).

### OUTPUT card UI
- `OutputModeToggle` — a two-segment control (`role="radiogroup"` with two `role="radio"` buttons + `aria-checked`) bound to the store.
- `OutputSettings` mounts the toggle on the heading row; in `Folder` mode it hides `NamingRuleForm` and shows the extraction note; the hero renders `<dir>/ ▸ <name>/` (folder) vs `<dir>/<name>.zip` (zip), and the zip preview alert is suppressed in folder mode.

### Tests
- wrapper / store action / toggle a11y / OutputSettings folder-vs-zip rendering — vitest 294 green.

## Verification

- Selecting `Folder` removes the `Name` row and shows "Each archive is extracted into its own folder…"; selecting `.zip file` restores it.
- The toggle exposes `role="radiogroup"` with two `role="radio"` buttons and a single `aria-checked="true"`.

## Test plan

- [ ] `pnpm test` / `pnpm lint:ci` / `pnpm fmt:check` / `pnpm knip` / `tsc --noEmit` green.
- [ ] Toggle to `Folder` → `Name` hidden, extraction note shown, hero shows a per-archive folder path.
- [ ] Toggle back to `.zip file` → `Name` shown, hero shows `<dir>/<name>.zip`.
