### PR TITLE
feat(naming): support an arbitrary sequence start number

### DIFF
--- a/crates/core/src/domain/archive_job.rs
+++ b/crates/core/src/domain/archive_job.rs
@@ -29,7 +29,7 @@ pub enum PlanError {
     /// [`NameError`]. This is intended.
     #[error("could not resolve a name for item #{seq}: {source}")]
     Resolve {
-        /// The 1-based sequence number of the offending item.
+        /// The sequence number of the offending item (`start + index`).
         seq: u32,
         /// The underlying naming failure.
         source: NameError,
@@ -39,6 +39,18 @@ pub enum PlanError {
     DuplicateName {
         /// The colliding filename.
         name: String,
+    },
+    /// The requested numbering range would exceed `u32::MAX`.
+    ///
+    /// Numbering starts at `start` and runs for `count` items, so the highest
+    /// sequence number is `start + count - 1`. When that would exceed `u32::MAX`
+    /// the job is rejected rather than wrapping or panicking.
+    #[error("numbering from {start} for {count} items exceeds u32::MAX")]
+    SequenceOverflow {
+        /// The requested starting sequence number.
+        start: u32,
+        /// The number of items to number.
+        count: usize,
     },
 }
 
@@ -89,15 +101,22 @@ pub enum TaskOutcome {
 // ArchiveJob
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Convert a 0-based item index to a 1-based `u32` sequence number.
+/// Convert a 0-based item index to a `u32`, asserting it does not truncate.
 ///
 /// Uses `try_from` rather than `as` to make the "no truncation" intent explicit.
 /// Any realistic job fits within `u32::MAX` items — allocating that many items
 /// would exhaust memory first.
-fn seq_index(i: usize) -> u32 {
+fn index_as_u32(i: usize) -> u32 {
     u32::try_from(i)
         .expect("job item count fits in u32; allocating that many items exhausts memory first")
-        + 1
+}
+
+/// Convert a 0-based item index to a 1-based `u32` task id.
+///
+/// `TaskId` is a stable per-task identity that is always 1-based, independent of
+/// the naming start number used to render output filenames.
+fn seq_index(i: usize) -> u32 {
+    index_as_u32(i) + 1
 }
 
 /// The aggregate root coordinating a batch of [`ArchiveTask`]s.
@@ -106,9 +125,11 @@ fn seq_index(i: usize) -> u32 {
 /// their output names, and the [`OutputDirectory`] they will be written to.
 ///
 /// **Position/identity invariant:** the task at position `p` always holds the
-/// name `rule.resolve(p + 1)`. This is established by [`ArchiveJob::plan`] and
-/// preserved by every reorder: names are position-derived and stay with the
-/// position, while each task's id and status travel with the task.
+/// name `rule.resolve(start + p)`, where `start` is the numbering start passed to
+/// [`ArchiveJob::plan_with_start`] (1 for [`ArchiveJob::plan`]). This is
+/// established at plan time and preserved by every reorder: names are
+/// position-derived and stay with the position, while each task's id and status
+/// travel with the task.
 ///
 /// `ArchiveJob` is a value type with full structural equality: it derives both
 /// `PartialEq` and `Eq`.
@@ -122,32 +143,59 @@ pub struct ArchiveJob {
 }
 
 impl ArchiveJob {
-    /// Plan a new job from `items`, deriving each task's output name from `rule`.
+    /// Plan a new job numbering items from 1.
     ///
-    /// Items are numbered 1-based in the order given: item at index `i` gets
-    /// `TaskId(i + 1)`, its output name `rule.resolve(SequenceNumber::new(i + 1))`,
-    /// and starts `Pending`. The `SequenceNumber` is a transient
-    /// argument to name resolution — it is derived from position and is NOT stored
-    /// on the task.
+    /// Equivalent to [`plan_with_start`] with `start = 1`: item at index `i` gets
+    /// `TaskId(i + 1)` and output name `rule.resolve(i + 1)`.
     ///
-    /// Returns [`PlanError::Empty`] when `items` is empty, [`PlanError::Resolve`]
-    /// when the rule cannot produce a valid name for some item, and
-    /// [`PlanError::DuplicateName`] when two items collide (a defensive guard;
-    /// see [`ArchiveJob::check_unique`]).
+    /// [`plan_with_start`]: ArchiveJob::plan_with_start
     pub fn plan(
         items: Vec<SourceItem>,
         rule: NamingRule,
         out_dir: OutputDirectory,
     ) -> Result<Self, PlanError> {
+        Self::plan_with_start(items, rule, out_dir, 1)
+    }
+
+    /// Plan a new job numbering items from `start`, deriving each task's output
+    /// name from `rule`.
+    ///
+    /// Item at index `i` is numbered `start + i` for naming, and keeps the
+    /// 1-based `TaskId(i + 1)` as its stable identity (independent of `start`).
+    /// The `SequenceNumber` is a transient argument to name resolution — it is
+    /// derived from position and is NOT stored on the task. `start` may be `0`.
+    ///
+    /// Returns [`PlanError::Empty`] when `items` is empty,
+    /// [`PlanError::SequenceOverflow`] when the numbering range
+    /// `start ..= start + count - 1` would exceed `u32::MAX`, [`PlanError::Resolve`]
+    /// when the rule cannot produce a valid name for some item, and
+    /// [`PlanError::DuplicateName`] when two items collide (a defensive guard;
+    /// see [`ArchiveJob::check_unique`]).
+    pub fn plan_with_start(
+        items: Vec<SourceItem>,
+        rule: NamingRule,
+        out_dir: OutputDirectory,
+        start: u32,
+    ) -> Result<Self, PlanError> {
         if items.is_empty() {
             return Err(PlanError::Empty);
         }
 
+        // Guard the whole numbering range up front so per-item addition cannot
+        // overflow u32. The highest sequence number is `start + (count - 1)`.
+        let count = items.len();
+        let last_offset = index_as_u32(count - 1);
+        start
+            .checked_add(last_offset)
+            .ok_or(PlanError::SequenceOverflow { start, count })?;
+
         // Resolve a name for every item, propagating the first resolution error.
-        let mut names: Vec<OutputFileName> = Vec::with_capacity(items.len());
-        for i in 0..items.len() {
-            let seq_n = seq_index(i);
-            let seq = SequenceNumber::new(seq_n).expect("seq_n >= 1 because i is 0-based");
+        let mut names: Vec<OutputFileName> = Vec::with_capacity(count);
+        for i in 0..count {
+            // Safe: the range guard above proved `start + last_offset` fits in
+            // u32, and `i <= count - 1`, so this addition cannot overflow.
+            let seq_n = start + index_as_u32(i);
+            let seq = SequenceNumber::new(seq_n);
             let name = rule
                 .resolve(seq)
                 .map_err(|source| PlanError::Resolve { seq: seq_n, source })?;
@@ -155,9 +203,9 @@ impl ArchiveJob {
         }
 
         // Defensive uniqueness guard. Via this path names cannot collide (the
-        // numbers 1..=N are distinct and rendering is injective), but we still
-        // assert it so any future rule change that breaks injectivity surfaces
-        // as an error instead of a silent overwrite.
+        // numbers start..=start+count-1 are distinct and rendering is injective),
+        // but we still assert it so any future rule change that breaks
+        // injectivity surfaces as an error instead of a silent overwrite.
         Self::check_unique(&names)?;
 
         // Build the tasks, pairing each item with its id and resolved name.
@@ -471,6 +519,69 @@ mod tests {
         let job = ArchiveJob::plan(items, rule("file{n}"), out_dir()).unwrap();
         let actual: Vec<&SourceItem> = job.tasks().iter().map(|t| t.source()).collect();
         assert_eq!(actual, expected.iter().collect::<Vec<_>>());
+    }
+
+    // ── plan_with_start ───────────────────────────────────────────────────────
+
+    #[test]
+    fn plan_with_start_numbers_names_from_start_but_keeps_one_based_ids() {
+        let job = ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 5).unwrap();
+        assert_eq!(
+            id_name_pairs(&job),
+            vec![
+                (1, "file5.zip".to_string()),
+                (2, "file6.zip".to_string()),
+                (3, "file7.zip".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_with_start_allows_zero() {
+        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 0).unwrap();
+        assert_eq!(
+            id_name_pairs(&job),
+            vec![
+                (1, "00.zip".to_string()),
+                (2, "01.zip".to_string()),
+                (3, "02.zip".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_with_start_grows_digits_past_the_pad_width() {
+        // printf semantics: {n:02} is a minimum width, so 100 renders as "100".
+        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 99).unwrap();
+        assert_eq!(
+            id_name_pairs(&job),
+            vec![
+                (1, "99.zip".to_string()),
+                (2, "100.zip".to_string()),
+                (3, "101.zip".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_with_start_rejects_u32_overflow() {
+        // Numbering 2 items from u32::MAX would need u32::MAX + 1.
+        let result = ArchiveJob::plan_with_start(sources(2), rule("file{n}"), out_dir(), u32::MAX);
+        assert_eq!(
+            result,
+            Err(PlanError::SequenceOverflow {
+                start: u32::MAX,
+                count: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn plan_numbers_from_one_by_default() {
+        let default = ArchiveJob::plan(sources(3), rule("file{n}"), out_dir()).unwrap();
+        let explicit =
+            ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 1).unwrap();
+        assert_eq!(id_name_pairs(&default), id_name_pairs(&explicit));
     }
 
     // ── plan: empty ───────────────────────────────────────────────────────────

--- a/crates/core/src/domain/naming_rule.rs
+++ b/crates/core/src/domain/naming_rule.rs
@@ -111,7 +111,7 @@ mod tests {
     fn resolve(template: &str, seq: u32) -> Result<String, NameError> {
         NamingRule::parse(template)
             .unwrap()
-            .resolve(SequenceNumber::new(seq).unwrap())
+            .resolve(SequenceNumber::new(seq))
             .map(|name| name.as_str().to_string())
     }
 
@@ -132,6 +132,14 @@ mod tests {
     }
 
     #[test]
+    fn resolve_renders_zero_sequence() {
+        // Start-from-0 numbering: a padded placeholder zero-fills, and a plain
+        // placeholder renders the bare "0".
+        assert_eq!(resolve("{n:02}", 0).unwrap(), "00.zip");
+        assert_eq!(resolve("{n}", 0).unwrap(), "0.zip");
+    }
+
+    #[test]
     fn resolve_appended_placeholder_is_unpadded() {
         assert_eq!(resolve("photo", 3).unwrap(), "photo_3.zip");
     }
@@ -146,7 +154,7 @@ mod tests {
         // The literal trailing space survives resolution and fails FileStem.
         let err = NamingRule::parse("{n} ")
             .unwrap()
-            .resolve(SequenceNumber::new(1).unwrap())
+            .resolve(SequenceNumber::new(1))
             .unwrap_err();
         assert_eq!(err, NameError::TrailingDotOrSpace);
     }

--- a/crates/core/src/domain/sequence_number.rs
+++ b/crates/core/src/domain/sequence_number.rs
@@ -1,28 +1,23 @@
-//! The 1-based sequence number assigned to each output file.
+//! The sequence number assigned to each output file.
+//!
+//! A sequence number renders the `{n}` / `{n:0W}` placeholder in a naming
+//! template. Any `u32` is valid, including `0`, so a batch can number its files
+//! from an arbitrary starting point (see `ArchiveJob::plan_with_start`).
 
-use std::num::NonZeroU32;
-
-/// A 1-based sequence number. Zero is rejected at construction.
+/// A sequence number used to render a naming template. Any `u32` value is valid,
+/// including `0`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SequenceNumber(NonZeroU32);
-
-/// Returned when a sequence number fails its invariant.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
-pub enum SequenceError {
-    /// Sequence numbers are 1-based; zero is not allowed.
-    #[error("sequence number must be 1 or greater")]
-    Zero,
-}
+pub struct SequenceNumber(u32);
 
 impl SequenceNumber {
-    /// Create a sequence number from a raw value; `0` is rejected.
-    pub fn new(value: u32) -> Result<Self, SequenceError> {
-        NonZeroU32::new(value).map(Self).ok_or(SequenceError::Zero)
+    /// Create a sequence number from a raw value. Every `u32` is valid.
+    pub fn new(value: u32) -> Self {
+        Self(value)
     }
 
-    /// The underlying value (always >= 1).
+    /// The underlying value.
     pub fn get(self) -> u32 {
-        self.0.get()
+        self.0
     }
 }
 
@@ -31,17 +26,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn one_is_valid() {
-        assert_eq!(SequenceNumber::new(1).unwrap().get(), 1);
+    fn zero_is_valid() {
+        // Zero is allowed so templates can start numbering from 0 (e.g. "00").
+        assert_eq!(SequenceNumber::new(0).get(), 0);
     }
 
     #[test]
-    fn zero_is_rejected() {
-        assert_eq!(SequenceNumber::new(0), Err(SequenceError::Zero));
+    fn one_is_valid() {
+        assert_eq!(SequenceNumber::new(1).get(), 1);
     }
 
     #[test]
     fn max_u32_is_valid() {
-        assert_eq!(SequenceNumber::new(u32::MAX).unwrap().get(), u32::MAX);
+        assert_eq!(SequenceNumber::new(u32::MAX).get(), u32::MAX);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub fn run() {
             presentation::commands::add_items,
             presentation::commands::reorder,
             presentation::commands::set_naming_rule,
+            presentation::commands::set_start_number,
             presentation::commands::set_output_dir,
             presentation::commands::set_output_mode,
             presentation::commands::set_conflict_policy,

--- a/src-tauri/src/presentation/commands.rs
+++ b/src-tauri/src/presentation/commands.rs
@@ -27,7 +27,8 @@ use crate::presentation::state::{AppState, RunState};
 /// boundary (the promise rejects with this message).
 #[tauri::command]
 pub fn preview_output_name(template: String, seq: u32) -> Result<String, String> {
-    let seq = SequenceNumber::new(seq).map_err(|e| e.to_string())?;
+    // Every u32 sequence number is valid, including 0 (start-from-0 numbering).
+    let seq = SequenceNumber::new(seq);
     let rule = NamingRule::parse(&template).map_err(|e| e.to_string())?;
     let name = rule.resolve(seq).map_err(|e| e.to_string())?;
     Ok(name.as_str().to_string())
@@ -84,6 +85,17 @@ pub fn set_naming_rule(
 ) -> Result<DraftSnapshot, String> {
     let mut draft = state.draft.lock().map_err(|e| e.to_string())?;
     draft.set_template(template)?;
+    Ok(draft.snapshot())
+}
+
+/// Set the draft's sequence start number, returning the new snapshot.
+///
+/// `start` may be `0`. Only Zip mode renders filenames from it; Folder mode
+/// ignores it.
+#[tauri::command]
+pub fn set_start_number(state: State<'_, AppState>, start: u32) -> Result<DraftSnapshot, String> {
+    let mut draft = state.draft.lock().map_err(|e| e.to_string())?;
+    draft.set_start_number(start);
     Ok(draft.snapshot())
 }
 
@@ -255,9 +267,14 @@ mod tests {
     }
 
     #[test]
-    fn preview_rejects_zero_sequence() {
-        let err = preview_output_name("{n}".to_string(), 0).unwrap_err();
-        assert_eq!(err, "sequence number must be 1 or greater");
+    fn preview_renders_zero_sequence() {
+        // Start-from-0 numbering: seq 0 is valid and renders the bare/zero-filled
+        // number rather than being rejected.
+        assert_eq!(preview_output_name("{n}".to_string(), 0).unwrap(), "0.zip");
+        assert_eq!(
+            preview_output_name("{n:02}".to_string(), 0).unwrap(),
+            "00.zip"
+        );
     }
 
     #[test]

--- a/src-tauri/src/presentation/dto.rs
+++ b/src-tauri/src/presentation/dto.rs
@@ -117,6 +117,8 @@ pub struct DraftSnapshot {
     pub items: Vec<DraftItemDto>,
     /// The naming template, if one has been set.
     pub naming_template: Option<String>,
+    /// The sequence start number used to render output filenames (default 1).
+    pub start_number: u32,
     /// The output directory, if one has been chosen.
     pub output_dir: Option<String>,
     /// The chosen output mode (re-zip vs extract-to-folder).
@@ -353,6 +355,7 @@ mod tests {
                 },
             ],
             naming_template: Some("f{n}".to_string()),
+            start_number: 1,
             output_dir: Some("/out".to_string()),
             output_mode: OutputMode::Zip,
             conflict_policy: ConflictPolicy::AutoRename,
@@ -362,8 +365,10 @@ mod tests {
         assert_eq!(v["items"][0]["kind"], json!("folder"));
         assert_eq!(v["items"][1]["kind"], json!("rar"));
         assert_eq!(v["namingTemplate"], json!("f{n}"));
+        assert_eq!(v["startNumber"], json!(1));
         assert_eq!(v["outputDir"], json!("/out"));
         assert!(v.get("naming_template").is_none());
+        assert!(v.get("start_number").is_none());
         assert!(v.get("output_dir").is_none());
     }
 
@@ -372,6 +377,7 @@ mod tests {
         let snapshot = DraftSnapshot {
             items: Vec::new(),
             naming_template: None,
+            start_number: 1,
             output_dir: None,
             output_mode: OutputMode::Zip,
             conflict_policy: ConflictPolicy::AutoRename,
@@ -405,6 +411,7 @@ mod tests {
         let snapshot = DraftSnapshot {
             items: Vec::new(),
             naming_template: None,
+            start_number: 1,
             output_dir: None,
             output_mode: OutputMode::Folder,
             conflict_policy: ConflictPolicy::AutoRename,
@@ -455,11 +462,26 @@ mod tests {
         let snapshot = DraftSnapshot {
             items: Vec::new(),
             naming_template: None,
+            start_number: 1,
             output_dir: None,
             output_mode: OutputMode::Folder,
             conflict_policy: ConflictPolicy::Overwrite,
         };
         let v = serde_json::to_value(&snapshot).unwrap();
         assert_eq!(v["conflictPolicy"], json!("overwrite"));
+    }
+
+    #[test]
+    fn draft_snapshot_includes_start_number() {
+        let snapshot = DraftSnapshot {
+            items: Vec::new(),
+            naming_template: None,
+            start_number: 5,
+            output_dir: None,
+            output_mode: OutputMode::Zip,
+            conflict_policy: ConflictPolicy::AutoRename,
+        };
+        let v = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(v["startNumber"], json!(5));
     }
 }

--- a/src-tauri/src/presentation/state.rs
+++ b/src-tauri/src/presentation/state.rs
@@ -50,10 +50,15 @@ struct ParsedTemplate {
 pub struct JobDraft {
     items: Vec<SourceItem>,
     template: Option<ParsedTemplate>,
+    start_number: u32,
     out_dir: Option<PathBuf>,
     output_mode: OutputMode,
     conflict_policy: ConflictPolicy,
 }
+
+/// The default sequence start when the user has not changed it. Matches the
+/// frontend `DEFAULT_START`, preserving the historical 1-based numbering.
+const DEFAULT_START_NUMBER: u32 = 1;
 
 impl JobDraft {
     /// Create an empty draft with no items, template, or output directory.
@@ -61,6 +66,7 @@ impl JobDraft {
         Self {
             items: Vec::new(),
             template: None,
+            start_number: DEFAULT_START_NUMBER,
             out_dir: None,
             output_mode: OutputMode::default(),         // Zip
             conflict_policy: ConflictPolicy::default(), // AutoRename
@@ -132,11 +138,20 @@ impl JobDraft {
         self.conflict_policy = policy;
     }
 
+    /// Set the sequence start number used to render output filenames.
+    ///
+    /// `0` is allowed (e.g. to number from "00"). Only Zip mode consumes this;
+    /// Folder mode ignores it (extraction folders are named after the source).
+    pub fn set_start_number(&mut self, start: u32) {
+        self.start_number = start;
+    }
+
     /// Return a serialisable snapshot of the current draft for the frontend.
     pub fn snapshot(&self) -> DraftSnapshot {
         DraftSnapshot {
             items: self.items.iter().map(draft_item_from_source).collect(),
             naming_template: self.template.as_ref().map(|t| t.raw.clone()),
+            start_number: self.start_number,
             output_dir: self
                 .out_dir
                 .as_ref()
@@ -152,7 +167,8 @@ impl JobDraft {
     ///
     /// Branches on [`output_mode`]:
     /// - [`OutputMode::Zip`]: requires both a naming template and an output
-    ///   directory, then calls [`ArchiveJob::plan`].
+    ///   directory, then calls [`ArchiveJob::plan_with_start`] with the draft's
+    ///   start number.
     /// - [`OutputMode::Folder`]: requires only an output directory (no template),
     ///   then calls [`ArchiveJob::plan_extract`].
     ///
@@ -173,11 +189,13 @@ impl JobDraft {
                     .as_ref()
                     .ok_or_else(|| "naming rule not set".to_string())?;
                 // Reuse the rule parsed in `set_template`; the template is
-                // never re-parsed here.
-                ArchiveJob::plan(
+                // never re-parsed here. Numbering starts at the draft's
+                // start_number (default 1).
+                ArchiveJob::plan_with_start(
                     self.items.clone(),
                     template.rule.clone(),
                     OutputDirectory::new(out_dir.clone()),
+                    self.start_number,
                 )
                 .map_err(|e| e.to_string())
             }
@@ -445,6 +463,38 @@ mod tests {
             snap.naming_template, None,
             "invalid template must not be stored"
         );
+    }
+
+    // ── set_start_number / snapshot.start_number ─────────────────────────────
+
+    /// A fresh draft numbers from 1 (preserving the historical behavior).
+    #[test]
+    fn default_start_number_is_one() {
+        let snap = JobDraft::new().snapshot();
+        assert_eq!(snap.start_number, 1);
+    }
+
+    /// The start number set on the draft appears in the snapshot.
+    #[test]
+    fn set_start_number_appears_in_snapshot() {
+        let mut draft = JobDraft::new();
+        draft.set_start_number(5);
+        assert_eq!(draft.snapshot().start_number, 5);
+    }
+
+    /// `start = 0` is accepted and flows into the planned job's first filename.
+    #[test]
+    fn set_start_number_zero_builds_and_numbers_from_zero() {
+        let mut draft = JobDraft::new();
+        draft.add_items(vec![SourceItem::RarFile(PathBuf::from("/a.rar"))]);
+        draft
+            .set_template("{n:02}".to_string())
+            .expect("valid template should be accepted");
+        draft.set_out_dir(PathBuf::from("/out"));
+        draft.set_start_number(0);
+
+        let job = draft.build().expect("draft should plan OK with start 0");
+        assert_eq!(job.tasks()[0].output_name().as_str(), "00.zip");
     }
 
     // ── set_out_dir / snapshot.output_dir ────────────────────────────────────

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -168,6 +168,7 @@ describe("App", () => {
       draft: {
         items: [{ path: "/a.rar", kind: "rar" }],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -257,6 +258,7 @@ describe("App", () => {
         draft: {
           items: [],
           namingTemplate: null,
+          startNumber: 1,
           outputDir: "/already/set",
           outputMode: "zip",
           conflictPolicy: "autoRename",
@@ -321,6 +323,7 @@ describe("App", () => {
           draft: {
             items: [],
             namingTemplate: null,
+            startNumber: 1,
             outputDir: "/user/picked",
             outputMode: "zip",
             conflictPolicy: "autoRename",

--- a/src/bindings/DraftSnapshot.ts
+++ b/src/bindings/DraftSnapshot.ts
@@ -16,6 +16,10 @@ export type DraftSnapshot = {
    */
   namingTemplate: string | null;
   /**
+   * The sequence start number used to render output filenames (default 1).
+   */
+  startNumber: number;
+  /**
    * The output directory, if one has been chosen.
    */
   outputDir: string | null;

--- a/src/components/ConflictPolicySelect.test.tsx
+++ b/src/components/ConflictPolicySelect.test.tsx
@@ -32,6 +32,7 @@ it("reflects the store's current policy", () => {
     draft: {
       items: [],
       namingTemplate: null,
+      startNumber: 1,
       outputDir: null,
       outputMode: "folder",
       conflictPolicy: "skip",

--- a/src/components/OutputDirPicker.test.tsx
+++ b/src/components/OutputDirPicker.test.tsx
@@ -30,6 +30,7 @@ describe("OutputDirPicker", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/my/output",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -46,6 +47,7 @@ describe("OutputDirPicker", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -63,6 +65,7 @@ describe("OutputDirPicker", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/my/output",
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/OutputSettings.test.tsx
+++ b/src/components/OutputSettings.test.tsx
@@ -27,9 +27,10 @@ describe("OutputSettings", () => {
     vi.mocked(open).mockReset();
     vi.mocked(previewOutputName).mockReset();
     vi.mocked(previewOutputName).mockResolvedValue("photo_001.zip");
-    // Replace setNamingRule with a spy so NamingRuleForm's debounced store push
-    // does not call the real action (which would invoke the backend).
-    useJobStore.setState({ setNamingRule: vi.fn() });
+    // Replace setNamingRule / setStartNumber with spies so the child forms'
+    // debounced store pushes do not call the real actions (which invoke the
+    // backend).
+    useJobStore.setState({ setNamingRule: vi.fn(), setStartNumber: vi.fn() });
   });
 
   it("hides the Name field and shows the extraction note in Folder mode", () => {
@@ -56,6 +57,27 @@ describe("OutputSettings", () => {
     expect(screen.getByLabelText("Name")).toBeDefined();
   });
 
+  it("shows the Start # field in zip mode", () => {
+    useJobStore.setState((s) => ({
+      draft: { ...s.draft, outputMode: "zip" },
+    }));
+    render(<OutputSettings />);
+    expect(screen.getByLabelText("Start #")).toBeDefined();
+  });
+
+  it("hides the Start # field in Folder mode", () => {
+    useJobStore.setState((s) => ({
+      draft: {
+        ...s.draft,
+        outputMode: "folder",
+        conflictPolicy: "autoRename",
+        outputDir: "/Users/me/Downloads",
+      },
+    }));
+    render(<OutputSettings />);
+    expect(screen.queryByLabelText("Start #")).toBeNull();
+  });
+
   it("renders the OUTPUT group heading and Destination/Name child headings", () => {
     render(<OutputSettings />);
 
@@ -69,6 +91,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -90,6 +113,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -110,6 +134,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -129,6 +154,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -161,6 +187,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [{ path: "/a.rar", kind: "rar" }],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -188,6 +215,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -212,6 +240,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -232,6 +261,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -260,6 +290,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "~/Archives",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -284,6 +315,7 @@ describe("OutputSettings", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/OutputSettings.tsx
+++ b/src/components/OutputSettings.tsx
@@ -4,6 +4,7 @@ import { ConflictPolicySelect } from "@/components/ConflictPolicySelect";
 import { NamingRuleForm } from "@/components/NamingRuleForm";
 import { OutputDirPicker } from "@/components/OutputDirPicker";
 import { OutputModeToggle } from "@/components/OutputModeToggle";
+import { StartNumberForm } from "@/components/StartNumberForm";
 import { joinOutputPath } from "@/lib/path";
 import { selectFirstPreview, useJobStore } from "@/store/jobStore";
 
@@ -110,7 +111,10 @@ export function OutputSettings() {
       <div className="grid grid-cols-[max-content_minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2.5">
         <OutputDirPicker />
         {outputMode === "zip" ? (
-          <NamingRuleForm />
+          <>
+            <NamingRuleForm />
+            <StartNumberForm />
+          </>
         ) : (
           <>
             <p className="col-span-3 text-xs text-muted-foreground">

--- a/src/components/RunControls.test.tsx
+++ b/src/components/RunControls.test.tsx
@@ -38,6 +38,7 @@ describe("RunControls – button visibility", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -56,6 +57,7 @@ describe("RunControls – button visibility", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -76,6 +78,7 @@ describe("RunControls – Run disabled reasons (accessible)", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -96,6 +99,7 @@ describe("RunControls – Run disabled reasons (accessible)", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -117,6 +121,7 @@ describe("RunControls – Run disabled reasons (accessible)", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -140,6 +145,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -161,6 +167,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -182,6 +189,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -204,6 +212,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -225,6 +234,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -249,6 +259,7 @@ describe("RunControls – Run action guard", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -271,6 +282,7 @@ describe("RunControls – ReadinessChip", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -288,6 +300,7 @@ describe("RunControls – ReadinessChip", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -305,6 +318,7 @@ describe("RunControls – ReadinessChip", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -327,6 +341,7 @@ describe("RunControls – ReadinessChip", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -349,6 +364,7 @@ describe("RunControls – overwrite confirmation", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "folder",
         conflictPolicy: "overwrite",
@@ -372,6 +388,7 @@ describe("RunControls – overwrite confirmation", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "folder",
         conflictPolicy: "overwrite",
@@ -396,6 +413,7 @@ describe("RunControls – overwrite confirmation", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "folder",
         conflictPolicy: "overwrite",
@@ -418,6 +436,7 @@ describe("RunControls – overwrite confirmation", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "folder",
         conflictPolicy: "autoRename",
@@ -440,6 +459,7 @@ describe("RunControls – overwrite confirmation", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "overwrite",
@@ -462,6 +482,7 @@ describe("RunControls – Cancel button", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -480,6 +501,7 @@ describe("RunControls – Cancel button", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/RunSummary.test.tsx
+++ b/src/components/RunSummary.test.tsx
@@ -96,6 +96,7 @@ describe("RunSummary", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "folder",
         conflictPolicy: "autoRename",
@@ -111,6 +112,7 @@ describe("RunSummary", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/SetupToolbar.test.tsx
+++ b/src/components/SetupToolbar.test.tsx
@@ -26,6 +26,7 @@ function withItems() {
     draft: {
       items: [ITEM],
       namingTemplate: null,
+      startNumber: 1,
       outputDir: null,
       outputMode: "zip",
       conflictPolicy: "autoRename",
@@ -108,6 +109,7 @@ describe("SetupToolbar", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/StartNumberForm.test.tsx
+++ b/src/components/StartNumberForm.test.tsx
@@ -1,0 +1,121 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { DEBOUNCE_MS, StartNumberForm } from "./StartNumberForm";
+
+describe("StartNumberForm", () => {
+  beforeEach(() => {
+    // Reset store, then replace setStartNumber with a spy so the real action
+    // never calls the backend during these tests.
+    resetJobStore();
+    const setStartNumber = vi.fn();
+    useJobStore.setState({ setStartNumber });
+  });
+
+  it("renders the Start heading and seeds the input with the default start", () => {
+    render(<StartNumberForm />);
+
+    expect(screen.getByText("Start #")).toBeDefined();
+    const input = screen.getByLabelText(/start/i) as HTMLInputElement;
+    expect(input.value).toBe("1");
+  });
+
+  it("seeds the input from a non-default store start", () => {
+    act(() => {
+      useJobStore.setState((s) => ({
+        draft: { ...s.draft, startNumber: 7 },
+      }));
+    });
+
+    render(<StartNumberForm />);
+
+    const input = screen.getByLabelText(/start/i) as HTMLInputElement;
+    expect(input.value).toBe("7");
+  });
+
+  it("syncs the input when the store start changes from outside the form", () => {
+    render(<StartNumberForm />);
+
+    const input = screen.getByLabelText(/start/i) as HTMLInputElement;
+    expect(input.value).toBe("1");
+
+    act(() => {
+      useJobStore.setState((s) => ({
+        draft: { ...s.draft, startNumber: 9 },
+      }));
+    });
+
+    expect(input.value).toBe("9");
+  });
+
+  it("calls setStartNumber with the parsed integer after the debounce delay", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<StartNumberForm />);
+      const input = screen.getByLabelText(/start/i);
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      const setStartNumber = vi.mocked(
+        useJobStore.getState().setStartNumber as ReturnType<typeof vi.fn>,
+      );
+      setStartNumber.mockClear();
+
+      act(() => {
+        fireEvent.change(input, { target: { value: "5" } });
+      });
+      expect(setStartNumber).toHaveBeenCalledTimes(0);
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 10);
+      expect(setStartNumber).toHaveBeenCalledTimes(1);
+      expect(setStartNumber).toHaveBeenCalledWith(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps a negative entry to 0 before pushing", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<StartNumberForm />);
+      const input = screen.getByLabelText(/start/i);
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      const setStartNumber = vi.mocked(
+        useJobStore.getState().setStartNumber as ReturnType<typeof vi.fn>,
+      );
+      setStartNumber.mockClear();
+
+      act(() => {
+        fireEvent.change(input, { target: { value: "-3" } });
+      });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 10);
+      expect(setStartNumber).toHaveBeenCalledWith(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not push a non-integer entry (leaves the stored start unchanged)", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<StartNumberForm />);
+      const input = screen.getByLabelText(/start/i);
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+      const setStartNumber = vi.mocked(
+        useJobStore.getState().setStartNumber as ReturnType<typeof vi.fn>,
+      );
+      setStartNumber.mockClear();
+
+      act(() => {
+        fireEvent.change(input, { target: { value: "1.5" } });
+      });
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 10);
+      expect(setStartNumber).toHaveBeenCalledTimes(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/StartNumberForm.tsx
+++ b/src/components/StartNumberForm.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DEFAULT_START, sanitizeStartNumber } from "@/lib/naming";
+import { useJobStore } from "@/store/jobStore";
+
+// Wait this long after the last keystroke before pushing the start number into
+// the store, so we make one store/IPC round-trip per typing pause rather than
+// one per character.
+export const DEBOUNCE_MS = 200;
+
+/**
+ * The "Start #" control inside the OUTPUT group: a debounced number input that
+ * pushes the sequence start number into the store via setStartNumber. The live
+ * preview reflects the start through OutputSettings' hero path.
+ *
+ * Renders as a fragment of two grid cells so it flattens into the shared OUTPUT
+ * editing grid owned by OutputSettings: a tier-2 "Start #" label cell followed
+ * by the number input in the control column (the action column stays empty).
+ *
+ * The field keeps its own raw text so a partial edit (empty, "-", "1.") is
+ * representable while typing; only a sanitized integer is pushed to the store.
+ */
+export function StartNumberForm() {
+  // Source the initial value from the store so a non-default draft start (future
+  // session restore, or a seeded test) shows the correct value rather than the
+  // compile-time default.
+  const storedStart = useJobStore((s) => s.draft.startNumber);
+  const [startText, setStartText] = useState(
+    String(storedStart ?? DEFAULT_START),
+  );
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const parsed = sanitizeStartNumber(startText);
+      // null = not a usable integer yet (mid-edit); leave the stored value as is.
+      if (parsed !== null) {
+        useJobStore.getState().setStartNumber(parsed);
+      }
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [startText]);
+
+  // Sync the field when the store start changes from OUTSIDE this form (e.g.
+  // session restore). Depend only on `storedStart` so this reacts to external
+  // store changes, not to local keystrokes (which already drive the debounce
+  // push above). The functional updater compares the field's sanitized value to
+  // the stored one, so when our own debounce pushes the value back this is a
+  // no-op and starts no update cycle.
+  useEffect(() => {
+    setStartText((current) =>
+      sanitizeStartNumber(current) === storedStart
+        ? current
+        : String(storedStart),
+    );
+  }, [storedStart]);
+
+  return (
+    <>
+      <Label
+        htmlFor="start-number"
+        className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground"
+      >
+        Start #
+      </Label>
+      <Input
+        id="start-number"
+        type="number"
+        min={0}
+        step={1}
+        value={startText}
+        onChange={(event) => setStartText(event.target.value)}
+      />
+    </>
+  );
+}

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -25,6 +25,7 @@ describe("StatusBar", () => {
           { path: "/b", kind: "folder" },
         ],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -39,6 +40,7 @@ describe("StatusBar", () => {
       draft: {
         items: [{ path: "/a.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -69,6 +71,7 @@ describe("StatusBar", () => {
       draft: {
         items: [ITEM, ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "folder",
         conflictPolicy: "autoRename",
@@ -90,6 +93,7 @@ describe("StatusBar", () => {
       draft: {
         items: [ITEM, ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -144,6 +148,7 @@ describe("StatusBar Reset slot – visibility", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -160,6 +165,7 @@ describe("StatusBar Reset slot – visibility", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -178,6 +184,7 @@ describe("StatusBar Reset slot – visibility", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -202,6 +209,7 @@ describe("StatusBar Reset slot – label", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -218,6 +226,7 @@ describe("StatusBar Reset slot – label", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -246,6 +255,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -266,6 +276,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -289,6 +300,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -314,6 +326,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -339,6 +352,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -364,6 +378,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -390,6 +405,7 @@ describe("StatusBar Reset slot – confirm dialog", () => {
       draft: {
         items: [ITEM],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -35,6 +35,7 @@ describe("TaskList rendering", () => {
           { path: "/tmp/photos", kind: "folder" },
         ],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -69,6 +70,7 @@ describe("TaskList rendering", () => {
       draft: {
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -88,6 +90,7 @@ describe("TaskList rendering", () => {
       draft: {
         items: [{ path: "/tmp/test.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -116,6 +119,7 @@ describe("TaskList reorder buttons", () => {
       draft: {
         items: makeItems(3),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -151,6 +155,7 @@ describe("TaskList reorder buttons", () => {
       draft: {
         items: makeItems(3),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -174,6 +179,7 @@ describe("TaskList reorder buttons", () => {
       draft: {
         items: makeItems(3),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -202,6 +208,7 @@ describe("TaskList status", () => {
       draft: {
         items: makeItems(2),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -222,6 +229,7 @@ describe("TaskList status", () => {
       draft: {
         items: makeItems(2),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -253,6 +261,7 @@ describe("TaskList status", () => {
       draft: {
         items: makeItems(2),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -278,6 +287,7 @@ describe("TaskList status", () => {
       draft: {
         items: makeItems(3),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -305,6 +315,7 @@ describe("TaskList status", () => {
       draft: {
         items: makeItems(1),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -336,6 +347,7 @@ describe("TaskList progress", () => {
       draft: {
         items: [{ path: "/tmp/a.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -361,6 +373,7 @@ describe("TaskList progress", () => {
       draft: {
         items: [{ path: "/tmp/a.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -381,6 +394,7 @@ describe("TaskList progress", () => {
       draft: {
         items: makeItems(3),
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -411,6 +425,7 @@ describe("TaskList progress", () => {
       draft: {
         items: [{ path: "/tmp/a.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/components/TaskRow.test.tsx
+++ b/src/components/TaskRow.test.tsx
@@ -23,6 +23,7 @@ describe("TaskRow", () => {
       draft: {
         items: [{ path: "/home/user/archive.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -41,6 +42,7 @@ describe("TaskRow", () => {
       draft: {
         items: [{ path: "/home/user/archive.zip", kind: "zip" as const }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -61,6 +63,7 @@ describe("TaskRow", () => {
       draft: {
         items: [{ path: "/a.rar", kind: "rar" }],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",

--- a/src/lib/archive.test.ts
+++ b/src/lib/archive.test.ts
@@ -21,6 +21,7 @@ import {
   setNamingRule,
   setOutputDir,
   setOutputMode,
+  setStartNumber,
   subscribeProgress,
 } from "./archive";
 
@@ -35,6 +36,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
       });
       await addItems(["/a", "/b"]);
@@ -56,6 +58,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
       });
       await reorder(0, 1);
@@ -71,6 +74,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: "img_{n}",
+        startNumber: 1,
         outputDir: null,
       });
       await setNamingRule("img_{n}");
@@ -80,11 +84,27 @@ describe("archive client", () => {
     });
   });
 
+  describe("setStartNumber", () => {
+    it("invokes set_start_number with the start value", async () => {
+      vi.mocked(invoke).mockResolvedValue({
+        items: [],
+        namingTemplate: null,
+        startNumber: 5,
+        outputDir: null,
+      });
+      await setStartNumber(5);
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith("set_start_number", {
+        start: 5,
+      });
+    });
+  });
+
   describe("setOutputDir", () => {
     it("invokes set_output_dir with the dir string", async () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: "/out",
       });
       await setOutputDir("/out");
@@ -99,6 +119,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "folder",
       });
@@ -115,6 +136,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: null,
+        startNumber: 1,
         outputDir: null,
         outputMode: "folder",
         conflictPolicy: "overwrite",
@@ -176,6 +198,7 @@ describe("archive client", () => {
       vi.mocked(invoke).mockResolvedValue({
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "/out",
       });
       await clearItems();
@@ -186,6 +209,7 @@ describe("archive client", () => {
       const snapshot = {
         items: [],
         namingTemplate: "photo_{n:03}",
+        startNumber: 1,
         outputDir: "/out",
       };
       vi.mocked(invoke).mockResolvedValue(snapshot);

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -35,6 +35,14 @@ export function setNamingRule(template: string): Promise<DraftSnapshot> {
 }
 
 /**
+ * Set the sequence start number used to render output filenames. May be 0.
+ * Returns the updated draft snapshot.
+ */
+export function setStartNumber(start: number): Promise<DraftSnapshot> {
+  return invoke<DraftSnapshot>("set_start_number", { start });
+}
+
+/**
  * Set the output directory where archives will be written.
  * Returns the updated draft snapshot.
  */
@@ -71,9 +79,9 @@ export function clearItems(): Promise<DraftSnapshot> {
 }
 
 /**
- * Resolve the preview output filename for a 1-based sequence number using the
- * given naming template. The backend is the single source of truth for naming.
- * Rejects if the template or sequence is invalid.
+ * Resolve the preview output filename for a sequence number using the given
+ * naming template. Any `u32` sequence is valid, including 0. The backend is the
+ * single source of truth for naming. Rejects if the template is invalid.
  */
 export function previewOutputName(
   template: string,

--- a/src/lib/naming.test.ts
+++ b/src/lib/naming.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_START, MAX_START, sanitizeStartNumber } from "./naming";
+
+describe("sanitizeStartNumber", () => {
+  it("accepts non-negative integers verbatim", () => {
+    expect(sanitizeStartNumber("0")).toBe(0);
+    expect(sanitizeStartNumber("5")).toBe(5);
+    expect(sanitizeStartNumber("  42  ")).toBe(42);
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(sanitizeStartNumber("-1")).toBe(0);
+    expect(sanitizeStartNumber("-100")).toBe(0);
+  });
+
+  it("clamps values above u32::MAX to MAX_START", () => {
+    expect(sanitizeStartNumber(String(MAX_START + 1))).toBe(MAX_START);
+    expect(sanitizeStartNumber("999999999999")).toBe(MAX_START);
+  });
+
+  it("rejects empty / non-integer / non-numeric input as null", () => {
+    expect(sanitizeStartNumber("")).toBeNull();
+    expect(sanitizeStartNumber("   ")).toBeNull();
+    expect(sanitizeStartNumber("1.5")).toBeNull();
+    expect(sanitizeStartNumber("abc")).toBeNull();
+    expect(sanitizeStartNumber("1e")).toBeNull();
+  });
+
+  it("exposes a default of 1", () => {
+    expect(DEFAULT_START).toBe(1);
+  });
+});

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -5,3 +5,30 @@
  * template without a presentation -> store import cycle.
  */
 export const DEFAULT_TEMPLATE = "photo_{n:03}";
+
+/**
+ * The default sequence start number. 1 preserves the historical numbering, so
+ * existing templates render 1, 2, 3, ... unless the user changes the start.
+ * Must match the backend `JobDraft` default.
+ */
+export const DEFAULT_START = 1;
+
+/** The largest valid start number — the backend numbers with a `u32`. */
+export const MAX_START = 4_294_967_295; // u32::MAX
+
+/**
+ * Parse a start-number input string into a valid start value, or `null` when the
+ * input is not a usable integer (empty / non-numeric / fractional). Negative
+ * values clamp to 0; values above `MAX_START` clamp to the maximum. Callers treat
+ * `null` as "leave the stored value unchanged" so partial edits never push an
+ * invalid start to the backend.
+ */
+export function sanitizeStartNumber(text: string): number | null {
+  const trimmed = text.trim();
+  if (trimmed === "") return null;
+  const value = Number(trimmed);
+  if (!Number.isInteger(value)) return null;
+  if (value < 0) return 0;
+  if (value > MAX_START) return MAX_START;
+  return value;
+}

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/archive", () => ({
   addItems: vi.fn(),
   reorder: vi.fn(),
   setNamingRule: vi.fn(),
+  setStartNumber: vi.fn(),
   setOutputDir: vi.fn(),
   setOutputMode: vi.fn(),
   setConflictPolicy: vi.fn(),
@@ -39,6 +40,7 @@ function makeDraft(
   itemCount: number,
   namingTemplate: string | null = null,
   outputDir: string | null = null,
+  startNumber: number = 1,
 ): DraftSnapshot {
   return {
     items: Array.from({ length: itemCount }, (_, i) => ({
@@ -46,6 +48,7 @@ function makeDraft(
       kind: "rar" as const,
     })),
     namingTemplate,
+    startNumber,
     outputDir,
     outputMode: "zip",
     conflictPolicy: "autoRename",
@@ -55,6 +58,7 @@ function makeDraft(
 const INITIAL_DRAFT: DraftSnapshot = {
   items: [],
   namingTemplate: null,
+  startNumber: 1,
   outputDir: null,
   outputMode: "zip",
   conflictPolicy: "autoRename",
@@ -244,6 +248,48 @@ describe("setNamingRule", () => {
   });
 });
 
+describe("setStartNumber", () => {
+  it("recomputes previews numbering the hero and items from the new start", async () => {
+    const draft = makeDraft(3, "photo_{n:03}", null, 5);
+    mockArchive.setStartNumber.mockResolvedValue(draft);
+    mockArchive.previewOutputName.mockImplementation((_template, seq) =>
+      Promise.resolve(`photo_${String(seq).padStart(3, "0")}.zip`),
+    );
+
+    await useJobStore.getState().setStartNumber(5);
+
+    expect(mockArchive.setStartNumber).toHaveBeenCalledWith(5);
+    // Hero uses start (5); the three items use start + i = 5, 6, 7.
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
+      "photo_{n:03}",
+      5,
+    );
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
+      "photo_{n:03}",
+      6,
+    );
+    expect(mockArchive.previewOutputName).toHaveBeenCalledWith(
+      "photo_{n:03}",
+      7,
+    );
+    expect(useJobStore.getState().previewNames).toEqual([
+      "photo_005.zip",
+      "photo_006.zip",
+      "photo_007.zip",
+    ]);
+    expect(useJobStore.getState().firstPreview).toBe("photo_005.zip");
+  });
+
+  it("sets error and leaves the draft unchanged on failure", async () => {
+    mockArchive.setStartNumber.mockRejectedValue("boom");
+
+    await useJobStore.getState().setStartNumber(3);
+
+    expect(useJobStore.getState().error).toBe("boom");
+    expect(useJobStore.getState().draft).toEqual(INITIAL_DRAFT);
+  });
+});
+
 describe("setOutputDir", () => {
   it("updates the draft outputDir without recomputing previews", async () => {
     const draft = makeDraft(2, "photo_{n}", "/out");
@@ -317,6 +363,7 @@ describe("setOutputMode", () => {
     const spy = vi.spyOn(archive, "setOutputMode").mockResolvedValue({
       items: [],
       namingTemplate: null,
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "folder",
       conflictPolicy: "autoRename",
@@ -334,6 +381,7 @@ describe("setConflictPolicy", () => {
     const spy = vi.spyOn(archive, "setConflictPolicy").mockResolvedValue({
       items: [],
       namingTemplate: null,
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "folder",
       conflictPolicy: "overwrite",
@@ -375,6 +423,7 @@ describe("recomputePreviews", () => {
       draft: {
         items: [],
         namingTemplate: "photo_{n}",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -411,6 +460,7 @@ describe("recomputePreviews", () => {
       draft: {
         items: makeDraft(1).items,
         namingTemplate: "a",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -425,6 +475,7 @@ describe("recomputePreviews", () => {
       draft: {
         items: makeDraft(1).items,
         namingTemplate: "b",
+        startNumber: 1,
         outputDir: null,
         outputMode: "zip",
         conflictPolicy: "autoRename",
@@ -578,6 +629,7 @@ describe("reset", () => {
     const clearedDraft: DraftSnapshot = {
       items: [],
       namingTemplate: "photo_{n}",
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "zip",
       conflictPolicy: "autoRename",
@@ -598,6 +650,7 @@ describe("reset", () => {
     const clearedDraft: DraftSnapshot = {
       items: [],
       namingTemplate: "photo_{n}",
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "zip",
       conflictPolicy: "autoRename",
@@ -639,6 +692,7 @@ describe("reset", () => {
     const clearedDraft: DraftSnapshot = {
       items: [],
       namingTemplate: "photo_{n}",
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "zip",
       conflictPolicy: "autoRename",
@@ -681,6 +735,7 @@ describe("reset", () => {
     const clearedDraft: DraftSnapshot = {
       items: [],
       namingTemplate: "photo_{n}",
+      startNumber: 1,
       outputDir: "/out",
       outputMode: "zip",
       conflictPolicy: "autoRename",

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -9,7 +9,7 @@ import type { ProgressEvent } from "@/bindings/ProgressEvent";
 // which share names (addItems, reorder, setNamingRule, ...).
 import * as archive from "@/lib/archive";
 import { messageFromReason } from "@/lib/errors";
-import { DEFAULT_TEMPLATE } from "@/lib/naming";
+import { DEFAULT_START, DEFAULT_TEMPLATE } from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
 
 // Monotonic counter tagging each recomputePreviews run. A run only commits its
@@ -82,6 +82,8 @@ export interface JobState {
   reorder: (from: number, to: number) => Promise<void>;
   /** Set the naming template, then recompute previews. */
   setNamingRule: (template: string) => Promise<void>;
+  /** Set the sequence start number (may be 0), then recompute previews. */
+  setStartNumber: (start: number) => Promise<void>;
   /** Set the output directory (does not affect preview filenames). */
   setOutputDir: (dir: string) => Promise<void>;
   /** Set the output mode (re-zip vs extract-to-folder); stores the returned draft. */
@@ -113,6 +115,7 @@ export const useJobStore = create<JobState>()((set, get) => ({
   draft: {
     items: [],
     namingTemplate: null,
+    startNumber: DEFAULT_START,
     outputDir: null,
     outputMode: "zip",
     conflictPolicy: "autoRename",
@@ -149,6 +152,18 @@ export const useJobStore = create<JobState>()((set, get) => ({
   setNamingRule: async (template) => {
     try {
       const draft = await archive.setNamingRule(template);
+      set({ draft, error: null });
+      await get().recomputePreviews();
+    } catch (reason) {
+      set({ error: messageFromReason(reason) });
+    }
+  },
+
+  setStartNumber: async (start) => {
+    try {
+      // The start number shifts every per-item number and the hero preview, so
+      // recompute previews after the backend stores it.
+      const draft = await archive.setStartNumber(start);
       set({ draft, error: null });
       await get().recomputePreviews();
     } catch (reason) {
@@ -234,6 +249,9 @@ export const useJobStore = create<JobState>()((set, get) => ({
     const generation = ++previewGeneration;
     const { draft } = get();
     const template = draft.namingTemplate;
+    // Numbering starts at the draft's start number: the hero shows `start` and
+    // per-item previews show `start + i`, mirroring the backend's plan_with_start.
+    const start = draft.startNumber;
     // The hero always shows a representative filename: fall back to the shared
     // default before NamingRuleForm has pushed a template, so the OUTPUT group
     // is meaningful on first paint even with an empty queue.
@@ -242,17 +260,16 @@ export const useJobStore = create<JobState>()((set, get) => ({
     // while the recompute is in flight, mirroring the old component-local guard.
     set({ firstPreview: null });
     try {
-      // Sequence numbers are 1-based, matching the backend's naming contract.
-      // The hero preview uses sequence 1; per-item previews use i + 1.
+      // The hero preview uses `start`; per-item previews use `start + i`.
       const [heroName, names] = await Promise.all([
-        archive.previewOutputName(heroTemplate, 1),
+        archive.previewOutputName(heroTemplate, start),
         // previewNames stays index-aligned with draft.items and empty for a null
         // template (no items, or no template => no per-item names).
         template === null
           ? Promise.resolve<string[]>([])
           : Promise.all(
               draft.items.map((_item, i) =>
-                archive.previewOutputName(template, i + 1),
+                archive.previewOutputName(template, start + i),
               ),
             ),
       ]);


### PR DESCRIPTION
## Summary

The naming sequence was hardcoded to begin at 1, so a batch could not be numbered from an arbitrary value. This threads a per-batch start number end to end (domain → IPC → UI), defaulting to 1 so existing output is unchanged, and adds a "Start #" control to the OUTPUT group — e.g. numbering `イクサガミ{n:02}` from `05`.

## Background / Motivation

- The template grammar only had `{n}` / `{n:0W}`, and `ArchiveJob` numbered items via `seq_index(i) = i + 1`, so numbering always began at 1 — no way to archive, say, the 5th+ volumes of a series as `イクサガミ05, イクサガミ06, …`.
- `SequenceNumber` was a `NonZeroU32` (0 rejected) and `preview_output_name` rejected seq 0, so 0-based numbering (`00`) was impossible.
- The OUTPUT group exposed only the Name template; there was no control for a start value.

## Changes

### Domain: numbering from a start

- `SequenceNumber` is now a plain `u32` newtype (0 is valid); the `NonZeroU32` invariant and `SequenceError` are removed.
- New `ArchiveJob::plan_with_start(items, rule, out_dir, start)`; `plan` delegates with `start = 1`, so every existing call site is unchanged. Item `i` is numbered `start + i`; `TaskId` stays the 1-based stable identity, independent of `start`.
- New `PlanError::SequenceOverflow { start, count }` guards `start + count - 1 > u32::MAX` (no wrap/panic). Pad-width overflow keeps printf semantics (`{n:02}` at 100 renders `"100"`).

### IPC + bindings

- `DraftSnapshot` gains `start_number: u32` (ts-rs regenerates `startNumber` in `src/bindings/DraftSnapshot.ts`); `JobDraft` stores it (default 1) and `build` calls `plan_with_start`.
- New `set_start_number` Tauri command (registered in `lib.rs`); `preview_output_name` now accepts seq 0.

### Frontend: Start # control

- New `src/components/StartNumberForm.tsx` — a debounced `type="number"` input rendered after `NamingRuleForm` in `OutputSettings` (zip mode only; hidden in folder mode). Negative input clamps to 0; non-integers are ignored (the stored value is left unchanged).
- `lib/naming.ts` adds `DEFAULT_START` / `MAX_START` / `sanitizeStartNumber`; `lib/archive.ts` adds `setStartNumber`.
- `jobStore` adds the `setStartNumber` action and numbers the hero preview at `start` and per-item previews at `start + i`.

### Tests

- Domain: numbering from 5 and from 0, pad-width digit growth (99 → 100 → 101), `SequenceOverflow`, and seq-0 rendering (`{n:02}` → `00`).
- IPC: snapshot carries `startNumber`, `set_start_number`, and `preview_output_name` renders seq 0.
- Frontend: `sanitizeStartNumber`, `StartNumberForm` (seed / external sync / debounce / clamp / reject), store `setStartNumber` previews, OUTPUT shows/hides `Start #` by mode, and the `setStartNumber` IPC wrapper.

## Verification

- In zip mode the OUTPUT group shows a `Start #` number input (label `Start #`, `input#start-number`). Set it to `5` with template `イクサガミ{n:02}` and the hero preview reads `イクサガミ05.zip`. Switch to folder mode and the field disappears.
- `rg "plan_with_start" crates/core` shows the new domain entry point; `rg "set_start_number" src-tauri src` shows the command + IPC wrapper.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (no issues)
- [x] `cargo nextest run` (320 passed)
- [x] `pnpm run test` (327 passed)
- [x] `pnpm run fmt:check` / `pnpm run lint:ci` / `pnpm run knip`
- [x] `pnpm run build` (tsc + vite)
