### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,7 +3616,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.3.0"
+version = "0.4.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Version bump **0.3.0 → 0.4.0** to cut the v0.4.0 release. No code changes — only the four tracked version files plus the matching `Cargo.lock` workspace entries.

v0.4.0 ships the new **Folder (Extract) output mode** landed since v0.3.0 (PRs #104–#107): each archive can be extracted into `Destination/<archive-name>/` instead of being re-zipped, with a per-batch conflict policy (Auto-rename / Skip / Overwrite, default Auto-rename) and mode-aware status/summary wording.

## Changes

- `package.json` → `0.4.0`
- `src-tauri/Cargo.toml` → `0.4.0`
- `crates/core/Cargo.toml` → `0.4.0`
- `src-tauri/tauri.conf.json` → `0.4.0`
- `Cargo.lock` — `simple-archiver` and `simple-archiver-core` entries → `0.4.0`

## Verification

- `cargo metadata --locked` succeeds (lockfile consistent with the bumped manifests).
- `git diff` contains only the six version lines above.

## Test plan

- [ ] CI green: `cargo nextest` / `clippy` / `fmt --check`.
- [ ] CI green: `pnpm test` / `lint:ci` / `fmt:check` / `knip` / `tsc`.
- [ ] After merge: tag `v0.4.0` on `main` and push → `release.yml` builds and attaches the macOS `.dmg` and Windows `.msi` / `.exe`.
