### PR TITLE
feat(naming): default the name template to a two-digit sequence (n:02)

### DIFF
--- a/src/lib/naming.test.ts
+++ b/src/lib/naming.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_START, MAX_START, sanitizeStartNumber } from "./naming";
+import {
+  DEFAULT_START,
+  DEFAULT_TEMPLATE,
+  MAX_START,
+  sanitizeStartNumber,
+} from "./naming";
+
+describe("DEFAULT_TEMPLATE", () => {
+  it("seeds the name field with a two-digit sequence by default", () => {
+    expect(DEFAULT_TEMPLATE).toBe("photo_{n:02}");
+  });
+});
 
 describe("sanitizeStartNumber", () => {
   it("accepts non-negative integers verbatim", () => {

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -4,7 +4,7 @@
  * store and the NamingRuleForm can share one source of truth for the starting
  * template without a presentation -> store import cycle.
  */
-export const DEFAULT_TEMPLATE = "photo_{n:03}";
+export const DEFAULT_TEMPLATE = "photo_{n:02}";
 
 /**
  * The default sequence start number. 1 preserves the historical numbering, so


### PR DESCRIPTION
## Summary

A fresh session seeded the OUTPUT **Name** field with `photo_{n:03}`, so the first archives landed as `photo_001.zip`, `photo_002.zip`, … — three-digit zero padding even for a handful of items. This switches the default seed to `photo_{n:02}`, so a new batch numbers as `photo_01.zip`, `photo_02.zip`, … out of the box. Users who want wider padding can still type `{n:03}` (or any width) themselves.

## Background / Motivation

- The default `{n:03}` over-pads typical batches: two files became `photo_001.zip` / `photo_002.zip` when `photo_01.zip` / `photo_02.zip` reads cleaner.
- The default is only a seed — the backend already parses any `{n:NN}` width (`{n:02}` is exercised in `state.rs` / `commands.rs`), so this is purely a starting-value change with no new formatting support required.

## Changes

### Default name template

- `src/lib/naming.ts`: `DEFAULT_TEMPLATE` changed from `"photo_{n:03}"` to `"photo_{n:02}"`. This single constant is the shared seed for both `NamingRuleForm` (the field's initial `useState`) and `jobStore` (the hero-preview fallback before a template is pushed), so the change flows to the form, the OUTPUT preview, and the first-paint placeholder at once.

### Tests

- `src/lib/naming.test.ts`: added a `DEFAULT_TEMPLATE` block asserting the default is `"photo_{n:02}"`, locking the two-digit default against accidental regression.

## Verification

- Launch with an empty queue: the **Name** field reads `photo_{n:02}` and the OUTPUT hero preview shows `photo_01.zip`. Add two items — the previews read `photo_01.zip` / `photo_02.zip`.
- No backend / DTO change → no `src/bindings/*.ts` regeneration.
- Frontend gates green by exit code: `pnpm test` (404 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 404 passed (incl. new `DEFAULT_TEMPLATE` assertion)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: launch fresh, confirm the Name field seeds `photo_{n:02}` and previews render `photo_01.zip` / `photo_02.zip`
