### PR TITLE
feat(ui): move Clear/New batch action beside Run

### DIFF
--- a/src/components/ResetButton.test.tsx
+++ b/src/components/ResetButton.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { ResetButton } from "./ResetButton";
+
+// Minimal DraftItemDto stub.
+const ITEM = { path: "/a.rar", kind: "rar" as const };
+
+// A draft with N items; the other fields are the store defaults.
+function draftWith(items: { path: string; kind: "rar" }[]) {
+  return {
+    items,
+    namingTemplate: null,
+    startNumber: 1,
+    outputDir: null,
+    outputMode: "zip" as const,
+    conflictPolicy: "autoRename" as const,
+  };
+}
+
+describe("ResetButton – visibility", () => {
+  beforeEach(() => resetJobStore());
+
+  it("renders nothing when the queue is empty (not running)", () => {
+    render(<ResetButton />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
+  it("renders nothing when the queue is empty and running", () => {
+    useJobStore.setState({ running: true });
+    render(<ResetButton />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
+  it("shows the action when hasItems and not running (no summary)", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+    });
+    render(<ResetButton />);
+    expect(screen.getByRole("button", { name: /clear/i })).toBeTruthy();
+  });
+
+  it("renders nothing when hasItems but running", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: true,
+      summary: null,
+    });
+    render(<ResetButton />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
+  it("shows the action after a job finishes (summary set, hasItems, not running)", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
+    });
+    render(<ResetButton />);
+    expect(screen.getByRole("button", { name: /new batch/i })).toBeTruthy();
+  });
+});
+
+describe("ResetButton – label", () => {
+  beforeEach(() => resetJobStore());
+
+  it("labels the button 'Clear' when summary is null", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+    });
+    render(<ResetButton />);
+    expect(screen.getByRole("button", { name: /^clear$/i })).toBeTruthy();
+  });
+
+  it("labels the button 'New batch' when summary is not null", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: {
+        succeeded: [],
+        cancelled: [],
+        failed: [{ taskId: 1, reason: "error" }],
+        results: [],
+      },
+    });
+    render(<ResetButton />);
+    expect(screen.getByRole("button", { name: /^new batch$/i })).toBeTruthy();
+  });
+});
+
+describe("ResetButton – confirm dialog", () => {
+  beforeEach(() => resetJobStore());
+
+  it("opens the dialog when the button is clicked", async () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("calls reset() once when the user confirms the dialog (Clear flow)", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /^clear$/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call reset() when the user cancels the dialog", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: /^cancel$/i,
+      }),
+    );
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("calls reset() once when confirming the 'New batch' dialog", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^new batch$/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /^new batch$/i }),
+    );
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call reset() when cancelling the 'New batch' dialog", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^new batch$/i }));
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: /^cancel$/i,
+      }),
+    );
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("closes the dialog after confirming", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: /^clear$/i,
+      }),
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes the dialog after cancelling", async () => {
+    const reset = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+      reset,
+    });
+    const user = userEvent.setup();
+    render(<ResetButton />);
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: /^cancel$/i,
+      }),
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -1,0 +1,99 @@
+import { RotateCcw } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useJobStore } from "@/store/jobStore";
+
+/** Content and labels for the confirm dialog, keyed by reset variant. */
+interface ResetDialogConfig {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
+const CLEAR_CONFIG: ResetDialogConfig = {
+  title: "Clear the queue?",
+  description:
+    "This removes all queued items. Your destination and naming are kept.",
+  confirmLabel: "Clear",
+  cancelLabel: "Cancel",
+};
+
+const NEW_BATCH_CONFIG: ResetDialogConfig = {
+  title: "Start a new batch?",
+  description:
+    "This clears the finished queue and summary. Your destination and naming are kept.",
+  confirmLabel: "New batch",
+  cancelLabel: "Cancel",
+};
+
+/**
+ * The queue reset action (Clear / New batch). It is visible only when there are
+ * queued items and no job is running, and opens a ConfirmDialog before calling
+ * the store's reset() so the user never accidentally clears the queue.
+ *
+ * Copy is summary-aware: "Clear" while a batch is being assembled, "New batch"
+ * once a run summary is present. This action used to live in the StatusBar
+ * footer; it now sits beside the Run control in the left rail so the queue's two
+ * verbs (reset vs run) share one row.
+ *
+ * It is fully self-contained (no props): it reads its visibility and the reset
+ * action from the store, so it is a drop-in wherever the run row is composed.
+ */
+export function ResetButton() {
+  const itemCount = useJobStore((s) => s.draft.items.length);
+  const hasSummary = useJobStore((s) => s.summary !== null);
+  const running = useJobStore((s) => s.running);
+  const reset = useJobStore((s) => s.reset);
+
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  const showReset = itemCount > 0 && !running;
+
+  // Choose dialog copy and the button label based on whether a finished summary
+  // is present.
+  const dialogConfig = hasSummary ? NEW_BATCH_CONFIG : CLEAR_CONFIG;
+  const buttonLabel = hasSummary ? "New batch" : "Clear";
+
+  function handleResetClick() {
+    setDialogOpen(true);
+  }
+
+  function handleConfirm() {
+    setDialogOpen(false);
+    void reset();
+  }
+
+  function handleCancel() {
+    setDialogOpen(false);
+  }
+
+  if (!showReset) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleResetClick}
+      >
+        <RotateCcw aria-hidden="true" />
+        {buttonLabel}
+      </Button>
+      <ConfirmDialog
+        open={dialogOpen}
+        title={dialogConfig.title}
+        description={dialogConfig.description}
+        confirmLabel={dialogConfig.confirmLabel}
+        cancelLabel={dialogConfig.cancelLabel}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </>
+  );
+}

