### PR TITLE
feat(ui): drag-and-drop reorder for queue rows

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -450,5 +450,131 @@ describe("TaskList progress", () => {
     });
     render(<TaskList />);
     expect(screen.getByText(/12\.4 \/ 19\.0 MB/)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop reorder
+// ---------------------------------------------------------------------------
+
+describe("TaskList drag-and-drop reorder", () => {
+  function setItems(n: number, extra: Record<string, unknown> = {}) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(n),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      ...extra,
+    });
+  }
+
+  // The first <tr> is the header; the remaining rows are the draggable items.
+  function bodyRows() {
+    return screen.getAllByRole("row").slice(1) as HTMLTableRowElement[];
+  }
+
+  it("marks item rows draggable when no job is running", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    for (const row of bodyRows()) {
+      expect(row.getAttribute("draggable")).toBe("true");
+    }
+  });
+
+  it("calls reorder(from, to) when a row is dropped onto a lower row", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    fireEvent.dragStart(rows[0]);
+    fireEvent.dragOver(rows[2]);
+    fireEvent.drop(rows[2]);
+
+    expect(reorder).toHaveBeenCalledWith(0, 2);
+  });
+
+  it("calls reorder(from, to) when a row is dropped onto a higher row", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    fireEvent.dragStart(rows[2]);
+    fireEvent.dragOver(rows[0]);
+    fireEvent.drop(rows[0]);
+
+    expect(reorder).toHaveBeenCalledWith(2, 0);
+  });
+
+  it("does not call reorder when a row is dropped onto itself", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    fireEvent.dragStart(rows[1]);
+    fireEvent.dragOver(rows[1]);
+    fireEvent.drop(rows[1]);
+
+    expect(reorder).not.toHaveBeenCalled();
+  });
+
+  it("marks the hovered row as the drop target while dragging another row", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    fireEvent.dragStart(rows[0]);
+    fireEvent.dragOver(rows[2]);
+
+    expect(rows[2].getAttribute("data-drop-target")).toBe("true");
+    expect(rows[0].getAttribute("data-drop-target")).toBeNull();
+    expect(rows[0].getAttribute("data-dragging")).toBe("true");
+  });
+
+  it("clears the drag state on drag end", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    fireEvent.dragStart(rows[0]);
+    fireEvent.dragOver(rows[2]);
+    fireEvent.dragEnd(rows[0]);
+
+    expect(rows[0].getAttribute("data-dragging")).toBeNull();
+    expect(rows[2].getAttribute("data-drop-target")).toBeNull();
+  });
+
+  it("does not allow dragging while a job is running", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, {
+      reorder,
+      running: true,
+      progress: {
+        overall: { bytesDone: 0, bytesTotal: 0 },
+        overallEtaMs: null,
+        perTask: [],
+        elapsedMs: 0,
+      },
+    });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    for (const row of rows) {
+      expect(row.getAttribute("draggable")).toBe("false");
+    }
+
+    fireEvent.dragStart(rows[0]);
+    fireEvent.dragOver(rows[2]);
+    fireEvent.drop(rows[2]);
+
+    expect(reorder).not.toHaveBeenCalled();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,3 +1,4 @@
+import { ReorderDndProvider } from "@/components/reorder-dnd";
 import { TaskRow } from "@/components/TaskRow";
 import { useJobStore } from "@/store/jobStore";
 
