### PR TITLE
feat(ui): add draggable resizer to set the left output panel width

### DIFF
--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -1,10 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_RAIL_WIDTH, RAIL_WIDTH_STORAGE_KEY } from "@/lib/rail-width";
 
 import { AppShell } from "./AppShell";
 
 describe("AppShell", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   function renderShell(banner?: ReactNode) {
     render(
       <AppShell
@@ -59,5 +65,51 @@ describe("AppShell", () => {
   it("renders the banner region when a banner is provided", () => {
     renderShell(<div>OOPS</div>);
     expect(screen.getByTestId("app-banner").textContent).toContain("OOPS");
+  });
+
+  it("renders a draggable separator between the rail and the canvas", () => {
+    renderShell();
+    const body = screen.getByTestId("app-body");
+    const separator = screen.getByRole("separator");
+    expect(body.contains(separator)).toBe(true);
+    // DOM order: rail pane, then separator, then canvas.
+    const railIndex = body.innerHTML.indexOf("RAIL");
+    const separatorIndex = body.innerHTML.indexOf("separator");
+    const canvasIndex = body.innerHTML.indexOf("CANVAS");
+    expect(railIndex).toBeLessThan(separatorIndex);
+    expect(separatorIndex).toBeLessThan(canvasIndex);
+  });
+
+  it("sizes the rail pane to the default width", () => {
+    renderShell();
+    expect(screen.getByTestId("rail-pane").style.width).toBe(
+      `${DEFAULT_RAIL_WIDTH}px`,
+    );
+  });
+
+  it("restores the persisted rail width on mount", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "440");
+    renderShell();
+    expect(screen.getByTestId("rail-pane").style.width).toBe("440px");
+  });
+
+  it("widens the rail pane as the separator is dragged right", () => {
+    renderShell();
+    const separator = screen.getByRole("separator");
+    fireEvent.pointerDown(separator, { clientX: 100, buttons: 1 });
+    fireEvent.pointerMove(separator, { clientX: 180, buttons: 1 });
+    expect(screen.getByTestId("rail-pane").style.width).toBe(
+      `${DEFAULT_RAIL_WIDTH + 80}px`,
+    );
+  });
+
+  it("resets the rail width on double-clicking the separator", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "500");
+    renderShell();
+    expect(screen.getByTestId("rail-pane").style.width).toBe("500px");
+    fireEvent.doubleClick(screen.getByRole("separator"));
+    expect(screen.getByTestId("rail-pane").style.width).toBe(
+      `${DEFAULT_RAIL_WIDTH}px`,
+    );
   });
 });

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 
+import { PaneSeparator } from "@/components/PaneSeparator";
+import { usePaneResize } from "@/hooks/usePaneResize";
+import { cn } from "@/lib/utils";
+
 interface AppShellProps {
   /** The fixed left rail: output settings + the Run/Cancel control. */
   rail: ReactNode;
@@ -17,12 +21,18 @@ interface AppShellProps {
  * header and theme toggle were removed; the theme follows the OS).
  *
  * Scroll discipline: the canvas (passed as `children`, a labelled `main`) is the
- * only region that scrolls vertically. The rail is shrink-0 and scrolls only
- * internally on a viewport too short to fit its natural height; the footer is
- * always pinned. The optional banner sits across the top of the body so a
+ * only region that scrolls vertically. The rail pane is shrink-0 and scrolls
+ * only internally on a viewport too short to fit its natural height; the footer
+ * is always pinned. The optional banner sits across the top of the body so a
  * surfaced error is visible above both panes.
+ *
+ * The rail pane is user-resizable: a {@link PaneSeparator} between the two panes
+ * drives {@link usePaneResize}, which owns the rail width (drag, double-click
+ * reset, and persistence). While dragging, the body suppresses text selection
+ * and shows the col-resize cursor across both panes.
  */
 export function AppShell({ rail, banner, statusBar, children }: AppShellProps) {
+  const { railWidth, isDragging, separatorProps } = usePaneResize();
   return (
     <div
       data-testid="app-shell"
@@ -38,9 +48,19 @@ export function AppShell({ rail, banner, statusBar, children }: AppShellProps) {
       ) : null}
       <div
         data-testid="app-body"
-        className="flex min-h-0 flex-1 flex-row overflow-hidden"
+        className={cn(
+          "flex min-h-0 flex-1 flex-row overflow-hidden",
+          isDragging && "cursor-col-resize select-none",
+        )}
       >
-        {rail}
+        <div
+          data-testid="rail-pane"
+          className="flex min-h-0 shrink-0"
+          style={{ width: `${railWidth}px` }}
+        >
+          {rail}
+        </div>
+        <PaneSeparator isDragging={isDragging} {...separatorProps} />
         {children}
       </div>
       <footer className="shrink-0 border-t border-border bg-muted/40 px-6 py-3">

--- a/src/components/LeftRail.tsx
+++ b/src/components/LeftRail.tsx
@@ -22,10 +22,11 @@ import { selectFirstPreview, useJobStore } from "@/store/jobStore";
  * source of preview truth (firstPreview, via selectFirstPreview) joined with the
  * output directory — it runs no preview pipeline of its own.
  *
- * The rail is shrink-0 so it never collapses; on a viewport too short to fit its
- * natural height it scrolls internally (the right canvas is the primary
- * scroller). It is a labelled complementary landmark (an <aside>) so assistive
- * tech can jump straight to the output settings.
+ * The rail fills its resizable pane (the width is owned by AppShell via the
+ * pane separator); on a viewport too short to fit its natural height it scrolls
+ * internally (the right canvas is the primary scroller). It is a labelled
+ * complementary landmark (an <aside>) so assistive tech can jump straight to the
+ * output settings.
  */
 export function LeftRail() {
   const outputDir = useJobStore((s) => s.draft.outputDir);
@@ -56,7 +57,7 @@ export function LeftRail() {
   return (
     <aside
       aria-label="Output settings"
-      className="flex w-80 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border bg-muted/40 px-5 py-4"
+      className="flex min-h-0 w-full flex-col gap-4 overflow-y-auto bg-muted/40 px-5 py-4"
     >
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">

--- a/src/components/PaneSeparator.test.tsx
+++ b/src/components/PaneSeparator.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PaneSeparator } from "./PaneSeparator";
+
+function baseProps() {
+  return {
+    role: "separator" as const,
+    "aria-orientation": "vertical" as const,
+    "aria-label": "Resize output panel",
+    onPointerDown: vi.fn(),
+    onPointerMove: vi.fn(),
+    onPointerUp: vi.fn(),
+    onPointerCancel: vi.fn(),
+    onLostPointerCapture: vi.fn(),
+    onDoubleClick: vi.fn(),
+  };
+}
+
+describe("PaneSeparator", () => {
+  it("renders a labelled vertical structural separator", () => {
+    render(<PaneSeparator isDragging={false} {...baseProps()} />);
+    const separator = screen.getByRole("separator");
+    expect(separator.getAttribute("aria-orientation")).toBe("vertical");
+    expect(separator.getAttribute("aria-label")).toBe("Resize output panel");
+  });
+
+  it("carries no aria-value props (it is not an operable widget)", () => {
+    render(<PaneSeparator isDragging={false} {...baseProps()} />);
+    const separator = screen.getByRole("separator");
+    expect(separator.hasAttribute("aria-valuenow")).toBe(false);
+    expect(separator.hasAttribute("aria-valuemin")).toBe(false);
+    expect(separator.hasAttribute("aria-valuemax")).toBe(false);
+    expect(separator.hasAttribute("tabindex")).toBe(false);
+  });
+
+  it("shows the col-resize affordance", () => {
+    render(<PaneSeparator isDragging={false} {...baseProps()} />);
+    expect(screen.getByRole("separator").className).toContain(
+      "cursor-col-resize",
+    );
+  });
+
+  it("marks itself as dragging while a drag is in progress", () => {
+    render(<PaneSeparator isDragging={true} {...baseProps()} />);
+    expect(screen.getByRole("separator").getAttribute("data-dragging")).toBe(
+      "true",
+    );
+  });
+
+  it("is not marked as dragging at rest", () => {
+    render(<PaneSeparator isDragging={false} {...baseProps()} />);
+    expect(
+      screen.getByRole("separator").getAttribute("data-dragging"),
+    ).toBeNull();
+  });
+
+  it("forwards pointer-down and double-click to its handlers", () => {
+    const props = baseProps();
+    render(<PaneSeparator isDragging={false} {...props} />);
+    const separator = screen.getByRole("separator");
+    fireEvent.pointerDown(separator);
+    fireEvent.doubleClick(separator);
+    expect(props.onPointerDown).toHaveBeenCalledTimes(1);
+    expect(props.onDoubleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/PaneSeparator.tsx
+++ b/src/components/PaneSeparator.tsx
@@ -1,0 +1,33 @@
+import type { PaneSeparatorProps } from "@/hooks/usePaneResize";
+import { cn } from "@/lib/utils";
+
+interface Props extends PaneSeparatorProps {
+  /** True while a drag is in progress — renders the active highlight. */
+  isDragging: boolean;
+}
+
+/**
+ * The draggable divider between the left rail and the right canvas. It is a thin
+ * vertical bar that replaces the rail's former right border: it shows the
+ * hairline color at rest, highlights to the primary color on hover, and stays
+ * highlighted while dragging. The `col-resize` cursor and the `separator` role
+ * communicate the resize affordance.
+ *
+ * Keyboard interaction is intentionally omitted: the separator is not focusable.
+ * It is a non-focusable structural divider (role=separator + aria-orientation +
+ * aria-label), so it carries no aria-value* properties — those would imply an
+ * operable window-splitter widget the user cannot focus or adjust.
+ */
+export function PaneSeparator({ isDragging, ...separatorProps }: Props) {
+  return (
+    <div
+      {...separatorProps}
+      data-testid="pane-separator"
+      data-dragging={isDragging ? "true" : undefined}
+      className={cn(
+        "w-1.5 shrink-0 cursor-col-resize touch-none select-none bg-border transition-colors hover:bg-primary/70",
+        isDragging && "bg-primary",
+      )}
+    />
+  );
+}

--- a/src/hooks/usePaneResize.test.ts
+++ b/src/hooks/usePaneResize.test.ts
@@ -1,0 +1,196 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_RAIL_WIDTH,
+  MAX_RAIL_WIDTH,
+  MIN_RAIL_WIDTH,
+  RAIL_WIDTH_STORAGE_KEY,
+} from "@/lib/rail-width";
+
+import { usePaneResize } from "./usePaneResize";
+
+/**
+ * Build a minimal stand-in for a React pointer event the hook reads from.
+ * `buttons` defaults to 1 (primary button held) so a move continues a drag;
+ * pass 0 to model a button-released / lost-capture move.
+ */
+function pointerEvent(clientX: number, buttons = 1): ReactPointerEvent {
+  return {
+    clientX,
+    buttons,
+    pointerId: 1,
+    preventDefault: () => {},
+    currentTarget: {
+      setPointerCapture: () => {},
+      releasePointerCapture: () => {},
+    },
+  } as unknown as ReactPointerEvent;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("usePaneResize", () => {
+  it("starts at the default width when nothing is persisted", () => {
+    const { result } = renderHook(() => usePaneResize());
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH);
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it("initializes from the persisted width", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "420");
+    const { result } = renderHook(() => usePaneResize());
+    expect(result.current.railWidth).toBe(420);
+  });
+
+  it("exposes a non-focusable structural separator (no aria-value props)", () => {
+    const { result } = renderHook(() => usePaneResize());
+    const props = result.current.separatorProps;
+    expect(props.role).toBe("separator");
+    expect(props["aria-orientation"]).toBe("vertical");
+    expect(props["aria-label"]).toBe("Resize output panel");
+    expect("aria-valuenow" in props).toBe(false);
+    expect("aria-valuemin" in props).toBe(false);
+    expect("aria-valuemax" in props).toBe(false);
+  });
+
+  it("widens the rail as the pointer drags right", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    expect(result.current.isDragging).toBe(true);
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(160));
+    });
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH + 60);
+  });
+
+  it("clamps the width while dragging past the maximum", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(0));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(5000));
+    });
+    expect(result.current.railWidth).toBe(MAX_RAIL_WIDTH);
+  });
+
+  it("clamps the width while dragging past the minimum", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(500));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(0));
+    });
+    expect(result.current.railWidth).toBe(MIN_RAIL_WIDTH);
+  });
+
+  it("ignores pointer movement when no drag is in progress", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(999));
+    });
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH);
+  });
+
+  it("ends the drag and persists the width on pointer up", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(140));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerUp(pointerEvent(140));
+    });
+    expect(result.current.isDragging).toBe(false);
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe(
+      String(DEFAULT_RAIL_WIDTH + 40),
+    );
+  });
+
+  it("does not persist the width mid-drag, only once it settles", () => {
+    const { result } = renderHook(() => usePaneResize());
+    // Nothing is written on mount — the default is never pinned.
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBeNull();
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(160));
+    });
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH + 60);
+    // Still unwritten while the drag is in progress.
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBeNull();
+    act(() => {
+      result.current.separatorProps.onPointerUp(pointerEvent(160));
+    });
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe(
+      String(DEFAULT_RAIL_WIDTH + 60),
+    );
+  });
+
+  it("ends a stuck drag on pointer cancel", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(140));
+    });
+    act(() => {
+      result.current.separatorProps.onPointerCancel(pointerEvent(140));
+    });
+    expect(result.current.isDragging).toBe(false);
+    // A later hover (no drag in progress) must not move the rail.
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(300));
+    });
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH + 40);
+  });
+
+  it("ends a stuck drag on lost pointer capture", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current.separatorProps.onLostPointerCapture(pointerEvent(100));
+    });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it("self-heals when a move arrives with no button held", () => {
+    const { result } = renderHook(() => usePaneResize());
+    act(() => {
+      result.current.separatorProps.onPointerDown(pointerEvent(100));
+    });
+    // A move with no button pressed (e.g. after lost capture) must end the drag
+    // rather than resize on hover.
+    act(() => {
+      result.current.separatorProps.onPointerMove(pointerEvent(300, 0));
+    });
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH);
+  });
+
+  it("resets to the default width on double-click and persists it", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "500");
+    const { result } = renderHook(() => usePaneResize());
+    expect(result.current.railWidth).toBe(500);
+    act(() => {
+      result.current.separatorProps.onDoubleClick();
+    });
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH);
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe(
+      String(DEFAULT_RAIL_WIDTH),
+    );
+  });
+});

