### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,7 +3616,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.4.0"
+version = "0.5.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Bump version `0.4.0` → `0.5.0` for the v0.5.0 release.

This release ships the **sequence start number ("Start #")** feature (#109): the
naming sequence can now begin at any value instead of always 1, defaulting to `1`
so existing output is unchanged.

## Changes

- Bump the version string in `package.json`, `src-tauri/Cargo.toml`,
  `crates/core/Cargo.toml`, `src-tauri/tauri.conf.json`, and both `Cargo.lock`
  entries (`simple-archiver`, `simple-archiver-core`).

## Verification

- `cargo metadata --locked` — exit 0 (lockfile consistent with the bumped manifests)
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo nextest run` — **320 passed, 0 skipped**
- `pnpm fmt:check`, `pnpm lint:ci`, `pnpm test` (**327 passed**), `pnpm build`,
  `pnpm knip` — all green
