### PR TITLE
fix(ui): keep live progress text fixed-width to stop per-tick jitter

### DIFF
--- a/src/components/OverallProgress.tsx
+++ b/src/components/OverallProgress.tsx
@@ -16,13 +16,15 @@ export function OverallProgress() {
     progress.overall.bytesTotal,
   );
 
+  // Right-pad percent to width 3 and render monospace/pre so the line keeps a
+  // constant width as percent grows 0 → 100 and does not shift horizontally.
+  const etaLabel = `${String(percent).padStart(3)}% · ETA ${formatEta(progress.overallEtaMs)}`;
+
   return (
     <section aria-label="Overall progress" className="flex flex-col gap-1">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span className="font-medium uppercase tracking-wide">Overall</span>
-        <span>
-          {percent}% · ETA {formatEta(progress.overallEtaMs)}
-        </span>
+        <span className="font-mono whitespace-pre">{etaLabel}</span>
       </div>
       <Progress value={percent} />
     </section>

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -447,6 +447,6 @@ describe("TaskList progress", () => {
       },
     });
     render(<TaskList />);
-    expect(screen.getByText(/12\.4 \/ 19 MB/)).toBeTruthy();
+    expect(screen.getByText(/12\.4 \/ 19\.0 MB/)).toBeTruthy();
   });
 });

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -89,6 +89,10 @@ function TaskRowImpl({ index }: TaskRowProps) {
 
   if (!row.exists) return null;
 
+  // Build the live label as one string so JSX whitespace folding / prettier
+  // reflow cannot strip the right-align padding spaces formatBytes emits.
+  const liveLabel = `${formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} · ETA ${formatEta(row.liveEtaMs)}`;
+
   return (
     <tr className="border-b border-border/50 hover:bg-muted/30 transition-colors">
       {/* Sequence number */}
@@ -124,9 +128,11 @@ function TaskRowImpl({ index }: TaskRowProps) {
                 row.liveBytesTotal ?? 0,
               )}
             />
-            <span className="text-xs">
-              {formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} ·
-              ETA {formatEta(row.liveEtaMs)}
+            {/* Monospace + whitespace-pre give every glyph (including the
+                right-align padding spaces from formatBytes) a constant width,
+                so the line does not jitter per tick as done grows. */}
+            <span className="text-xs font-mono whitespace-pre">
+              {liveLabel}
             </span>
           </div>
         ) : (

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -37,20 +37,29 @@ describe("progressPercent", () => {
 });
 
 describe("formatBytes", () => {
-  it("renders both numbers on the unit of the total", () => {
-    // 12.4 MB done of 19 MB total (1 MB = 1024*1024).
-    expect(formatBytes(13_002_342, 19_922_944)).toBe("12.4 / 19 MB");
+  it("renders both numbers on the unit of the total with one decimal", () => {
+    // 12.4 MB done of 19 MB total (1 MB = 1024*1024); a whole total still
+    // keeps one decimal so done and total share the same shape.
+    expect(formatBytes(13_002_342, 19_922_944)).toBe("12.4 / 19.0 MB");
   });
-  it("uses whole numbers for bytes (no decimals under 1 KB)", () => {
-    expect(formatBytes(512, 1000)).toBe("512 / 1000 B");
+  it("uses whole numbers for bytes and right-aligns done to total width", () => {
+    expect(formatBytes(512, 1000)).toBe(" 512 / 1000 B");
   });
-  it("scales to KB", () => {
-    expect(formatBytes(512, 2048)).toBe("0.5 / 2 KB");
+  it("scales to KB with one decimal on both numbers", () => {
+    expect(formatBytes(512, 2048)).toBe("0.5 / 2.0 KB");
   });
   it("handles a zero total without dividing by zero", () => {
     expect(formatBytes(0, 0)).toBe("0 / 0 B");
   });
   it("clamps negative inputs to zero", () => {
     expect(formatBytes(-5, -10)).toBe("0 / 0 B");
+  });
+  it("keeps the rendered width constant as done grows for a fixed total", () => {
+    const total = 145 * 1024 * 1024;
+    expect(formatBytes(5 * 1024 * 1024, total)).toBe("  5.0 / 145.0 MB");
+    expect(formatBytes(123 * 1024 * 1024, total)).toBe("123.0 / 145.0 MB");
+    expect(formatBytes(5 * 1024 * 1024, total)).toHaveLength(
+      formatBytes(123 * 1024 * 1024, total).length,
+    );
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -27,9 +27,13 @@ const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
 
 /**
  * Format a byte pair as "<done> / <total> <unit>", choosing the unit from the
- * total so both numbers share one scale (e.g. "12.4 / 19 MB"). Bytes render as
- * whole numbers; larger units keep one decimal. Pure formatting only — the
- * backend owns all progress truth.
+ * total so both numbers share one scale (e.g. "12.4 / 19.0 MB"). Bytes render
+ * as whole numbers; larger units ALWAYS keep exactly one decimal (so a whole
+ * "19" MB renders "19.0"), giving done and total the same shape. `done` is then
+ * right-aligned to the width of `total` with leading spaces, so for a fixed
+ * total the returned string keeps a constant width as `done` grows — the live
+ * progress label never jitters tick to tick. Pure formatting only — the backend
+ * owns all progress truth.
  */
 export function formatBytes(done: number, total: number): string {
   // Byte counts are non-negative by construction; clamp defensively so this
@@ -46,9 +50,12 @@ export function formatBytes(done: number, total: number): string {
   }
   const render = (n: number) => {
     const scaled = n / 1024 ** unitIndex;
-    return unitIndex === 0
-      ? String(Math.round(scaled))
-      : (Math.round(scaled * 10) / 10).toString();
+    return unitIndex === 0 ? String(Math.round(scaled)) : scaled.toFixed(1);
   };
-  return `${render(done)} / ${render(total)} ${BYTE_UNITS[unitIndex]}`;
+  const doneStr = render(done);
+  const totalStr = render(total);
+  // Right-align done to the total's width; total is always the widest possible
+  // value for this unit, so done never overflows and the column stays fixed.
+  const paddedDone = doneStr.padStart(totalStr.length);
+  return `${paddedDone} / ${totalStr} ${BYTE_UNITS[unitIndex]}`;
 }

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -79,7 +79,7 @@ describe("computeStatus", () => {
     const progress = progressWith([
       { taskId: 10, bytesDone: 512, bytesTotal: 2048, etaMs: null },
     ]);
-    expect(computeStatus(0, true, progress, null, [10])).toBe("0.5 / 2 KB");
+    expect(computeStatus(0, true, progress, null, [10])).toBe("0.5 / 2.0 KB");
   });
 
   it("returns 'Processing' while running before this row's per-task entry arrives", () => {


### PR DESCRIPTION
## Summary

While a run is in flight, each queue row's live progress text (`done / total <unit> · ETA`) jittered left/right on every progress tick. This pins it to a constant width: `formatBytes` right-aligns `done` to the total's width with a unified one-decimal shape, and the labels render monospace + `whitespace-pre`, so the `/ total · ETA` portion stays put as the numbers grow. The overall progress percent/ETA line gets the same treatment.

## Background / Motivation

- `formatBytes` rendered `done` and `total` raw, and for larger units it dropped a trailing `.0` (a whole `19` MB became `"19"`), so `done` (`"12.4"`) and `total` had mismatched shapes. As `done` climbed `5 → 52 → 123` during a run, the `/ total · ETA` tail shifted right tick by tick.
- The `text-xs` label used a proportional font, so even at a fixed digit count the glyph widths differed, adding fine horizontal wobble.
- `OverallProgress` had the same problem: `{percent}% · ETA` widened as percent went `0 → 100`, nudging the right-aligned line sideways.

## Changes

### Fixed-width byte formatting (`formatBytes`)

- Larger units now always show exactly one decimal (`scaled.toFixed(1)`, so a whole `19` MB renders `"19.0"`), giving `done` and `total` the same shape.
- `done` is `padStart`-ed to the width of `total`; `total` is the widest possible value for that unit, so `done` never overflows and, for a fixed total, the returned string keeps a constant width as `done` grows.
- The `0 / 0` and negative-clamp paths still return `"0 / 0 B"`; unit-selection logic is unchanged.

### Monospace, jitter-proof labels

- `TaskRow`: the live label is built as one `liveLabel` string and rendered in a `text-xs font-mono whitespace-pre` span — equal-width glyphs plus preserved padding spaces keep the line fixed-width per tick (`done` right-aligns and grows leftward instead of pushing the tail).
- `OverallProgress`: percent is `padStart`-ed to width 3 and rendered in a `font-mono whitespace-pre` span.

### Tests

- `format.test.ts`: updated expectations for the new shape (`"12.4 / 19.0 MB"`, `" 512 / 1000 B"`, `"0.5 / 2.0 KB"`) plus a width-stability case asserting the string length is constant as `done` grows for a fixed total.
- `status.test.ts` / `TaskList.test.tsx`: bumped the two literals that hardcoded the old `formatBytes` output to the new shape.

## Verification

- During a run, in each queue row's `done / total <unit> · ETA`, the `/`, total, `·` and `ETA` no longer move as `done` increases (`done` is right-aligned and grows leftward).
- DOM: the under-bar text span carries `font-mono whitespace-pre` — `rg "whitespace-pre" src/components/TaskRow.tsx src/components/OverallProgress.tsx` hits both spots.
- `formatBytes` unit: for a fixed total, varying `done` leaves `.length` unchanged.

## Test plan

- [x] `pnpm test` (320 passed, 35 files)
- [x] `pnpm lint:ci` (oxlint --deny-warnings)
- [x] `pnpm fmt:check` (oxfmt --check)
- [x] `pnpm build` (tsc + vite)