--- a/src/hooks/usePaneResize.ts
+++ b/src/hooks/usePaneResize.ts
@@ -1,0 +1,116 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useRef, useState } from "react";
+
+import {
+  clampRailWidth,
+  DEFAULT_RAIL_WIDTH,
+  loadPersistedRailWidth,
+  persistRailWidth,
+} from "@/lib/rail-width";
+
+/** ARIA + pointer handlers a separator element spreads to become draggable. */
+export interface PaneSeparatorProps {
+  role: "separator";
+  "aria-orientation": "vertical";
+  "aria-label": string;
+  onPointerDown: (event: ReactPointerEvent) => void;
+  onPointerMove: (event: ReactPointerEvent) => void;
+  onPointerUp: (event: ReactPointerEvent) => void;
+  onPointerCancel: (event: ReactPointerEvent) => void;
+  onLostPointerCapture: (event: ReactPointerEvent) => void;
+  onDoubleClick: () => void;
+}
+
+export interface PaneResize {
+  /** The current left-rail width in px, clamped to [MIN, MAX]. */
+  railWidth: number;
+  /** True while a resize drag is in progress. */
+  isDragging: boolean;
+  /** Props to spread onto the separator element between the two panes. */
+  separatorProps: PaneSeparatorProps;
+}
+
+/**
+ * Owns the left-rail width of the two-pane shell: a pointer-drag resize, a
+ * double-click reset to the default, and persistence to localStorage. The width
+ * is always clamped to [MIN_RAIL_WIDTH, MAX_RAIL_WIDTH].
+ *
+ * The drag is tracked relative to its origin (the pointer X and rail width at
+ * pointerdown), so it is robust regardless of where the separator sits. Pointer
+ * capture keeps the gesture flowing to the separator even when the cursor moves
+ * off the thin handle; environments without pointer capture (e.g. jsdom) simply
+ * skip it.
+ *
+ * The drag teardown is shared by pointerup, pointercancel, and lost pointer
+ * capture (window blur / OS interruption) so the drag can never get stuck
+ * active; a move with no button held also self-heals. The width is persisted
+ * only when the gesture settles or on reset — never on every drag frame, and
+ * never on mount (so the default is not pinned for users who never resize).
+ */
+export function usePaneResize(): PaneResize {
+  const [railWidth, setRailWidth] = useState<number>(loadPersistedRailWidth);
+  const [isDragging, setIsDragging] = useState(false);
+  // Drag origin captured at pointerdown; null when no drag is in progress.
+  const dragOrigin = useRef<{ pointerX: number; width: number } | null>(null);
+  // Mirror the latest width so the end-of-gesture teardown can persist it
+  // without re-subscribing the pointer handlers on every drag frame.
+  const railWidthRef = useRef(railWidth);
+  railWidthRef.current = railWidth;
+
+  const endDrag = useCallback(() => {
+    if (dragOrigin.current === null) return;
+    dragOrigin.current = null;
+    setIsDragging(false);
+    // Persist once the gesture settles — never mid-drag.
+    persistRailWidth(railWidthRef.current);
+  }, []);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent) => {
+    event.preventDefault();
+    dragOrigin.current = {
+      pointerX: event.clientX,
+      width: railWidthRef.current,
+    };
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent) => {
+      const origin = dragOrigin.current;
+      if (origin === null) return;
+      // Self-heal a stuck drag: if no button is held (an interrupted gesture or
+      // lost pointer capture left the drag active), end it instead of resizing
+      // when the user merely hovers the separator.
+      if (event.buttons === 0) {
+        endDrag();
+        return;
+      }
+      setRailWidth(
+        clampRailWidth(origin.width + (event.clientX - origin.pointerX)),
+      );
+    },
+    [endDrag],
+  );
+
+  const onDoubleClick = useCallback(() => {
+    setRailWidth(DEFAULT_RAIL_WIDTH);
+    persistRailWidth(DEFAULT_RAIL_WIDTH);
+  }, []);
+
+  return {
+    railWidth,
+    isDragging,
+    separatorProps: {
+      role: "separator",
+      "aria-orientation": "vertical",
+      "aria-label": "Resize output panel",
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+      onLostPointerCapture: endDrag,
+      onDoubleClick,
+    },
+  };
+}

