### PR TITLE
fix(ui): center the confirm dialog instead of pinning it top-left

### DIFF
--- a/src/components/ui/confirm-dialog.test.tsx
+++ b/src/components/ui/confirm-dialog.test.tsx
@@ -34,6 +34,20 @@ describe("ConfirmDialog – open state", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
   });
 
+  it("stretches the dialog panel across the full viewport so its content is centered", () => {
+    // Regression: a native <dialog open> defaults to `width/height: fit-content`
+    // (and Tailwind Preflight zeroes its margin), so without explicit full-size
+    // utilities the flex container collapses to the card and pins it to the
+    // top-left corner. The dialog must fill the viewport for `items-center
+    // justify-center` to center the card on screen.
+    render(<ConfirmDialog {...baseProps} open={true} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("h-full");
+    expect(dialog.className).toContain("w-full");
+    expect(dialog.className).toContain("items-center");
+    expect(dialog.className).toContain("justify-center");
+  });
+
   it("does not render description element when description prop is omitted", () => {
     const { title, confirmLabel, cancelLabel, onConfirm, onCancel } = baseProps;
     render(

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -63,13 +63,20 @@ export function ConfirmDialog({
         onClick={onCancel}
         aria-hidden="true"
       />
-      {/* Dialog panel — positioned above the backdrop; stop propagation so panel clicks do not reach the backdrop. */}
+      {/*
+        Dialog panel — positioned above the backdrop; stop propagation so panel
+        clicks do not reach the backdrop. A native <dialog open> defaults to
+        `width/height: fit-content` and Tailwind Preflight zeroes its margin,
+        which would collapse this flex container to the card and pin it
+        top-left. `m-0 h-full w-full` make the dialog fill the viewport so the
+        card stays centered on screen.
+      */}
       <dialog
         open
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={description ? descriptionId : undefined}
-        className="fixed inset-0 z-[51] flex items-center justify-center border-0 bg-transparent p-0"
+        className="fixed inset-0 z-[51] m-0 flex h-full w-full items-center justify-center border-0 bg-transparent p-0"
       >
         {/* Stop click propagation on the content card so clicks here do not bubble to the backdrop. */}
         <div


### PR DESCRIPTION
## Summary

The **"Clear the queue?"** confirmation dialog rendered flush against the **top-left corner** of the window instead of centered. The shared `ConfirmDialog` primitive already styled its panel with `fixed inset-0 flex items-center justify-center`, but a native `<dialog open>` carries user-agent defaults that collapsed the flex container down to the card's own size, so the centering had nothing to span. Adding `m-0 h-full w-full` makes the dialog fill the viewport so the card lands in the middle of the screen.

## Background / Motivation

- A native `<dialog>` opened via the `open` attribute (not `showModal()`) defaults to `width/height: fit-content`, and Tailwind Preflight zeroes its `margin`. The flex container therefore shrank to the size of the inner card and pinned it top-left, so `items-center justify-center` centered the card *inside a collapsed box* rather than across the viewport.
- The backdrop (`fixed inset-0` plain `<div>`) covered the whole screen correctly, which rules out an ancestor `transform` containing-block issue and isolates the cause to the `<dialog>` element's UA styling.
- `ConfirmDialog` is the single shared confirmation primitive (used by the queue Reset/Clear flow), so every consumer was mis-positioned, not just one screen.

## Changes

### Center the dialog panel

- `src/components/ui/confirm-dialog.tsx`: add `m-0 h-full w-full` to the `<dialog>` className so it overrides the UA `fit-content` size and zeroed margin and fills the viewport. The existing `flex items-center justify-center` then centers the card on screen.
- Documented the UA-style interaction in a comment above the element so the sizing utilities are not "cleaned up" in a future refactor.

### Tests

- `src/components/ui/confirm-dialog.test.tsx`: added a regression test asserting the dialog panel carries the full-viewport sizing (`h-full`, `w-full`) plus the centering utilities (`items-center`, `justify-center`). It fails on the pre-fix markup and passes after.

## Verification

- Open the queue Clear confirmation (footer Clear → "Clear the queue?"): the dialog is centered horizontally and vertically over the dimmed backdrop.
- DOM: `rg "h-full w-full" src/components/ui/confirm-dialog.tsx` shows the sizing utilities on the `<dialog>`.
- Frontend gates green by exit code: `pnpm test` (352 passed), `pnpm fmt:check` (oxfmt --check), `pnpm lint:ci` (oxlint --deny-warnings), `pnpm build` (tsc + vite), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 352 passed, including the new centering regression test
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: trigger "Clear the queue?" and confirm the panel is centered on screen