@@ -25,27 +26,29 @@ export function TaskList() {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            <th className="pb-2 pr-3 w-8">#</th>
-            <th className="pb-2 pr-3">Kind</th>
-            <th className="pb-2 pr-3">Source</th>
-            <th className="pb-2 pr-3">Output</th>
-            <th className="pb-2 pr-3">Status</th>
-            <th className="pb-2">Reorder</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((_item, i) => (
-            // rows are a positional, backend-ordered list with no per-row local state;
-            // item paths may legitimately duplicate, so index keys are correct here.
-            // oxlint-disable-next-line react/no-array-index-key
-            <TaskRow index={i} key={i} />
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <ReorderDndProvider>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <th className="pb-2 pr-3 w-8">#</th>
+              <th className="pb-2 pr-3">Kind</th>
+              <th className="pb-2 pr-3">Source</th>
+              <th className="pb-2 pr-3">Output</th>
+              <th className="pb-2 pr-3">Status</th>
+              <th className="pb-2">Reorder</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((_item, i) => (
+              // rows are a positional, backend-ordered list with no per-row local state;
+              // item paths may legitimately duplicate, so index keys are correct here.
+              // oxlint-disable-next-line react/no-array-index-key
+              <TaskRow index={i} key={i} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ReorderDndProvider>
   );
 }

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,7 +1,9 @@
+import { GripVertical } from "lucide-react";
 import { memo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type { SourceKind } from "@/bindings/SourceKind";
+import { useReorderRow } from "@/components/reorder-dnd";
 import { Progress } from "@/components/ui/progress";
 import { formatBytes, formatEta, progressPercent } from "@/lib/format";
 import { basename } from "@/lib/path";
@@ -87,14 +89,39 @@ function TaskRowImpl({ index }: TaskRowProps) {
     }),
   );
 
+  // Drag-and-drop reorder wiring. The dragged/drop-target flags re-render this
+  // row during an active drag only; a drag never overlaps a running job, so
+  // this does not interact with the per-tick render isolation above.
+  const dnd = useReorderRow(index);
+
   if (!row.exists) return null;
 
   // Build the live label as one string so JSX whitespace folding / prettier
   // reflow cannot strip the right-align padding spaces formatBytes emits.
   const liveLabel = `${formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} · ETA ${formatEta(row.liveEtaMs)}`;
 
+  // Drag affordances: grab cursor while draggable, dim the row being dragged,
+  // and highlight the row the pointer is currently over as the drop target.
+  const rowClassName = [
+    "border-b border-border/50 transition-colors",
+    dnd.draggable && "cursor-grab active:cursor-grabbing",
+    dnd.isDragging ? "opacity-40" : "hover:bg-muted/30",
+    dnd.isOver && "bg-primary/10",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <tr className="border-b border-border/50 hover:bg-muted/30 transition-colors">
+    <tr
+      draggable={dnd.draggable}
+      onDragStart={dnd.onDragStart}
+      onDragOver={dnd.onDragOver}
+      onDrop={dnd.onDrop}
+      onDragEnd={dnd.onDragEnd}
+      data-dragging={dnd.isDragging || undefined}
+      data-drop-target={dnd.isOver || undefined}
+      className={rowClassName}
+    >
       {/* Sequence number */}
       <td className="py-2 pr-3 text-muted-foreground font-mono">{index + 1}</td>
 
@@ -140,9 +167,15 @@ function TaskRowImpl({ index }: TaskRowProps) {
         )}
       </td>
 
-      {/* Reorder buttons */}
+      {/* Reorder: drag handle affordance + keyboard-accessible up/down buttons */}
       <td className="py-2">
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
+          <GripVertical
+            aria-hidden
+            className={`size-4 shrink-0 text-muted-foreground/60 ${
+              dnd.draggable ? "cursor-grab" : "opacity-30"
+            }`}
+          />
           <button
             type="button"
             aria-label="Move up"

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -1,0 +1,162 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type DragEvent,
+  type ReactNode,
+} from "react";
+
+import { useJobStore } from "@/store/jobStore";
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+type RowDragEvent = DragEvent<HTMLTableRowElement>;
+
+interface ReorderDndContextValue {
+  /** Whether rows may be dragged at all (false while a job is running). */
+  draggable: boolean;
+  /** Index of the row currently being dragged, or null. */
+  draggingIndex: number | null;
+  /** Index of the row currently hovered as the drop target, or null. */
+  overIndex: number | null;
+  start: (index: number, event: RowDragEvent) => void;
+  over: (index: number, event: RowDragEvent) => void;
+  drop: (index: number, event: RowDragEvent) => void;
+  end: () => void;
+}
+
+const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/**
+ * ReorderDndProvider owns the ephemeral drag state (which row is being dragged,
+ * which row is the current drop target) and translates a native HTML5
+ * drag-and-drop gesture into a single `reorder(from, to)` store action.
+ *
+ * The state lives here rather than in the global job store because it is
+ * purely transient UI state; it is only observed by the rows during an active
+ * drag, which never overlaps a running job (dragging is disabled then).
+ */
+export function ReorderDndProvider({ children }: { children: ReactNode }) {
+  const running = useJobStore((s) => s.running);
+  const reorder = useJobStore((s) => s.reorder);
+
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const draggable = !running;
+
+  const reset = useCallback(() => {
+    setDraggingIndex(null);
+    setOverIndex(null);
+  }, []);
+
+  const start = useCallback(
+    (index: number, event: RowDragEvent) => {
+      // Guard so a synthetic dragstart can never begin a drag mid-run.
+      if (running) return;
+      setDraggingIndex(index);
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        // A payload makes the gesture a valid native drag in every browser.
+        event.dataTransfer.setData("text/plain", String(index));
+      }
+    },
+    [running],
+  );
+
+  const over = useCallback((index: number, event: RowDragEvent) => {
+    // preventDefault is what marks this row as a valid drop target.
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    setOverIndex(index);
+  }, []);
+
+  const drop = useCallback(
+    (index: number, event: RowDragEvent) => {
+      event.preventDefault();
+      // Dropping a row onto index `to` lands it exactly at `to` (the store's
+      // reorder is a remove-then-insert), so the drop target index maps
+      // directly to the destination. Skip no-op and mid-run drops.
+      if (draggingIndex !== null && draggingIndex !== index && !running) {
+        void reorder(draggingIndex, index);
+      }
+      reset();
+    },
+    [draggingIndex, running, reorder, reset],
+  );
+
+  const value = useMemo<ReorderDndContextValue>(
+    () => ({
+      draggable,
+      draggingIndex,
+      overIndex,
+      start,
+      over,
+      drop,
+      end: reset,
+    }),
+    [draggable, draggingIndex, overIndex, start, over, drop, reset],
+  );
+
+  return (
+    <ReorderDndContext.Provider value={value}>
+      {children}
+    </ReorderDndContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row consumer hook
+// ---------------------------------------------------------------------------
+
+interface ReorderRow {
+  draggable: boolean;
+  isDragging: boolean;
+  isOver: boolean;
+  onDragStart: (event: RowDragEvent) => void;
+  onDragOver: (event: RowDragEvent) => void;
+  onDrop: (event: RowDragEvent) => void;
+  onDragEnd: () => void;
+}
+
+// Fallback for a row rendered outside a provider (e.g. an isolated unit test):
+// the row is simply not reorderable; its up/down buttons still work.
+const NON_DRAGGABLE_ROW: ReorderRow = {
+  draggable: false,
+  isDragging: false,
+  isOver: false,
+  onDragStart: () => {},
+  onDragOver: () => {},
+  onDrop: () => {},
+  onDragEnd: () => {},
+};
+
+/**
+ * useReorderRow returns the drag props and visual flags for the row at `index`.
+ * Outside a {@link ReorderDndProvider} the row falls back to non-draggable.
+ */
+export function useReorderRow(index: number): ReorderRow {
+  const ctx = useContext(ReorderDndContext);
+  if (ctx === null) {
+    return NON_DRAGGABLE_ROW;
+  }
+  const { draggable, draggingIndex, overIndex, start, over, drop, end } = ctx;
+  return {
+    draggable,
+    isDragging: draggingIndex === index,
+    // The dragged row is never its own drop target.
+    isOver: overIndex === index && draggingIndex !== index,
+    onDragStart: (event) => start(index, event),
+    onDragOver: (event) => over(index, event),
+    onDrop: (event) => drop(index, event),
+    onDragEnd: end,
+  };
+}


### PR DESCRIPTION
## Summary

The queue table could only be reordered one position at a time via the ▲/▼ buttons. This adds native mouse drag-and-drop: grab any row and drop it onto another row to move it to that position in a single gesture. The ▲/▼ buttons stay for keyboard/accessible reordering, and no new dependency is introduced.

## Background / Motivation

- Reordering a long queue with the ▲/▼ buttons takes one click per position — moving an item from the bottom to the top means many clicks.
- The backend `reorder(from, to)` command already supports arbitrary moves (remove-then-insert), but the UI only ever invoked it with adjacent indices (`index ± 1`), so the multi-position capability was unreachable.
- `TaskRow`'s per-row render isolation (a `useShallow` selector flattened to scalars, so a progress tick only re-renders rows whose bytes changed) must not be disturbed, so the new drag state cannot live on the high-frequency progress path.

## Changes

### Drag-and-drop context (new module)

- `src/components/reorder-dnd.tsx`: new `ReorderDndProvider` + `useReorderRow(index)` hook. The provider owns ephemeral drag state (`draggingIndex`, `overIndex`) and reads `running` / `reorder` from the job store.
- A native HTML5 gesture (`dragstart` → `dragover` → `drop`) is translated into a single `reorder(from, to)` store action. Dropping a row onto index `to` lands it exactly at `to` (the store's reorder is a remove-then-insert), so the drop-target index maps directly to the destination; no-op (`from === to`) and mid-run drops are skipped.
- Drag state lives here rather than in the global store because it is purely transient UI state observed only during an active drag — which never overlaps a running job (dragging is disabled then) — keeping it off the progress-tick render path.
- Outside a provider (isolated unit tests) `useReorderRow` falls back to a non-draggable row, so `TaskRow` stays renderable standalone.

### Queue table wiring

- `src/components/TaskList.tsx`: wrap the table in `ReorderDndProvider`.
- `src/components/TaskRow.tsx`: the `<tr>` becomes `draggable` (disabled while a job runs) with `onDragStart/Over/Drop/DragEnd` handlers and `data-dragging` / `data-drop-target` attributes. Visual feedback: `cursor-grab`, the dragged row dims (`opacity-40`), the drop target highlights (`bg-primary/10`), plus a `GripVertical` (lucide) handle affordance in the Reorder column.

### Tests

- `src/components/TaskList.test.tsx`: added drag-and-drop cases — rows draggable when idle; drop onto a lower/higher row calls `reorder(from, to)`; drop onto self is a no-op; the hovered row is marked `data-drop-target` while another row is dragged; drag state clears on `dragend`; dragging disabled while a job runs.

## Verification

- Add 3+ items, then drag a row (by any cell or the grip handle) and drop it onto another row — it moves to that row's position and the output preview names recompute. The ▲/▼ buttons still reorder one step.
- While a run is in progress, rows are not draggable (`draggable="false"`), consistent with the disabled ▲/▼ buttons.
- DOM: the row being dragged carries `data-dragging="true"`; the current drop target carries `data-drop-target="true"`.
- Frontend gates green by exit code: `pnpm test` (358 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 358 passed, including the new drag-and-drop cases
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: drag a row onto another and confirm it lands at that position; confirm ▲/▼ still work and dragging is disabled mid-run