--- a/src/lib/rail-width.test.ts
+++ b/src/lib/rail-width.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clampRailWidth,
+  DEFAULT_RAIL_WIDTH,
+  loadPersistedRailWidth,
+  MAX_RAIL_WIDTH,
+  MIN_RAIL_WIDTH,
+  persistRailWidth,
+  RAIL_WIDTH_STORAGE_KEY,
+} from "./rail-width";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("clampRailWidth", () => {
+  it("returns a width within range unchanged", () => {
+    expect(clampRailWidth(400)).toBe(400);
+  });
+
+  it("clamps a width below the minimum up to the minimum", () => {
+    expect(clampRailWidth(MIN_RAIL_WIDTH - 50)).toBe(MIN_RAIL_WIDTH);
+  });
+
+  it("clamps a width above the maximum down to the maximum", () => {
+    expect(clampRailWidth(MAX_RAIL_WIDTH + 50)).toBe(MAX_RAIL_WIDTH);
+  });
+
+  it("rounds a fractional width to a whole pixel", () => {
+    expect(clampRailWidth(400.6)).toBe(401);
+  });
+
+  it("falls back to the default for a non-finite width", () => {
+    expect(clampRailWidth(Number.NaN)).toBe(DEFAULT_RAIL_WIDTH);
+    expect(clampRailWidth(Number.POSITIVE_INFINITY)).toBe(MAX_RAIL_WIDTH);
+  });
+});
+
+describe("loadPersistedRailWidth", () => {
+  it("returns the default when nothing is stored", () => {
+    expect(loadPersistedRailWidth()).toBe(DEFAULT_RAIL_WIDTH);
+  });
+
+  it("returns the stored width when valid", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "420");
+    expect(loadPersistedRailWidth()).toBe(420);
+  });
+
+  it("clamps an out-of-range stored width", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "9999");
+    expect(loadPersistedRailWidth()).toBe(MAX_RAIL_WIDTH);
+  });
+
+  it("returns the default for a non-numeric stored value", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "not-a-number");
+    expect(loadPersistedRailWidth()).toBe(DEFAULT_RAIL_WIDTH);
+  });
+
+  it("returns the default when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(loadPersistedRailWidth()).toBe(DEFAULT_RAIL_WIDTH);
+  });
+});
+
+describe("persistRailWidth", () => {
+  it("writes the width to localStorage", () => {
+    persistRailWidth(380);
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe("380");
+  });
+
+  it("clamps the width before writing", () => {
+    persistRailWidth(50);
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe(
+      String(MIN_RAIL_WIDTH),
+    );
+  });
+
+  it("does not throw when localStorage write fails", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => persistRailWidth(400)).not.toThrow();
+  });
+});

