### PR TITLE
feat(ui): Clear button + last-batch chip + start-number auto-continue (PR4)

### DIFF
--- a/src/components/LastBatchChip.test.tsx
+++ b/src/components/LastBatchChip.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
+import { openPath } from "@/lib/reveal";
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { LastBatchChip } from "./LastBatchChip";
+
+// The store imports the archive lib at load time; mock it so nothing reaches
+// the real Tauri backend during render/interaction.
+vi.mock("@/lib/archive", () => ({
+  addItems: vi.fn(),
+  reorder: vi.fn(),
+  setNamingRule: vi.fn(),
+  setStartNumber: vi.fn(),
+  setOutputDir: vi.fn(),
+  runJob: vi.fn(),
+  cancelJob: vi.fn(),
+  clearItems: vi.fn(),
+  previewOutputName: vi.fn(),
+  subscribeProgress: vi.fn(),
+}));
+
+// Mock the opener wrapper so the chip's Open action never reaches Tauri.
+vi.mock("@/lib/reveal", () => ({
+  openPath: vi.fn(),
+  revealItem: vi.fn(),
+  copyText: vi.fn(),
+}));
+
+const SUMMARY: JobSummaryDto = {
+  succeeded: [1, 2, 3],
+  cancelled: [],
+  failed: [],
+  results: [],
+};
+
+beforeEach(() => {
+  resetJobStore();
+  vi.mocked(openPath).mockReset();
+});
+
+describe("LastBatchChip", () => {
+  it("renders nothing when there is no residual last batch", () => {
+    const { container } = render(<LastBatchChip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the batch count and destination", () => {
+    useJobStore.setState({
+      lastBatch: { summary: SUMMARY, outputDir: "/out/dir", count: 3 },
+    });
+    render(<LastBatchChip />);
+    expect(screen.getByText(/3 items/i)).toBeTruthy();
+    expect(screen.getByText(/\/out\/dir/)).toBeTruthy();
+  });
+
+  it("opens the batch destination when Open is clicked", async () => {
+    vi.mocked(openPath).mockResolvedValue(undefined);
+    useJobStore.setState({
+      lastBatch: { summary: SUMMARY, outputDir: "/out/dir", count: 3 },
+    });
+    render(<LastBatchChip />);
+
+    await userEvent.click(screen.getByRole("button", { name: /open/i }));
+
+    expect(vi.mocked(openPath)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(openPath)).toHaveBeenCalledWith("/out/dir");
+  });
+
+  it("disables Open when the destination is null", () => {
+    useJobStore.setState({
+      lastBatch: { summary: SUMMARY, outputDir: null, count: 3 },
+    });
+    render(<LastBatchChip />);
+    const open = screen.getByRole("button", { name: /open/i });
+    expect((open as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("restores the cleared run when Undo is clicked", async () => {
+    useJobStore.setState({
+      cleared: true,
+      summary: null,
+      lastBatch: { summary: SUMMARY, outputDir: "/out/dir", count: 3 },
+    });
+    render(<LastBatchChip />);
+
+    await userEvent.click(screen.getByRole("button", { name: /undo/i }));
+
+    const state = useJobStore.getState();
+    expect(state.summary).toEqual(SUMMARY);
+    expect(state.cleared).toBe(false);
+    expect(state.lastBatch).toBeNull();
+  });
+
+  it("labels the Open and Undo actions for assistive tech", () => {
+    useJobStore.setState({
+      lastBatch: { summary: SUMMARY, outputDir: "/out/dir", count: 3 },
+    });
+    render(<LastBatchChip />);
+    expect(screen.getByRole("button", { name: /open/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /undo/i })).toBeTruthy();
+  });
+});

--- a/src/components/LastBatchChip.tsx
+++ b/src/components/LastBatchChip.tsx
@@ -1,0 +1,77 @@
+import { FolderOpen, Undo2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { messageFromReason } from "@/lib/errors";
+import { openPath } from "@/lib/reveal";
+import { useJobStore } from "@/store/jobStore";
+
+/**
+ * The residual "last batch" chip: a slim pinned row shown above the drop zone
+ * after a finished run is cleared. It summarizes the most recent batch
+ * (`Last: N items → <destination>`) and offers two affordances:
+ *   - Open: reveal the batch destination in the OS file explorer (disabled when
+ *     no destination was set), and
+ *   - Undo: restore the cleared run's Ledger (the chip is the sole undo path —
+ *     there is no confirm dialog or toast).
+ *
+ * Renders nothing unless a residual batch is present. Reads `lastBatch` straight
+ * from the store so it stays a pure projection of that state.
+ */
+export function LastBatchChip() {
+  const lastBatch = useJobStore((s) => s.lastBatch);
+  const restoreResults = useJobStore((s) => s.restoreResults);
+
+  if (lastBatch === null) return null;
+
+  const { outputDir, count } = lastBatch;
+  // Pluralize the noun so "1 item" reads naturally next to "3 items".
+  const itemLabel = count === 1 ? "item" : "items";
+
+  // Surface an Open failure through the shared store error path rather than
+  // swallowing it, mirroring the Ledger's handlers.
+  async function openDestination() {
+    if (outputDir === null) return;
+    try {
+      await openPath(outputDir);
+    } catch (reason) {
+      useJobStore.setState({ error: messageFromReason(reason) });
+    }
+  }
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-4 py-2 text-sm">
+      <span className="min-w-0 truncate text-muted-foreground">
+        <span className="font-medium text-foreground">
+          Last: {count} {itemLabel}
+        </span>
+        <span aria-hidden="true" className="px-1.5">
+          →
+        </span>
+        <span className="font-mono">{outputDir ?? "(no destination)"}</span>
+      </span>
+
+      <div className="flex shrink-0 items-center gap-1">
+        {/* Disabled when no destination was set, so it never opens a null path. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Open last batch folder"
+          disabled={outputDir === null}
+          onClick={openDestination}
+        >
+          <FolderOpen aria-hidden="true" />
+          Open
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Undo clear"
+          onClick={restoreResults}
+        >
+          <Undo2 aria-hidden="true" />
+          Undo
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Ledger.test.tsx
+++ b/src/components/Ledger.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
+import * as archive from "@/lib/archive";
 import { copyText, openPath, revealItem } from "@/lib/reveal";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
@@ -16,9 +17,11 @@ vi.mock("@/lib/archive", () => ({
   addItems: vi.fn(),
   reorder: vi.fn(),
   setNamingRule: vi.fn(),
+  setStartNumber: vi.fn(),
   setOutputDir: vi.fn(),
   runJob: vi.fn(),
   cancelJob: vi.fn(),
+  clearItems: vi.fn(),
   previewOutputName: vi.fn(),
   subscribeProgress: vi.fn(),
 }));
@@ -178,8 +181,9 @@ describe("Ledger", () => {
       },
     });
     render(<Ledger />);
-    // 2048 bytes total → "2 KB".
-    expect(screen.getByText(/2 KB/)).toBeTruthy();
+    // 2048 bytes total → "2.0 / 2.0 KB": formatBytes renders KB and larger with
+    // one fixed-width decimal (the row passes bytesTotal as both done and total).
+    expect(screen.getByText(/2\.0 \/ 2\.0 KB/)).toBeTruthy();
   });
 
   it("omits the size gracefully when no progress entry matches the row", () => {
@@ -293,6 +297,46 @@ describe("Ledger", () => {
       });
       render(<Ledger />);
       expect(screen.queryByRole("button", { name: /open folder/i })).toBeNull();
+    });
+  });
+
+  describe("Clear button", () => {
+    it("clears the results into a residual last batch when clicked", async () => {
+      // setStartNumber recomputes previews; give it a resolving default so the
+      // clearResults round-trip settles.
+      vi.mocked(archive.previewOutputName).mockResolvedValue("photo_001.zip");
+      vi.mocked(archive.setStartNumber).mockResolvedValue(
+        draftWith([], "/out"),
+      );
+      vi.mocked(archive.clearItems).mockResolvedValue(draftWith([], "/out"));
+      useJobStore.setState({
+        draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+        summary: MIXED_SUMMARY,
+      });
+      render(<Ledger />);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /clear results/i }),
+      );
+
+      const state = useJobStore.getState();
+      expect(state.cleared).toBe(true);
+      expect(state.lastBatch?.count).toBe(3);
+      expect(state.summary).toBeNull();
+      // Start # auto-continues from 1 by the 3-task count.
+      expect(vi.mocked(archive.setStartNumber)).toHaveBeenCalledWith(4);
+      expect(vi.mocked(archive.clearItems)).toHaveBeenCalledTimes(1);
+    });
+
+    it("labels the Clear control for assistive tech", () => {
+      useJobStore.setState({
+        draft: draftWith(["/in/a.rar"]),
+        summary: MIXED_SUMMARY,
+      });
+      render(<Ledger />);
+      expect(
+        screen.getByRole("button", { name: /clear results/i }),
+      ).toBeTruthy();
     });
   });
 

--- a/src/components/Ledger.tsx
+++ b/src/components/Ledger.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Copy, FolderOpen } from "lucide-react";
+import { ArrowUpRight, Copy, Eraser, FolderOpen } from "lucide-react";
 
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 import type { TaskResultDto } from "@/bindings/TaskResultDto";
@@ -136,6 +136,7 @@ export function Ledger() {
   const progress = useJobStore((s) => s.progress);
   const items = useJobStore((s) => s.draft.items);
   const outputDir = useJobStore((s) => s.draft.outputDir);
+  const clearResults = useJobStore((s) => s.clearResults);
 
   if (summary === null) return null;
 
@@ -173,18 +174,33 @@ export function Ledger() {
           ))}
         </div>
 
-        {/* Guarded on outputDir so it never opens a null path. */}
-        {outputDir !== null && (
+        <div className="flex items-center gap-2">
+          {/* Guarded on outputDir so it never opens a null path. */}
+          {outputDir !== null && (
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label="Open folder"
+              onClick={() => runOrReportError(() => openPath(outputDir))}
+            >
+              <FolderOpen aria-hidden="true" />
+              Open folder
+            </Button>
+          )}
+
+          {/* Clear folds the Ledger back to the drop zone and pins the residual
+              chip; it never deletes files on disk. The chip's Undo is the undo
+              affordance, so there is no confirm dialog. */}
           <Button
             variant="outline"
             size="sm"
-            aria-label="Open folder"
-            onClick={() => runOrReportError(() => openPath(outputDir))}
+            aria-label="Clear results"
+            onClick={() => runOrReportError(() => clearResults())}
           >
-            <FolderOpen aria-hidden="true" />
-            Open folder
+            <Eraser aria-hidden="true" />
+            Clear
           </Button>
-        )}
+        </div>
       </div>
 
       {/* One row per task, in job order. */}

--- a/src/components/RightCanvas.test.tsx
+++ b/src/components/RightCanvas.test.tsx
@@ -96,6 +96,26 @@ describe("RightCanvas", () => {
     expect(screen.queryByTestId("empty-queue")).toBeNull();
   });
 
+  it("shows the drop zone and the last-batch chip after a clear", () => {
+    // Clear folds the Ledger back to the drop zone while pinning the chip.
+    useJobStore.setState({
+      cleared: true,
+      summary: null,
+      lastBatch: { summary: SUMMARY, outputDir: "/out", count: 2 },
+    });
+    render(<RightCanvas />);
+    // The drop zone returns.
+    expect(screen.getByTestId("empty-queue")).toBeTruthy();
+    // The residual chip is pinned above it.
+    expect(screen.getByText(/2 items/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /undo/i })).toBeTruthy();
+  });
+
+  it("does not render the chip when there is no residual last batch", () => {
+    render(<RightCanvas />);
+    expect(screen.queryByRole("button", { name: /undo/i })).toBeNull();
+  });
+
   it("prefers the running phase over a stale summary", () => {
     setItems(1);
     useJobStore.setState({

--- a/src/components/RightCanvas.tsx
+++ b/src/components/RightCanvas.tsx
@@ -1,5 +1,6 @@
 import { AddSourceButtons } from "@/components/AddSourceButtons";
 import { EmptyQueue } from "@/components/EmptyQueue";
+import { LastBatchChip } from "@/components/LastBatchChip";
 import { Ledger } from "@/components/Ledger";
 import { OverallProgress } from "@/components/OverallProgress";
 import { TaskList } from "@/components/TaskList";
@@ -16,6 +17,9 @@ import { useJobStore } from "@/store/jobStore";
  *             (each row keeps its own live progress),
  *   results → the Inline Ledger (per-row Reveal/Copy + status tally header).
  *
+ * After a finished run is cleared, the canvas returns to the drop zone with the
+ * residual {@link LastBatchChip} pinned above it (whenever a last batch exists).
+ *
  * The canvas is the only region that scrolls vertically (the left rail is
  * shrink-0 and scrolls only internally on short viewports). It is a labelled
  * landmark region so assistive tech can jump to the work area.
@@ -24,14 +28,17 @@ export function RightCanvas() {
   const itemCount = useJobStore((s) => s.draft.items.length);
   const running = useJobStore((s) => s.running);
   const hasSummary = useJobStore((s) => s.summary !== null);
+  const cleared = useJobStore((s) => s.cleared);
 
-  const phase = canvasPhase({ itemCount, running, hasSummary });
+  const phase = canvasPhase({ itemCount, running, hasSummary, cleared });
 
   return (
     <main
       aria-label="Work area"
       className="min-w-0 flex-1 overflow-y-auto px-6 py-4"
     >
+      {/* The residual chip pins above whichever phase renders below it. */}
+      <LastBatchChip />
       {phase === "empty" ? <EmptyQueue /> : null}
       {phase === "queued" ? (
         <div className="flex flex-col gap-4">

--- a/src/lib/canvas-phase.test.ts
+++ b/src/lib/canvas-phase.test.ts
@@ -51,4 +51,52 @@ describe("canvasPhase", () => {
       canvasPhase({ itemCount: 0, running: false, hasSummary: true }),
     ).toBe("results");
   });
+
+  // After Clear, the canvas returns to the drop zone even though a fresh summary
+  // is absent; the residual chip is rendered above the empty phase separately.
+  it("returns 'empty' when cleared with no items, no run, and no summary", () => {
+    expect(
+      canvasPhase({
+        itemCount: 0,
+        running: false,
+        hasSummary: false,
+        cleared: true,
+      }),
+    ).toBe("empty");
+  });
+
+  it("prefers 'running' over a cleared flag (a new run started after a clear)", () => {
+    expect(
+      canvasPhase({
+        itemCount: 0,
+        running: true,
+        hasSummary: false,
+        cleared: true,
+      }),
+    ).toBe("running");
+  });
+
+  it("prefers 'results' over a cleared flag (a fresh summary supersedes the clear)", () => {
+    expect(
+      canvasPhase({
+        itemCount: 0,
+        running: false,
+        hasSummary: true,
+        cleared: true,
+      }),
+    ).toBe("results");
+  });
+
+  it("returns 'empty' when cleared even if stale items linger (defensive)", () => {
+    // Clear empties the queue, but defend against a stale itemCount so the
+    // cleared canvas never falls through to the queued task list.
+    expect(
+      canvasPhase({
+        itemCount: 3,
+        running: false,
+        hasSummary: false,
+        cleared: true,
+      }),
+    ).toBe("empty");
+  });
 });

--- a/src/lib/canvas-phase.ts
+++ b/src/lib/canvas-phase.ts
@@ -10,16 +10,24 @@ export type CanvasPhase = "empty" | "queued" | "running" | "results";
 
 /**
  * Compute the canvas phase from the draft/job state. Precedence is
- * running > results > queued > empty: an in-flight run always wins, then a
- * finished summary, then a non-empty queue, falling back to the empty state.
+ * running > results > cleared > queued > empty: an in-flight run always wins,
+ * then a finished summary, then a fresh clear (which folds the Ledger back to
+ * the drop zone), then a non-empty queue, falling back to the empty state.
+ *
+ * `cleared` reflects a user-initiated Clear of a finished run: the queue is
+ * emptied and the canvas returns to the drop zone, ready for the next batch.
+ * Defaults to false so callers that predate Clear keep the original precedence.
  */
 export function canvasPhase(s: {
   itemCount: number;
   running: boolean;
   hasSummary: boolean;
+  cleared?: boolean;
 }): CanvasPhase {
   if (s.running) return "running";
   if (s.hasSummary) return "results";
+  // A fresh clear returns to the drop zone even if a stale itemCount lingers.
+  if (s.cleared) return "empty";
   if (s.itemCount > 0) return "queued";
   return "empty";
 }

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/archive", () => ({
 vi.mock("@/lib/output-dir-default", () => ({ persistOutputDir: vi.fn() }));
 
 import * as archive from "@/lib/archive";
-import { DEFAULT_TEMPLATE } from "@/lib/naming";
+import { DEFAULT_TEMPLATE, MAX_START } from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
 
 import { resetJobStore, useJobStore } from "./jobStore";
@@ -79,6 +79,8 @@ describe("jobStore initial state", () => {
     expect(state.taskIdByIndex).toEqual([]);
     expect(state.running).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.lastBatch).toBeNull();
+    expect(state.cleared).toBe(false);
   });
 });
 
@@ -149,6 +151,30 @@ describe("addItems", () => {
 
     expect(useJobStore.getState().error).toBe("backend boom");
     expect(useJobStore.getState().draft).toEqual(INITIAL_DRAFT);
+  });
+
+  it("discards the residual last-batch chip when the next batch is queued", async () => {
+    // Simulate a prior Clear leaving a residual chip; queuing a new batch must
+    // dismiss it so the chip only ever refers to the most recent completed run.
+    const lastBatch = {
+      summary: {
+        succeeded: [1],
+        cancelled: [],
+        failed: [],
+        results: [],
+      } as JobSummaryDto,
+      outputDir: "/out",
+      count: 1,
+    };
+    useJobStore.setState({ lastBatch, cleared: true });
+
+    const draft = makeDraft(1);
+    mockArchive.addItems.mockResolvedValue(draft);
+
+    await useJobStore.getState().addItems(["/a.rar"]);
+
+    expect(useJobStore.getState().lastBatch).toBeNull();
+    expect(useJobStore.getState().cleared).toBe(false);
   });
 });
 
@@ -566,6 +592,36 @@ describe("runJob", () => {
     expect(useJobStore.getState().summary).toEqual(summary);
   });
 
+  it("discards the residual last-batch chip when a new job starts", async () => {
+    // Running the next batch supersedes the residual chip, just like queuing.
+    const lastBatch = {
+      summary: {
+        succeeded: [1],
+        cancelled: [],
+        failed: [],
+        results: [],
+      } as JobSummaryDto,
+      outputDir: "/out",
+      count: 1,
+    };
+    useJobStore.setState({ lastBatch, cleared: true });
+
+    const summary: JobSummaryDto = {
+      succeeded: [1],
+      cancelled: [],
+      failed: [],
+      results: [],
+    };
+    mockArchive.runJob.mockResolvedValue(summary);
+
+    const pending = useJobStore.getState().runJob();
+    // The chip is dropped synchronously when the run starts.
+    expect(useJobStore.getState().lastBatch).toBeNull();
+    expect(useJobStore.getState().cleared).toBe(false);
+    await pending;
+    expect(useJobStore.getState().lastBatch).toBeNull();
+  });
+
   it("keeps the existing taskIdByIndex when no progress was emitted", async () => {
     // With progress === null, runJob falls back to the existing taskIdByIndex
     // instead of wiping it to []. Seed it via setState since addItems/reorder
@@ -775,5 +831,176 @@ describe("reset", () => {
     const state = useJobStore.getState();
     expect(state.error).toBe("backend boom");
     expect(state.draft).toEqual(originalDraft);
+  });
+});
+
+describe("clearResults", () => {
+  // A mixed three-task summary; only its length feeds the auto-continue count.
+  const SUMMARY: JobSummaryDto = {
+    succeeded: [10, 11],
+    cancelled: [],
+    failed: [{ taskId: 12, reason: "boom" }],
+    results: [
+      {
+        taskId: 10,
+        outputName: "out_1.zip",
+        outputPath: "/out/out_1.zip",
+        status: "succeeded",
+        reason: null,
+      },
+      {
+        taskId: 11,
+        outputName: "out_2.zip",
+        outputPath: "/out/out_2.zip",
+        status: "succeeded",
+        reason: null,
+      },
+      {
+        taskId: 12,
+        outputName: "out_3.zip",
+        outputPath: "/out/out_3.zip",
+        status: "failed",
+        reason: "boom",
+      },
+    ],
+  };
+
+  // clearResults advances Start # via setStartNumber, which recomputes previews.
+  // Give previewOutputName a resolving default so the recompute settles (other
+  // describe blocks leave a never-resolving impl behind, since vi.clearAllMocks
+  // resets call history but not implementations).
+  beforeEach(() => {
+    mockArchive.previewOutputName.mockResolvedValue("photo_001.zip");
+  });
+
+  it("does nothing when there is no finished summary", async () => {
+    await useJobStore.getState().clearResults();
+
+    expect(useJobStore.getState().cleared).toBe(false);
+    expect(useJobStore.getState().lastBatch).toBeNull();
+    expect(mockArchive.clearItems).not.toHaveBeenCalled();
+    expect(mockArchive.setStartNumber).not.toHaveBeenCalled();
+  });
+
+  it("stashes the summary into lastBatch, marks cleared, and nulls the summary", async () => {
+    useJobStore.setState({
+      draft: makeDraft(3, "photo_{n}", "/out", 1),
+      summary: SUMMARY,
+    });
+    // setStartNumber and clearItems both return refreshed drafts.
+    mockArchive.setStartNumber.mockResolvedValue(
+      makeDraft(3, "photo_{n}", "/out", 4),
+    );
+    mockArchive.clearItems.mockResolvedValue(
+      makeDraft(0, "photo_{n}", "/out", 4),
+    );
+
+    await useJobStore.getState().clearResults();
+
+    const state = useJobStore.getState();
+    expect(state.cleared).toBe(true);
+    expect(state.lastBatch).toEqual({
+      summary: SUMMARY,
+      outputDir: "/out",
+      count: 3,
+    });
+    expect(state.summary).toBeNull();
+    expect(state.progress).toBeNull();
+    expect(state.taskIdByIndex).toEqual([]);
+    expect(state.previewNames).toEqual([]);
+  });
+
+  it("auto-continues the start number by the batch count and clears the queue", async () => {
+    useJobStore.setState({
+      draft: makeDraft(3, "photo_{n}", "/out", 1),
+      summary: SUMMARY,
+    });
+    mockArchive.setStartNumber.mockResolvedValue(
+      makeDraft(3, "photo_{n}", "/out", 4),
+    );
+    mockArchive.clearItems.mockResolvedValue(
+      makeDraft(0, "photo_{n}", "/out", 4),
+    );
+
+    await useJobStore.getState().clearResults();
+
+    // Start # advances from 1 by the three-task count to 4.
+    expect(mockArchive.setStartNumber).toHaveBeenCalledWith(4);
+    expect(mockArchive.clearItems).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps the auto-continued start number to MAX_START", async () => {
+    // A start near u32::MAX plus the batch count must not overflow the field.
+    useJobStore.setState({
+      draft: makeDraft(3, "photo_{n}", "/out", MAX_START - 1),
+      summary: SUMMARY,
+    });
+    mockArchive.setStartNumber.mockResolvedValue(
+      makeDraft(3, "photo_{n}", "/out", MAX_START),
+    );
+    mockArchive.clearItems.mockResolvedValue(
+      makeDraft(0, "photo_{n}", "/out", MAX_START),
+    );
+
+    await useJobStore.getState().clearResults();
+
+    expect(mockArchive.setStartNumber).toHaveBeenCalledWith(MAX_START);
+  });
+
+  it("keeps lastBatch after the queue is cleared (Undo must still work)", async () => {
+    useJobStore.setState({
+      draft: makeDraft(3, "photo_{n}", "/out", 1),
+      summary: SUMMARY,
+    });
+    mockArchive.setStartNumber.mockResolvedValue(
+      makeDraft(3, "photo_{n}", "/out", 4),
+    );
+    mockArchive.clearItems.mockResolvedValue(
+      makeDraft(0, "photo_{n}", "/out", 4),
+    );
+
+    await useJobStore.getState().clearResults();
+
+    expect(useJobStore.getState().lastBatch).not.toBeNull();
+    expect(useJobStore.getState().lastBatch?.count).toBe(3);
+  });
+});
+
+describe("restoreResults", () => {
+  const SUMMARY: JobSummaryDto = {
+    succeeded: [1],
+    cancelled: [],
+    failed: [],
+    results: [
+      {
+        taskId: 1,
+        outputName: "out_1.zip",
+        outputPath: "/out/out_1.zip",
+        status: "succeeded",
+        reason: null,
+      },
+    ],
+  };
+
+  it("does nothing when there is no residual last batch", () => {
+    useJobStore.getState().restoreResults();
+
+    expect(useJobStore.getState().summary).toBeNull();
+    expect(useJobStore.getState().cleared).toBe(false);
+  });
+
+  it("restores the stashed summary, unsets cleared, and drops lastBatch", () => {
+    useJobStore.setState({
+      cleared: true,
+      summary: null,
+      lastBatch: { summary: SUMMARY, outputDir: "/out", count: 1 },
+    });
+
+    useJobStore.getState().restoreResults();
+
+    const state = useJobStore.getState();
+    expect(state.summary).toEqual(SUMMARY);
+    expect(state.cleared).toBe(false);
+    expect(state.lastBatch).toBeNull();
   });
 });

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -9,7 +9,7 @@ import type { ProgressEvent } from "@/bindings/ProgressEvent";
 // which share names (addItems, reorder, setNamingRule, ...).
 import * as archive from "@/lib/archive";
 import { messageFromReason } from "@/lib/errors";
-import { DEFAULT_START, DEFAULT_TEMPLATE } from "@/lib/naming";
+import { DEFAULT_START, DEFAULT_TEMPLATE, MAX_START } from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
 
 // Monotonic counter tagging each recomputePreviews run. A run only commits its
@@ -28,6 +28,20 @@ function draftEdit(draft: DraftSnapshot): Partial<JobState> {
     progress: null,
     taskIdByIndex: [],
   };
+}
+
+/**
+ * A snapshot of the most recently cleared run, kept so the residual "last batch"
+ * chip can summarize it (count + destination) and Undo can restore its Ledger.
+ * Only the single most-recent batch is retained — there is no run history.
+ */
+interface LastBatch {
+  /** The finished job's summary, restored verbatim by restoreResults(). */
+  summary: JobSummaryDto;
+  /** The destination the batch wrote to (the chip's Open target), or null. */
+  outputDir: string | null;
+  /** The number of tasks in the batch (drives the chip label + auto-continue). */
+  count: number;
 }
 
 /**
@@ -75,6 +89,18 @@ export interface JobState {
   running: boolean;
   /** The latest error message, or null when the last action succeeded. */
   error: string | null;
+  /**
+   * The most recently cleared run, kept so the residual chip can summarize it
+   * and Undo can restore its Ledger. Null when no run has been cleared (or the
+   * chip was discarded by queuing/running the next batch).
+   */
+  lastBatch: LastBatch | null;
+  /**
+   * True after a finished run was cleared: the canvas folds back to the drop
+   * zone while `lastBatch` pins the residual chip above it. Reset to false once
+   * the next batch is queued/run or the clear is undone.
+   */
+  cleared: boolean;
 
   /** Add file/folder paths to the draft, then recompute previews. */
   addItems: (paths: string[]) => Promise<void>;
@@ -109,6 +135,21 @@ export interface JobState {
    * test-only full reset.
    */
   reset: () => Promise<void>;
+  /**
+   * Fold the finished run's Ledger back to the drop zone, ready for the next
+   * batch. Stashes the current summary into `lastBatch` (so the residual chip
+   * and Undo can use it), advances Start # by the batch count (auto-continue,
+   * clamped to MAX_START), clears the queue, and nulls the transient job state
+   * like reset() — but KEEPS `lastBatch`. Files on disk are never touched; this
+   * only folds the list view. No-op when there is no finished summary.
+   */
+  clearResults: () => Promise<void>;
+  /**
+   * Undo the most recent clear: restore the stashed summary (returning the
+   * canvas to the Ledger), unset `cleared`, and drop `lastBatch`. No-op when
+   * there is no residual batch to restore.
+   */
+  restoreResults: () => void;
 }
 
 export const useJobStore = create<JobState>()((set, get) => ({
@@ -128,11 +169,15 @@ export const useJobStore = create<JobState>()((set, get) => ({
   taskIdByIndex: [],
   running: false,
   error: null,
+  lastBatch: null,
+  cleared: false,
 
   addItems: async (paths) => {
     try {
       const draft = await archive.addItems(paths);
-      set(draftEdit(draft));
+      // Queuing the next batch discards the residual chip: it only ever refers
+      // to the most recent completed run.
+      set({ ...draftEdit(draft), lastBatch: null, cleared: false });
       await get().recomputePreviews();
     } catch (reason) {
       set({ error: messageFromReason(reason) });
@@ -213,7 +258,14 @@ export const useJobStore = create<JobState>()((set, get) => ({
   },
 
   runJob: async () => {
-    set({ running: true, summary: null, error: null });
+    // Starting the next run supersedes the residual chip, just like queuing.
+    set({
+      running: true,
+      summary: null,
+      error: null,
+      lastBatch: null,
+      cleared: false,
+    });
     try {
       const summary = await archive.runJob();
       // Derive task ids from the latest progress if a job emitted any.
@@ -321,6 +373,51 @@ export const useJobStore = create<JobState>()((set, get) => ({
     } catch (reason) {
       set({ error: messageFromReason(reason) });
     }
+  },
+
+  clearResults: async () => {
+    const { summary, draft } = get();
+    // No finished run means nothing to clear; Clear is a no-op there.
+    if (summary === null) return;
+    const count = summary.results.length;
+    // Auto-continue: the next batch picks up where this one ended. Clamp to the
+    // field's max so a near-overflow start never exceeds the backend's u32.
+    const nextStart = Math.min(draft.startNumber + count, MAX_START);
+    // Stash the finished run BEFORE mutating, so the residual chip and Undo can
+    // summarize/restore it. setStartNumber recomputes previews against the new
+    // (empty) queue; clearItems empties the backend draft.
+    set({
+      lastBatch: { summary, outputDir: draft.outputDir, count },
+      cleared: true,
+    });
+    let clearedDraft: DraftSnapshot;
+    try {
+      // setStartNumber pushes the advanced start (and recomputes previews);
+      // clearItems empties the backend draft and returns the cleared snapshot.
+      await get().setStartNumber(nextStart);
+      clearedDraft = await archive.clearItems();
+    } catch (reason) {
+      set({ error: messageFromReason(reason) });
+      return;
+    }
+    // Mirror reset()'s transient wipe, but KEEP lastBatch so Undo still works.
+    // Store the cleared snapshot so the draft (empty queue + advanced start)
+    // stays in sync with the backend, just as reset() does.
+    set({
+      draft: clearedDraft,
+      summary: null,
+      progress: null,
+      taskIdByIndex: [],
+      previewNames: [],
+    });
+  },
+
+  restoreResults: () => {
+    const lastBatch = get().lastBatch;
+    // Nothing stashed means nothing to undo.
+    if (lastBatch === null) return;
+    // Return to the results/Ledger phase with the previously cleared summary.
+    set({ summary: lastBatch.summary, cleared: false, lastBatch: null });
   },
 }));
 


### PR DESCRIPTION
Closes #116.

## Summary

The Ledger had no way to start the next batch — clearing meant losing the results view and the path to the files. This adds a **Clear** button to the Ledger header that empties the canvas back to a drop zone, pins a single **"last batch" chip** (Open + Undo) so the previous run is never lost, and **auto-continues the sequence number**. Final PR of the 4-PR redesign. #113/#114/#115 (PR1–PR3) are merged to `main`, so this targets `main` directly.

## Background / Motivation

- After a run the Ledger filled the canvas; there was no affordance to move on to the next batch without losing the current view.
- The only "fresh start" was the footer Reset/Clear, which discarded everything — including the path to the just-produced files.
- Repeating a batch meant manually re-typing the next Start # each time.

## Changes

### Store: clear / restore / auto-continue

- `jobStore` gains `lastBatch: { summary, outputDir, count } | null` and `cleared: boolean`.
- `clearResults()` stashes the finished summary into `lastBatch`, sets `cleared`, advances Start # to `prevStart + count` (clamped to `MAX_START`), clears the queue (`clearItems`) and nulls transient job state — keeping `lastBatch` so Undo works.
- `restoreResults()` puts the stashed summary back and clears the chip.
- `addItems()` and `runJob()` discard the chip, so it disappears once the next batch is queued/run.

### Phase routing + canvas

- `canvasPhase` gains a `cleared` flag (precedence `running > results > cleared→empty > queued > empty`).
- `RightCanvas` renders `LastBatchChip` above the phase content (self-hides when `lastBatch` is null) and passes `cleared` into the phase.

### Ledger Clear button + chip

- Ledger header gains a Clear button (lucide `Eraser`, `aria-label="Clear results"`) next to Open folder → `clearResults()`.
- New `LastBatchChip`: slim pinned "Last: N items → \<destination\>" with Open (`openPath`, disabled when null) + Undo (`Undo2` → `restoreResults`).

### Tests

- `jobStore` (clear stashes + auto-continues + clears queue; restore; chip discarded on add/run), `canvas-phase` (cleared precedence), `RightCanvas` (chip render + cleared→drop zone), `Ledger` (Clear button), `LastBatchChip` (Open/Undo/disabled). 350 FE tests pass.

## Verification

- After a run, the Ledger header shows **Clear** next to **Open folder**; clicking Clear empties to the drop zone, pins "Last: N → \<dest\>" with Open + Undo, and the rail Start # advances by N. Undo restores the Ledger. Dropping the next batch dismisses the chip.
- Gates green by exit code: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo nextest run`, `pnpm fmt:check`, `pnpm lint:ci`, `pnpm test:coverage`, `pnpm build`, `pnpm knip`.

Locked decisions: no confirm dialog / toast (the chip's Undo is the undo); single most-recent batch only (no history); number reset via the rail field.

---
Final PR of the 4-step redesign · order #113 → #114 → #115 → #116 (first three merged). Base `main`, so `Closes #116` auto-closes on merge.