--- a/src/components/RunControls.test.tsx
+++ b/src/components/RunControls.test.tsx
@@ -476,6 +476,92 @@ describe("RunControls – overwrite confirmation", () => {
   });
 });
 
+describe("RunControls – reset action placement", () => {
+  it("renders the Clear action beside Run when idle with items", () => {
+    useJobStore.setState({
+      draft: {
+        items: [ITEM],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: "/out",
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      running: false,
+      error: null,
+      summary: null,
+    });
+    render(<RunControls />);
+    const clear = screen.getByRole("button", { name: /^clear$/i });
+    const run = screen.getByRole("button", { name: /^run$/i });
+    expect(clear).toBeTruthy();
+    expect(run).toBeTruthy();
+    // Approved layout: the destructive reset sits left of the primary Run, so
+    // Clear must precede Run in document order.
+    expect(
+      clear.compareDocumentPosition(run) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders the New batch action beside Run when a summary is present", () => {
+    useJobStore.setState({
+      draft: {
+        items: [ITEM],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: "/out",
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      running: false,
+      error: null,
+      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
+    });
+    render(<RunControls />);
+    expect(screen.getByRole("button", { name: /^new batch$/i })).toBeTruthy();
+  });
+
+  it("does not render the reset action when the queue is empty", () => {
+    useJobStore.setState({
+      draft: {
+        items: [],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: "/out",
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      running: false,
+      error: null,
+      summary: null,
+    });
+    render(<RunControls />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
+  it("does not render the reset action while running", () => {
+    useJobStore.setState({
+      draft: {
+        items: [ITEM],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: "/out",
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      running: true,
+      error: null,
+      summary: null,
+    });
+    render(<RunControls />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+});
+
 describe("RunControls – Cancel button", () => {
   it("does not render Cancel when not running", () => {
     useJobStore.setState({

--- a/src/components/RunControls.tsx
+++ b/src/components/RunControls.tsx
@@ -1,6 +1,7 @@
 import { Check, CircleDot, Play } from "lucide-react";
 import * as React from "react";
 
+import { ResetButton } from "@/components/ResetButton";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -44,9 +45,15 @@ function ReadinessChip({ readiness }: { readiness: Readiness }) {
 }
 
 /**
- * RunControls renders the primary job action for the current state:
- *   - idle  (running === false): Run only (Cancel is not in the DOM).
- *   - active (running === true): Cancel only (Run is not in the DOM).
+ * RunControls renders the queue's run row for the current state:
+ *   - idle  (running === false): the reset action (Clear / New batch) anchored
+ *     left, with the readiness chip + Run grouped at the right edge.
+ *   - active (running === true): Cancel only (Run is not in the DOM), kept at the
+ *     right edge so the primary button does not jump when toggling Run↔Cancel.
+ *
+ * The destructive reset action and the primary brand Run sit at opposite ends of
+ * the row to minimise misclicks; the right group is pushed right with `ml-auto`
+ * so Run stays anchored even when the reset action is hidden (empty queue).
  *
  * Run retains full accessible-disabled semantics (aria-disabled / aria-describedby /
  * sr-only reason span / title / handler guard) so assistive technology can announce
@@ -103,8 +110,10 @@ export function RunControls() {
   }
 
   if (running) {
+    // Cancel sits at the right edge, where Run was, so the primary button keeps
+    // its position across the Run↔Cancel toggle.
     return (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center justify-end gap-2">
         <Button type="button" variant="outline" onClick={handleCancel}>
           Cancel
         </Button>
@@ -114,24 +123,30 @@ export function RunControls() {
 
   return (
     <div className="flex items-center gap-2">
-      <ReadinessChip readiness={readiness} />
-      <Button
-        type="button"
-        variant="brand"
-        aria-disabled={runDisabled || undefined}
-        aria-describedby={runDisabled ? RUN_REASON_ID : undefined}
-        title={runReason || undefined}
-        className={cn(runDisabled && "opacity-50")}
-        onClick={handleRun}
-      >
-        <Play aria-hidden="true" />
-        Run
-      </Button>
-      {runDisabled ? (
-        <span id={RUN_REASON_ID} className="sr-only">
-          {runReason}
-        </span>
-      ) : null}
+      {/* Destructive reset at the left edge, kept clear of the primary CTA. It
+          renders nothing when the queue is empty; the right group's ml-auto then
+          keeps Run anchored right with no positional jump. */}
+      <ResetButton />
+      <div className="ml-auto flex items-center gap-2">
+        <ReadinessChip readiness={readiness} />
+        <Button
+          type="button"
+          variant="brand"
+          aria-disabled={runDisabled || undefined}
+          aria-describedby={runDisabled ? RUN_REASON_ID : undefined}
+          title={runReason || undefined}
+          className={cn(runDisabled && "opacity-50")}
+          onClick={handleRun}
+        >
+          <Play aria-hidden="true" />
+          Run
+        </Button>
+        {runDisabled ? (
+          <span id={RUN_REASON_ID} className="sr-only">
+            {runReason}
+          </span>
+        ) : null}
+      </div>
       <ConfirmDialog
         open={confirmOpen}
         title="Overwrite existing folders?"

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
@@ -124,29 +123,15 @@ describe("StatusBar", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Reset slot — visibility
+// Reset action — relocated to RunControls (regression guard)
 // ---------------------------------------------------------------------------
 
-describe("StatusBar Reset slot – visibility", () => {
+describe("StatusBar – reset action moved out", () => {
   beforeEach(() => resetJobStore());
 
-  it("does not show Reset when items is empty (not running)", () => {
-    // default state: no items, not running
-    render(<StatusBar />);
-    expect(
-      screen.queryByRole("button", { name: /clear|new batch/i }),
-    ).toBeNull();
-  });
-
-  it("does not show Reset when items is empty and running", () => {
-    useJobStore.setState({ running: true });
-    render(<StatusBar />);
-    expect(
-      screen.queryByRole("button", { name: /clear|new batch/i }),
-    ).toBeNull();
-  });
-
-  it("shows Reset when hasItems and not running (no summary)", () => {
+  // The Clear / New batch action moved to RunControls (beside Run). The slim
+  // footer must no longer render it, in any queue/summary state.
+  it("does not render a Clear/New batch button when items are queued", () => {
     useJobStore.setState({
       draft: {
         items: [ITEM],
@@ -160,29 +145,12 @@ describe("StatusBar Reset slot – visibility", () => {
       summary: null,
     });
     render(<StatusBar />);
-    expect(screen.getByRole("button", { name: /clear/i })).toBeTruthy();
-  });
-
-  it("does not show Reset when hasItems but running", () => {
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: true,
-      summary: null,
-    });
-    render(<StatusBar />);
     expect(
       screen.queryByRole("button", { name: /clear|new batch/i }),
     ).toBeNull();
   });
 
-  it("shows Reset after job finishes (summary set, hasItems, not running)", () => {
+  it("does not render a Clear/New batch button after a job finishes", () => {
     useJobStore.setState({
       draft: {
         items: [ITEM],
@@ -196,237 +164,8 @@ describe("StatusBar Reset slot – visibility", () => {
       summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
     });
     render(<StatusBar />);
-    expect(screen.getByRole("button", { name: /new batch/i })).toBeTruthy();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Reset slot — label
-// ---------------------------------------------------------------------------
-
-describe("StatusBar Reset slot – label", () => {
-  beforeEach(() => resetJobStore());
-
-  it("labels the button 'Clear' when summary is null", () => {
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-    });
-    render(<StatusBar />);
-    expect(screen.getByRole("button", { name: /^clear$/i })).toBeTruthy();
-  });
-
-  it("labels the button 'New batch' when summary is not null", () => {
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: {
-        succeeded: [],
-        cancelled: [],
-        failed: [{ taskId: 1, reason: "error" }],
-        results: [],
-      },
-    });
-    render(<StatusBar />);
-    expect(screen.getByRole("button", { name: /^new batch$/i })).toBeTruthy();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Reset slot — ConfirmDialog flow
-// ---------------------------------------------------------------------------
-
-describe("StatusBar Reset slot – confirm dialog", () => {
-  beforeEach(() => resetJobStore());
-
-  it("opens the dialog when the Reset button is clicked", async () => {
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    expect(screen.queryByRole("dialog")).toBeNull();
-    await user.click(screen.getByRole("button", { name: /^clear$/i }));
-    expect(screen.getByRole("dialog")).toBeTruthy();
-  });
-
-  it("calls reset() once when the user confirms the dialog (Clear flow)", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^clear$/i }));
-    // The confirm button inside the dialog: scope to dialog to avoid ambiguity.
-    const dialog = screen.getByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: /^clear$/i }));
-    expect(reset).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not call reset() when the user cancels the dialog", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^clear$/i }));
-    await user.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
-        name: /^cancel$/i,
-      }),
-    );
-    expect(reset).not.toHaveBeenCalled();
-  });
-
-  it("calls reset() once when confirming the 'New batch' dialog", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^new batch$/i }));
-    // Scope to the dialog to avoid ambiguity with the footer Reset button.
-    const dialog = screen.getByRole("dialog");
-    await user.click(
-      within(dialog).getByRole("button", { name: /^new batch$/i }),
-    );
-    expect(reset).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not call reset() when cancelling the 'New batch' dialog", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^new batch$/i }));
-    await user.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
-        name: /^cancel$/i,
-      }),
-    );
-    expect(reset).not.toHaveBeenCalled();
-  });
-
-  it("closes the dialog after confirming", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^clear$/i }));
-    expect(screen.getByRole("dialog")).toBeTruthy();
-    await user.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
-        name: /^clear$/i,
-      }),
-    );
-    expect(screen.queryByRole("dialog")).toBeNull();
-  });
-
-  it("closes the dialog after cancelling", async () => {
-    const reset = vi.fn().mockResolvedValue(undefined);
-    useJobStore.setState({
-      draft: {
-        items: [ITEM],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: null,
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      summary: null,
-      reset,
-    });
-    const user = userEvent.setup();
-    render(<StatusBar />);
-    await user.click(screen.getByRole("button", { name: /^clear$/i }));
-    expect(screen.getByRole("dialog")).toBeTruthy();
-    await user.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
-        name: /^cancel$/i,
-      }),
-    );
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
   });
 });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,126 +1,43 @@
-import { RotateCcw } from "lucide-react";
-import * as React from "react";
-
-import { Button } from "@/components/ui/button";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { verbForMode } from "@/lib/wording";
 import { useJobStore } from "@/store/jobStore";
 
-/** Content and labels for the confirm dialog, keyed by reset variant. */
-interface ResetDialogConfig {
-  title: string;
-  description: string;
-  confirmLabel: string;
-  cancelLabel: string;
-}
-
-const CLEAR_CONFIG: ResetDialogConfig = {
-  title: "Clear the queue?",
-  description:
-    "This removes all queued items. Your destination and naming are kept.",
-  confirmLabel: "Clear",
-  cancelLabel: "Cancel",
-};
-
-const NEW_BATCH_CONFIG: ResetDialogConfig = {
-  title: "Start a new batch?",
-  description:
-    "This clears the finished queue and summary. Your destination and naming are kept.",
-  confirmLabel: "New batch",
-  cancelLabel: "Cancel",
-};
-
 /**
  * The slim status footer (AppShell's `statusBar` slot). It is a quiet status
- * line plus the queue Reset/Clear action. The aggregate progress bar and the
- * run summary no longer live here — they render in the right canvas (the
- * morphing work area), so the footer stays slim.
+ * line only. The aggregate progress bar and the run summary render in the right
+ * canvas (the morphing work area), and the queue reset action (Clear / New
+ * batch) now lives beside Run in the left rail (see {@link ResetButton}), so the
+ * footer stays slim.
  *
- * The left slot shows a quiet hint: a Ready/queued-count line when idle, and an
- * sr-only mode-aware live announcement ("extracted N" / "archived N") while a
- * job is in flight so screen-reader users hear mode-aware progress copy.
- *
- * The right slot holds a Reset button that is visible when there are queued
- * items and no job is running. It opens a ConfirmDialog before calling the
- * store's reset() action so the user never accidentally clears the queue.
+ * It shows a quiet hint: a Ready/queued-count line when idle, plus an sr-only
+ * mode-aware live announcement ("extracted N" / "archived N") while a job is in
+ * flight so screen-reader users hear mode-aware progress copy.
  */
 export function StatusBar() {
   const itemCount = useJobStore((s) => s.draft.items.length);
   const outputMode = useJobStore((s) => s.draft.outputMode);
   const hasProgress = useJobStore((s) => s.progress !== null);
   const hasSummary = useJobStore((s) => s.summary !== null);
-  const running = useJobStore((s) => s.running);
-  const reset = useJobStore((s) => s.reset);
 
   // Mode-aware verb: "extracted" in Folder mode vs "archived" in Zip mode. Used
   // for the live progress announcement below.
   const verb = verbForMode(outputMode);
 
-  const [dialogOpen, setDialogOpen] = React.useState(false);
-
-  const hasItems = itemCount > 0;
-  const showReset = hasItems && !running;
-
-  // Choose dialog copy based on whether a finished summary is present.
-  const dialogConfig = hasSummary ? NEW_BATCH_CONFIG : CLEAR_CONFIG;
-  const buttonLabel = hasSummary ? "New batch" : "Clear";
-
-  function handleResetClick() {
-    setDialogOpen(true);
-  }
-
-  function handleConfirm() {
-    setDialogOpen(false);
-    void reset();
-  }
-
-  function handleCancel() {
-    setDialogOpen(false);
-  }
-
   return (
-    <>
-      <div className="flex items-center justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          {/* While a job is in flight (progress, no summary yet) announce the
-              mode-aware action so screen-reader users hear "extracted"/"archived".
-              The visible aggregate bar lives in the canvas; this footer only
-              carries the sr-only line. */}
-          {hasProgress && !hasSummary ? (
-            <p className="sr-only" aria-live="polite">
-              {verb} {itemCount}
-            </p>
-          ) : null}
-          <p className="text-xs text-muted-foreground">
-            {itemCount === 0
-              ? "Ready — add files or folders to begin."
-              : `${itemCount} item${itemCount === 1 ? "" : "s"} queued`}
-          </p>
-        </div>
-        {/* Reset slot — fixed height to avoid footer reflow when it appears/disappears. */}
-        <div className="flex h-8 shrink-0 items-center">
-          {showReset && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleResetClick}
-            >
-              <RotateCcw aria-hidden="true" />
-              {buttonLabel}
-            </Button>
-          )}
-        </div>
-      </div>
-      <ConfirmDialog
-        open={dialogOpen}
-        title={dialogConfig.title}
-        description={dialogConfig.description}
-        confirmLabel={dialogConfig.confirmLabel}
-        cancelLabel={dialogConfig.cancelLabel}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-      />
-    </>
+    <div className="min-w-0">
+      {/* While a job is in flight (progress, no summary yet) announce the
+          mode-aware action so screen-reader users hear "extracted"/"archived".
+          The visible aggregate bar lives in the canvas; this footer only
+          carries the sr-only line. */}
+      {hasProgress && !hasSummary ? (
+        <p className="sr-only" aria-live="polite">
+          {verb} {itemCount}
+        </p>
+      ) : null}
+      <p className="text-xs text-muted-foreground">
+        {itemCount === 0
+          ? "Ready — add files or folders to begin."
+          : `${itemCount} item${itemCount === 1 ? "" : "s"} queued`}
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The queue reset action (the `Clear` / `New batch` button) lived in the slim `StatusBar` footer at the far bottom-right of the window, physically distant from the primary `Run` at the foot of the left rail. This relocates it into the run row itself: a new self-contained `ResetButton` is anchored at the **left** edge while the readiness chip + `Run` group stay anchored **right** via `ml-auto`, so the queue's two verbs — reset and run — share one row without the destructive action crowding the primary CTA.

## Background / Motivation

- The reset button sat in the bottom-right footer while `Run` sat in the bottom-left rail, so "clear and start over" meant crossing the window away from where the eye already was when deciding to run.
- The slim footer mixed a quiet status surface (Ready hint / queued count + sr-only live announcement) with an interactive destructive control, overloading a region meant to stay slim.
- The reset confirm-dialog logic lived inline in `StatusBar`, coupling the footer to the queue-mutation flow and keeping it from being placed anywhere else.

## Changes

### New `ResetButton` component

- `src/components/ResetButton.tsx`: extracts the Clear/New batch button + its `ConfirmDialog` and summary-aware copy (`CLEAR_CONFIG` / `NEW_BATCH_CONFIG`) into a self-contained, prop-less unit that reads visibility and `reset()` from the store. Renders only when `items > 0 && !running`; returns `null` otherwise, so it is a drop-in wherever the run row is composed.

### `RunControls` — reset beside Run (split row)

- `src/components/RunControls.tsx`: the idle branch now composes `<ResetButton />` at the left edge with the readiness chip + `Run` grouped at the right edge (`ml-auto`). The destructive reset and the primary brand `Run` sit at opposite ends to minimise misclicks, complementing the existing confirm dialog; the chip stays glued to `Run` (it describes Run's state).
- `ml-auto` keeps `Run` anchored right whether or not `Clear` is shown (empty queue hides it), so the primary button never jumps horizontally. The running branch right-aligns `Cancel` (`justify-end`) so the primary button keeps its position across the Run↔Cancel toggle.

### `StatusBar` — slimmed to a status line

- `src/components/StatusBar.tsx`: drops the reset button, its `ConfirmDialog`, the dialog config, and the `running`/`reset`/`hasSummary` store reads that only fed it. Keeps the Ready-hint / queued-count line and the sr-only mode-aware live announcement (`extracted N` / `archived N`).

### Tests

- `ResetButton.test.tsx` (new): visibility (items × running × summary), label (`Clear` vs `New batch`), and the full confirm-dialog flow (open / confirm calls `reset()` once / cancel does not / closes after either), ported from the old `StatusBar` reset suite.
- `RunControls.test.tsx`: reset action appears beside `Run` when idle with items, shows `New batch` once a summary exists, is absent when empty or running, and `Clear` precedes `Run` in document order (locks the approved left/right layout).
- `StatusBar.test.tsx`: removed the three reset-slot suites; added a regression guard that the footer no longer renders a Clear/New batch button in any queue/summary state.

## Verification

- In the left rail's run row, the reset action sits at the left edge and `[Ready] Run` at the right edge; the footer shows only the status line. Clear is hidden when the queue is empty and while a run is in flight (Cancel only).
- DOM: `rg "ml-auto" src/components/RunControls.tsx` shows the right-anchored group; `rg "ResetButton" src/components/RunControls.tsx` confirms composition.
- FE gates green by exit code: `pnpm test` (357 passed), `pnpm build` (tsc + vite), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm knip`. FE-only change; no Rust / bindings touched.

## Test plan

- [x] `pnpm test` — 357 passed (39 files), including the new `ResetButton` suite, the RunControls placement/order cases, and the StatusBar regression guard
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: with items queued, confirm Clear sits left of Run; click Clear → "Clear the queue?" → confirm empties the queue; after a run, the button reads "New batch"; start a run and confirm only Cancel shows (no Clear)