--- a/src/lib/rail-width.ts
+++ b/src/lib/rail-width.ts
@@ -1,0 +1,56 @@
+/** localStorage key for the user's chosen left-rail width, in pixels. */
+export const RAIL_WIDTH_STORAGE_KEY = "simple-archiver-rail-width";
+
+/** Default left-rail width in px (the previous fixed `w-80` = 20rem = 320px). */
+export const DEFAULT_RAIL_WIDTH = 320;
+
+/** Minimum left-rail width in px — keeps the setup controls from collapsing. */
+export const MIN_RAIL_WIDTH = 240;
+
+/** Maximum left-rail width in px — keeps the right canvas usable. */
+export const MAX_RAIL_WIDTH = 560;
+
+/**
+ * Clamp an arbitrary width to the [MIN, MAX] range and round it to a whole
+ * pixel. A non-finite input (NaN) falls back to the default; ±Infinity clamps
+ * to the corresponding bound via Math.min/Math.max.
+ */
+export function clampRailWidth(width: number): number {
+  if (Number.isNaN(width)) return DEFAULT_RAIL_WIDTH;
+  return Math.min(MAX_RAIL_WIDTH, Math.max(MIN_RAIL_WIDTH, Math.round(width)));
+}
+
+/**
+ * Read the persisted rail width from localStorage. Returns the clamped stored
+ * value, or the default when nothing valid is stored. Never throws — DOM
+ * storage may be disabled (private mode, restricted WebView), in which case the
+ * default applies. Mirrors the validate-before-use pattern used elsewhere
+ * (e.g. {@link ../lib/output-dir-default}).
+ */
+export function loadPersistedRailWidth(): number {
+  try {
+    const stored = localStorage.getItem(RAIL_WIDTH_STORAGE_KEY);
+    if (stored === null) return DEFAULT_RAIL_WIDTH;
+    const parsed = Number.parseInt(stored, 10);
+    return Number.isNaN(parsed) ? DEFAULT_RAIL_WIDTH : clampRailWidth(parsed);
+  } catch (reason) {
+    console.error(
+      "loadPersistedRailWidth: reading localStorage failed",
+      reason,
+    );
+    return DEFAULT_RAIL_WIDTH;
+  }
+}
+
+/**
+ * Persist the rail width to localStorage, clamped to the valid range so a
+ * corrupt out-of-range value can never be stored. Never throws (storage may be
+ * disabled).
+ */
+export function persistRailWidth(width: number): void {
+  try {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, String(clampRailWidth(width)));
+  } catch (reason) {
+    console.error("persistRailWidth: writing localStorage failed", reason);
+  }
+}


