### PR TITLE
feat(ui): per-row delete in the archive queue (PR1)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub fn run() {
             presentation::commands::preview_output_name,
             presentation::commands::add_items,
             presentation::commands::reorder,
+            presentation::commands::remove_item,
             presentation::commands::set_naming_rule,
             presentation::commands::set_start_number,
             presentation::commands::set_output_dir,

--- a/src-tauri/src/presentation/commands.rs
+++ b/src-tauri/src/presentation/commands.rs
@@ -80,6 +80,14 @@ pub fn reorder(
     Ok(draft.snapshot())
 }
 
+/// Remove the draft item at `index`, returning the new snapshot.
+#[tauri::command]
+pub fn remove_item(state: State<'_, AppState>, index: usize) -> Result<DraftSnapshot, String> {
+    let mut draft = state.draft.lock().map_err(|e| e.to_string())?;
+    draft.remove_item(index)?;
+    Ok(draft.snapshot())
+}
+
 /// Set the draft's naming template, returning the new snapshot.
 #[tauri::command]
 pub fn set_naming_rule(

--- a/src-tauri/src/presentation/state.rs
+++ b/src-tauri/src/presentation/state.rs
@@ -98,6 +98,21 @@ impl JobDraft {
         Ok(())
     }
 
+    /// Remove the item at `index` (0-based).
+    ///
+    /// Returns an error message if the index is out of range. Leaves the
+    /// template, start number, and output settings untouched.
+    pub fn remove_item(&mut self, index: usize) -> Result<(), String> {
+        let len = self.items.len();
+        if index >= len {
+            return Err(format!(
+                "remove_item: index {index} is out of range (len = {len})"
+            ));
+        }
+        self.items.remove(index);
+        Ok(())
+    }
+
     /// Set the naming template, validating it with [`NamingRule::parse`].
     ///
     /// On success the validated template string and its parsed [`NamingRule`]
@@ -400,6 +415,87 @@ mod tests {
         assert!(
             err.contains("from"),
             "error on empty draft should mention `from`: {err}"
+        );
+    }
+
+    // ── remove_item ───────────────────────────────────────────────────────────
+
+    /// Removing a middle item shifts the rest down to close the gap.
+    #[test]
+    fn remove_item_in_range_shifts_remaining() {
+        let mut draft = JobDraft::new();
+        draft.add_items(vec![
+            SourceItem::Folder(PathBuf::from("/first")),
+            SourceItem::Folder(PathBuf::from("/second")),
+            SourceItem::Folder(PathBuf::from("/third")),
+        ]);
+        // Remove the middle item at index 1.
+        draft.remove_item(1).expect("remove_item should succeed");
+        let snap = draft.snapshot();
+        assert_eq!(snap.items.len(), 2);
+        assert_eq!(snap.items[0].path, "/first");
+        assert_eq!(snap.items[1].path, "/third");
+    }
+
+    /// An index that equals the length is out of range; the error message
+    /// mentions both the index and the length.
+    #[test]
+    fn remove_item_out_of_range_returns_err() {
+        let mut draft = JobDraft::new();
+        draft.add_items(vec![SourceItem::Folder(PathBuf::from("/a"))]);
+        let result = draft.remove_item(1); // len is 1, index 1 is OOB
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains('1'), "error should mention the index: {msg}");
+        assert!(
+            msg.contains("len"),
+            "error should mention the length: {msg}"
+        );
+    }
+
+    /// Removing an item preserves the naming template, start number, and output
+    /// directory that were already configured.
+    #[test]
+    fn remove_item_preserves_template_start_and_out_dir() {
+        let mut draft = JobDraft::new();
+        draft.add_items(vec![
+            SourceItem::RarFile(PathBuf::from("/a.rar")),
+            SourceItem::Folder(PathBuf::from("/b")),
+        ]);
+        draft
+            .set_template("photo_{n:03}".to_string())
+            .expect("valid template should be accepted");
+        draft.set_start_number(5);
+        draft.set_out_dir(PathBuf::from("/output"));
+
+        draft.remove_item(0).expect("remove_item should succeed");
+
+        let snap = draft.snapshot();
+        assert_eq!(snap.items.len(), 1, "one item must remain after remove");
+        assert_eq!(
+            snap.naming_template,
+            Some("photo_{n:03}".to_string()),
+            "naming_template must be preserved"
+        );
+        assert_eq!(snap.start_number, 5, "start_number must be preserved");
+        assert_eq!(
+            snap.output_dir,
+            Some("/output".to_string()),
+            "output_dir must be preserved"
+        );
+    }
+
+    /// Removing the only item leaves `items` empty.
+    #[test]
+    fn remove_item_removing_only_item_leaves_empty() {
+        let mut draft = JobDraft::new();
+        draft.add_items(vec![SourceItem::Folder(PathBuf::from("/only"))]);
+        draft.remove_item(0).expect("remove_item should succeed");
+        let snap = draft.snapshot();
+        assert_eq!(
+            snap.items.len(),
+            0,
+            "items must be empty after removing only"
         );
     }
 

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -65,6 +65,24 @@ describe("TaskList rendering", () => {
     expect(screen.getByText("out_003.zip")).toBeTruthy();
   });
 
+  it("labels the last column header 'Actions'", () => {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(1),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+    });
+
+    render(<TaskList />);
+
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeTruthy();
+  });
+
   it("renders empty state message when items list is empty", () => {
     useJobStore.setState({
       draft: {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -34,7 +34,7 @@ export function TaskList() {
             <th className="pb-2 pr-3">Source</th>
             <th className="pb-2 pr-3">Output</th>
             <th className="pb-2 pr-3">Status</th>
-            <th className="pb-2">Reorder</th>
+            <th className="pb-2">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/TaskRow.test.tsx
+++ b/src/components/TaskRow.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
@@ -79,5 +80,83 @@ describe("TaskRow", () => {
     });
     renderRow(0);
     expect(screen.getByRole("progressbar")).toBeTruthy();
+  });
+
+  it("renders a delete button labelled with the row's basename and the Trash2 icon", () => {
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+    });
+    renderRow(0);
+
+    const remove = screen.getByRole("button", {
+      name: "Remove archive.rar from queue",
+    });
+    expect(remove).toBeTruthy();
+    // lucide-react renders an inline <svg> with a class derived from the icon
+    // name; assert the Trash2 glyph specifically (not the reorder ▲▼ glyphs).
+    expect(remove.querySelector("svg.lucide-trash2")).toBeTruthy();
+  });
+
+  it("calls removeItem with the row index when the delete button is clicked", async () => {
+    const removeItem = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: {
+        items: [
+          { path: "/a.rar", kind: "rar" },
+          { path: "/home/user/archive.rar", kind: "rar" },
+        ],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip", "out_002.zip"],
+      removeItem,
+    });
+
+    const user = userEvent.setup();
+    renderRow(1);
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove archive.rar from queue" }),
+    );
+
+    expect(removeItem).toHaveBeenCalledWith(1);
+  });
+
+  it("disables the delete button while a job is running", () => {
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      running: true,
+      progress: {
+        overall: { bytesDone: 0, bytesTotal: 0 },
+        overallEtaMs: null,
+        perTask: [],
+        elapsedMs: 0,
+      },
+    });
+    renderRow(0);
+
+    const remove = screen.getByRole("button", {
+      name: "Remove archive.rar from queue",
+    }) as HTMLButtonElement;
+    expect(remove.disabled).toBe(true);
   });
 });

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,3 +1,4 @@
+import { Trash2 } from "lucide-react";
 import { memo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
@@ -24,6 +25,12 @@ const KIND_BADGE_COLORS: Record<SourceKind, string> = {
 // Styling shared by both reorder buttons (Move up / Move down).
 const REORDER_BUTTON_CLASS =
   "rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors";
+
+// The delete button reuses REORDER_BUTTON_CLASS for size/weight parity with its
+// column mates, but its danger color appears only on hover so a resting row
+// stays calm. The extra left margin sets it apart from "Move down" to reduce
+// mis-clicks.
+const DELETE_BUTTON_CLASS = `${REORDER_BUTTON_CLASS} ml-1.5 hover:text-status-danger-foreground`;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -74,6 +81,8 @@ function TaskRowImpl({ index }: TaskRowProps) {
         // The action reference is stable across renders, so it is safe to
         // return directly for shallow comparison.
         reorder: s.reorder,
+        // Same stability guarantee as `reorder`, safe for the shallow compare.
+        removeItem: s.removeItem,
         // Compute the text status here so the selector exposes a flat string
         // rather than the progress/summary/taskIdByIndex collections.
         status: computeStatus(
@@ -140,9 +149,9 @@ function TaskRowImpl({ index }: TaskRowProps) {
         )}
       </td>
 
-      {/* Reorder buttons */}
+      {/* Actions: reorder buttons + delete */}
       <td className="py-2">
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
           <button
             type="button"
             aria-label="Move up"
@@ -160,6 +169,18 @@ function TaskRowImpl({ index }: TaskRowProps) {
             className={REORDER_BUTTON_CLASS}
           >
             ▼
+          </button>
+          {/* Delete: removes this single row. Disabled while running because
+              dropping a row mid-run would desync the positional progress
+              arrays. Enabled even when it is the only remaining row. */}
+          <button
+            type="button"
+            aria-label={`Remove ${basename(row.path)} from queue`}
+            disabled={row.running}
+            onClick={() => row.removeItem(index)}
+            className={DELETE_BUTTON_CLASS}
+          >
+            <Trash2 aria-hidden="true" className="size-4" />
           </button>
         </div>
       </td>

--- a/src/lib/archive.ts
+++ b/src/lib/archive.ts
@@ -27,6 +27,14 @@ export function reorder(from: number, to: number): Promise<DraftSnapshot> {
 }
 
 /**
+ * Remove the draft item at `index`.
+ * Returns the updated draft snapshot.
+ */
+export function removeItem(index: number): Promise<DraftSnapshot> {
+  return invoke<DraftSnapshot>("remove_item", { index });
+}
+
+/**
  * Set the naming-rule template used when generating output filenames.
  * Returns the updated draft snapshot.
  */

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -8,6 +8,7 @@ import type { ProgressEvent } from "@/bindings/ProgressEvent";
 vi.mock("@/lib/archive", () => ({
   addItems: vi.fn(),
   reorder: vi.fn(),
+  removeItem: vi.fn(),
   setNamingRule: vi.fn(),
   setStartNumber: vi.fn(),
   setOutputDir: vi.fn(),
@@ -224,6 +225,75 @@ describe("reorder", () => {
     mockArchive.reorder.mockRejectedValue(new Error("bad index"));
 
     await useJobStore.getState().reorder(9, 0);
+
+    expect(useJobStore.getState().error).toBe("bad index");
+    expect(useJobStore.getState().draft).toEqual(INITIAL_DRAFT);
+  });
+});
+
+describe("removeItem", () => {
+  it("calls archive.removeItem with the index and replaces the draft", async () => {
+    const draft = makeDraft(2);
+    mockArchive.removeItem.mockResolvedValue(draft);
+
+    await useJobStore.getState().removeItem(1);
+
+    expect(mockArchive.removeItem).toHaveBeenCalledWith(1);
+    expect(useJobStore.getState().draft).toEqual(draft);
+  });
+
+  it("recomputes previews so the # sequence and names shift up", async () => {
+    // Removing a row renumbers every row below it, so the store must recompute
+    // previews against the new, shorter item list (start + i for each item).
+    const draft = makeDraft(2, "photo_{n:03}");
+    mockArchive.removeItem.mockResolvedValue(draft);
+    mockArchive.previewOutputName.mockImplementation((_template, seq) =>
+      Promise.resolve(`photo_${String(seq).padStart(3, "0")}.zip`),
+    );
+
+    await useJobStore.getState().removeItem(0);
+
+    // One call per remaining item, sequential from the start number.
+    expect(useJobStore.getState().previewNames).toEqual([
+      "photo_001.zip",
+      "photo_002.zip",
+    ]);
+  });
+
+  it("clears stale finished-job result state on success", async () => {
+    // Like reorder, removing a row invalidates the positionally-aligned verdicts
+    // (summary/progress/taskIdByIndex) from any prior finished job.
+    const summary: JobSummaryDto = {
+      succeeded: [10],
+      cancelled: [],
+      failed: [{ taskId: 11, reason: "boom" }],
+      results: [],
+    };
+    const progress: ProgressEvent = {
+      overall: { bytesDone: 100, bytesTotal: 100 },
+      perTask: [
+        { taskId: 10, bytesDone: 50, bytesTotal: 50, etaMs: null },
+        { taskId: 11, bytesDone: 50, bytesTotal: 50, etaMs: null },
+      ],
+      elapsedMs: 5,
+      overallEtaMs: null,
+    };
+    useJobStore.setState({ summary, progress, taskIdByIndex: [10, 11] });
+
+    const draft = makeDraft(1, null);
+    mockArchive.removeItem.mockResolvedValue(draft);
+
+    await useJobStore.getState().removeItem(0);
+
+    expect(useJobStore.getState().summary).toBeNull();
+    expect(useJobStore.getState().progress).toBeNull();
+    expect(useJobStore.getState().taskIdByIndex).toEqual([]);
+  });
+
+  it("sets error and leaves the draft unchanged on failure", async () => {
+    mockArchive.removeItem.mockRejectedValue(new Error("bad index"));
+
+    await useJobStore.getState().removeItem(9);
 
     expect(useJobStore.getState().error).toBe("bad index");
     expect(useJobStore.getState().draft).toEqual(INITIAL_DRAFT);

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -106,6 +106,8 @@ export interface JobState {
   addItems: (paths: string[]) => Promise<void>;
   /** Move the draft item at `from` to `to`, then recompute previews. */
   reorder: (from: number, to: number) => Promise<void>;
+  /** Remove the draft item at `index`, then recompute previews. */
+  removeItem: (index: number) => Promise<void>;
   /** Set the naming template, then recompute previews. */
   setNamingRule: (template: string) => Promise<void>;
   /** Set the sequence start number (may be 0), then recompute previews. */
@@ -187,6 +189,16 @@ export const useJobStore = create<JobState>()((set, get) => ({
   reorder: async (from, to) => {
     try {
       const draft = await archive.reorder(from, to);
+      set(draftEdit(draft));
+      await get().recomputePreviews();
+    } catch (reason) {
+      set({ error: messageFromReason(reason) });
+    }
+  },
+
+  removeItem: async (index) => {
+    try {
+      const draft = await archive.removeItem(index);
       set(draftEdit(draft));
       await get().recomputePreviews();
     } catch (reason) {


### PR DESCRIPTION
Closes #125.

## Summary

The queue had no way to remove a single item — only **Clear** wiped the whole queue, and right-clicking a row surfaced the WebView's default browser menu ("Reload" / "Inspect Element") instead of anything useful. This adds a **visible per-row delete button** to each queue row that removes that single item and re-numbers / re-previews the rest, mirroring the existing `reorder` data path end to end.

## Background / Motivation

- Users could only clear the entire queue — there was no affordance to drop one wrong item.
- Right-clicking a row leaked the dev WebView context menu, which has no place in a shipped native app.
- A principal UI/UX review recommended starting with the visible, accessible affordance (discoverable, keyboard- and screen-reader-friendly) before any right-click menu.

## Changes

### Backend: remove a single draft item

- `JobDraft::remove_item(index)` — range-checked `Vec` removal (`Err` on out-of-range); the domain stays pure. Mirrors `reorder`.
- `remove_item` Tauri command (lock draft → `remove_item(index)?` → return snapshot), registered in `invoke_handler`.

### Frontend: wrapper + store action

- `archive.removeItem(index)` invokes `"remove_item"` with `{ index }`.
- `jobStore.removeItem(index)` mirrors `reorder`: backend call → `draftEdit` (clears the now-stale `summary` / `progress` / `taskIdByIndex`) → `recomputePreviews()`; errors route through `messageFromReason`.

### Frontend: row affordance

- `TaskRow` gains a `lucide-react` `Trash2` ghost button in the actions column: `aria-label="Remove <name> from queue"`, `disabled` while `running` (removing mid-run would desync the positional `progress.perTask[index]` bars), danger color on hover only, set apart from the reorder buttons. Stays enabled even as the only remaining row.
- `TaskList` column header renamed `Reorder` → `Actions`.

### Tests

- Backend (nextest): middle-remove shifts the rest, out-of-range returns `Err`, settings (template / start / out-dir) preserved, removing the only item empties the queue.
- Frontend (Vitest): delete button renders with the correct `aria-label` + `Trash2` icon and calls `removeItem(index)`; disabled while running; store `removeItem` calls archive, recomputes previews, routes errors to `error`; header reads "Actions".

## Verification

- Each queue row shows a trash button in the **Actions** column; clicking it removes that row, and the `#` sequence / output previews of the rows below shift accordingly. The button is disabled during a run. Removing the last row falls back to the empty state ("No items yet — add files or folders to begin.").
- Gates green by exit code: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo nextest run` (100 pass), `pnpm fmt:check` (oxfmt 0.55), `pnpm lint:ci` (oxlint 1.70), `pnpm test` (359 pass), `pnpm build`, `pnpm knip`.

---
PR1 of a phased design. Undo toast (PR2) and a custom right-click menu + default-menu suppression (PR3) are deferred. Base `main`, so `Closes #125` auto-closes on merge. No DTO change → no `src/bindings/*.ts` regeneration · 10 files, +317/-4.