### PR DESCRIPTION
## Summary

The boundary between the two panes was a static `border-r`, so the left **OUTPUT** panel was locked at a fixed 320 px. This turns that boundary into a real draggable splitter: the user drags it left/right to set the rail width (clamped to **240–560 px**), double-clicks to reset to the default, and the chosen width **persists across launches**. Long source titles and the destination path now get as much room as the user wants.

## Background / Motivation

- The left rail was hard-pinned to `w-80` (320 px) with the only divider being a non-interactive `border-r`; there was no way to widen it when the OUTPUT path or naming preview was clipped.
- Wide destination paths and long source names in the right canvas competed for a fixed split the user could not rebalance.
- The app already persists user layout/setup choices to `localStorage` (smart default output dir), so a remembered pane width is the consistent expectation.

## Changes

### Width model & persistence

- `src/lib/rail-width.ts` (new): `DEFAULT_RAIL_WIDTH` (320), `MIN_RAIL_WIDTH` (240), `MAX_RAIL_WIDTH` (560), and `clampRailWidth` / `loadPersistedRailWidth` / `persistRailWidth`. Validate-before-use and never-throw (storage may be disabled), mirroring `output-dir-default.ts`. The width is clamped on both read and write so a corrupt value can never be stored or applied.

### Resize behavior

- `src/hooks/usePaneResize.ts` (new): owns the rail width via an origin-relative pointer drag, a double-click reset, and persistence. The drag teardown is shared across `pointerup`, `pointercancel`, and `lostpointercapture` (window blur / OS interruption), plus a no-button self-heal in `pointermove`, so a drag can never get stuck active. The width is persisted only when the gesture settles or on reset — never mid-drag, and never on mount (the default is not pinned for users who never resize).

### The separator

- `src/components/PaneSeparator.tsx` (new): a non-focusable structural divider — `role="separator"` + `aria-orientation="vertical"` + `aria-label`, deliberately carrying no `aria-value*` (those would imply an operable window-splitter the user cannot focus). Shows the `col-resize` cursor, highlights to the primary color on hover, and stays highlighted while dragging (`data-dragging`).

### Shell wiring

- `src/components/AppShell.tsx`: calls `usePaneResize`, wraps the rail in a width-controlled `rail-pane` (`data-testid="rail-pane"`, inline `width`), renders the `PaneSeparator` between the panes, and suppresses text selection + shows the resize cursor across the body while dragging.
- `src/components/LeftRail.tsx`: drops `w-80`/`shrink-0`/`border-r` and fills its pane (`min-h-0 w-full`); the separator now provides the divider.

### Tests

- `rail-width.test.ts` (clamp boundaries, parse/corrupt/throw paths), `usePaneResize.test.ts` (drag math, min/max clamp, ignore-move-without-down, settle-only persistence + no mount write, cancel / lost-capture / no-button teardown, double-click reset), `PaneSeparator.test.tsx` (structural ARIA with no `aria-value*`, drag highlight, handler forwarding), and `AppShell.test.tsx` (separator placement, default/persisted width, drag widens the pane, double-click reset).

## Verification

- Drag the bar between the OUTPUT panel and the queue: the left panel resizes and the bar highlights; release and reload — the width is restored. Double-click the bar to snap back to the default.
- DOM: the divider is `[role="separator"][data-testid="pane-separator"]`; the resizable pane is `[data-testid="rail-pane"]` with an inline `width`; `localStorage["simple-archiver-rail-width"]` holds the persisted px value after a drag.
- Frontend gates green by exit code: `pnpm test` (389 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 389 passed (incl. drag/clamp/persist/teardown + AppShell integration)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: drag the separator to widen/narrow the OUTPUT panel; release and reload to confirm the width is remembered; double-click to reset to the default
