### PR TITLE
feat(ui): expand the rail pane right to the canvas minimum width

### DIFF
--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -1,14 +1,25 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_RAIL_WIDTH, RAIL_WIDTH_STORAGE_KEY } from "@/lib/rail-width";
 
 import { AppShell } from "./AppShell";
 
+/** Override an element's measured width so the canvas-min clamp can be tested. */
+function mockWidth(element: Element, width: number) {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    width,
+  } as DOMRect);
+}
+
 describe("AppShell", () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   function renderShell(banner?: ReactNode) {
@@ -101,6 +112,44 @@ describe("AppShell", () => {
     expect(screen.getByTestId("rail-pane").style.width).toBe(
       `${DEFAULT_RAIL_WIDTH + 80}px`,
     );
+  });
+
+  it("lets the separator drag the rail past the former fixed cap", () => {
+    // Regression: the rail used to stop at 560px. With no measured container it
+    // now follows the pointer to the right unbounded.
+    renderShell();
+    const separator = screen.getByRole("separator");
+    fireEvent.pointerDown(separator, { clientX: 100, buttons: 1 });
+    fireEvent.pointerMove(separator, { clientX: 700, buttons: 1 });
+    expect(screen.getByTestId("rail-pane").style.width).toBe(
+      `${DEFAULT_RAIL_WIDTH + 600}px`,
+    );
+  });
+
+  it("stops the rail so the canvas keeps its minimum width", () => {
+    renderShell();
+    const body = screen.getByTestId("app-body");
+    const separator = screen.getByRole("separator");
+    mockWidth(body, 1000);
+    mockWidth(separator, 6);
+    fireEvent.pointerDown(separator, { clientX: 0, buttons: 1 });
+    fireEvent.pointerMove(separator, { clientX: 5000, buttons: 1 });
+    // 1000 container - 6 separator - 360 canvas-min = 634px.
+    expect(screen.getByTestId("rail-pane").style.width).toBe("634px");
+  });
+
+  it("re-clamps the rail when the window shrinks below its width", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "900");
+    renderShell();
+    // Restored at its persisted width while the shell is still unmeasured.
+    expect(screen.getByTestId("rail-pane").style.width).toBe("900px");
+    mockWidth(screen.getByTestId("app-body"), 700);
+    mockWidth(screen.getByRole("separator"), 6);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    // 700 - 6 - 360 = 334px.
+    expect(screen.getByTestId("rail-pane").style.width).toBe("334px");
   });
 
   it("resets the rail width on double-clicking the separator", () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -32,7 +32,8 @@ interface AppShellProps {
  * and shows the col-resize cursor across both panes.
  */
 export function AppShell({ rail, banner, statusBar, children }: AppShellProps) {
-  const { railWidth, isDragging, separatorProps } = usePaneResize();
+  const { railWidth, isDragging, containerRef, separatorProps } =
+    usePaneResize();
   return (
     <div
       data-testid="app-shell"
@@ -47,6 +48,7 @@ export function AppShell({ rail, banner, statusBar, children }: AppShellProps) {
         </div>
       ) : null}
       <div
+        ref={containerRef}
         data-testid="app-body"
         className={cn(
           "flex min-h-0 flex-1 flex-row overflow-hidden",

--- a/src/hooks/usePaneResize.test.ts
+++ b/src/hooks/usePaneResize.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   DEFAULT_RAIL_WIDTH,
-  MAX_RAIL_WIDTH,
   MIN_RAIL_WIDTH,
   RAIL_WIDTH_STORAGE_KEY,
 } from "@/lib/rail-width";
@@ -69,15 +68,22 @@ describe("usePaneResize", () => {
     expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH + 60);
   });
 
-  it("clamps the width while dragging past the maximum", () => {
+  it("expands past the former fixed maximum when no canvas bound applies", () => {
+    // With no measured container the rail follows the pointer freely. The old
+    // build capped this at 560px; the rail now widens to the right unbounded.
     const { result } = renderHook(() => usePaneResize());
     act(() => {
       result.current.separatorProps.onPointerDown(pointerEvent(0));
     });
     act(() => {
-      result.current.separatorProps.onPointerMove(pointerEvent(5000));
+      result.current.separatorProps.onPointerMove(pointerEvent(900));
     });
-    expect(result.current.railWidth).toBe(MAX_RAIL_WIDTH);
+    expect(result.current.railWidth).toBe(DEFAULT_RAIL_WIDTH + 900);
+  });
+
+  it("exposes a container ref to attach to the resizable body", () => {
+    const { result } = renderHook(() => usePaneResize());
+    expect(result.current.containerRef.current).toBeNull();
   });
 
   it("clamps the width while dragging past the minimum", () => {

--- a/src/hooks/usePaneResize.ts
+++ b/src/hooks/usePaneResize.ts
@@ -1,11 +1,12 @@
-import type { PointerEvent as ReactPointerEvent } from "react";
-import { useCallback, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent, RefObject } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   clampRailWidth,
   DEFAULT_RAIL_WIDTH,
   loadPersistedRailWidth,
   persistRailWidth,
+  railWidthMaxFor,
 } from "@/lib/rail-width";
 
 /** ARIA + pointer handlers a separator element spreads to become draggable. */
@@ -22,10 +23,12 @@ export interface PaneSeparatorProps {
 }
 
 export interface PaneResize {
-  /** The current left-rail width in px, clamped to [MIN, MAX]. */
+  /** The current left-rail width in px, clamped to the canvas-preserving range. */
   railWidth: number;
   /** True while a resize drag is in progress. */
   isDragging: boolean;
+  /** Ref to attach to the two-pane body; its width bounds how far the rail grows. */
+  containerRef: RefObject<HTMLDivElement | null>;
   /** Props to spread onto the separator element between the two panes. */
   separatorProps: PaneSeparatorProps;
 }
@@ -33,7 +36,10 @@ export interface PaneResize {
 /**
  * Owns the left-rail width of the two-pane shell: a pointer-drag resize, a
  * double-click reset to the default, and persistence to localStorage. The width
- * is always clamped to [MIN_RAIL_WIDTH, MAX_RAIL_WIDTH].
+ * floor is MIN_RAIL_WIDTH; the ceiling is dynamic — the rail widens to the right
+ * until the canvas would shrink below MIN_CANVAS_WIDTH, measured live from the
+ * container (so a wider window allows a wider rail). The container is reached via
+ * {@link PaneResize.containerRef}, which the shell attaches to the body.
  *
  * The drag is tracked relative to its origin (the pointer X and rail width at
  * pointerdown), so it is robust regardless of where the separator sits. Pointer
@@ -46,6 +52,10 @@ export interface PaneResize {
  * active; a move with no button held also self-heals. The width is persisted
  * only when the gesture settles or on reset — never on every drag frame, and
  * never on mount (so the default is not pinned for users who never resize).
+ *
+ * On mount and on every window resize the width is re-clamped to the live
+ * ceiling, so shrinking the window (or restoring a width persisted on a wider
+ * one) never pushes the canvas below its minimum.
  */
 export function usePaneResize(): PaneResize {
   const [railWidth, setRailWidth] = useState<number>(loadPersistedRailWidth);
@@ -56,6 +66,24 @@ export function usePaneResize(): PaneResize {
   // without re-subscribing the pointer handlers on every drag frame.
   const railWidthRef = useRef(railWidth);
   railWidthRef.current = railWidth;
+  // The two-pane body; its width (minus the separator and the canvas minimum)
+  // is the live ceiling the rail can grow to.
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // The largest rail width that still leaves the canvas its minimum, measured
+  // from the live body and separator. +Infinity while the shell is unmeasured
+  // (no container yet, or jsdom before layout) so nothing clamps to a degenerate
+  // value before the real geometry is known.
+  const currentMaxWidth = useCallback(() => {
+    const container = containerRef.current;
+    if (container === null) return Number.POSITIVE_INFINITY;
+    const separator =
+      container.querySelector<HTMLElement>('[role="separator"]');
+    return railWidthMaxFor(
+      container.getBoundingClientRect().width,
+      separator?.getBoundingClientRect().width ?? 0,
+    );
+  }, []);
 
   const endDrag = useCallback(() => {
     if (dragOrigin.current === null) return;
@@ -87,10 +115,13 @@ export function usePaneResize(): PaneResize {
         return;
       }
       setRailWidth(
-        clampRailWidth(origin.width + (event.clientX - origin.pointerX)),
+        clampRailWidth(
+          origin.width + (event.clientX - origin.pointerX),
+          currentMaxWidth(),
+        ),
       );
     },
-    [endDrag],
+    [endDrag, currentMaxWidth],
   );
 
   const onDoubleClick = useCallback(() => {
@@ -98,9 +129,21 @@ export function usePaneResize(): PaneResize {
     persistRailWidth(DEFAULT_RAIL_WIDTH);
   }, []);
 
+  // Keep the rail within the canvas-preserving ceiling as the window resizes,
+  // and correct an over-wide persisted width once the shell has laid out.
+  useEffect(() => {
+    const clampToContainer = () => {
+      setRailWidth((current) => clampRailWidth(current, currentMaxWidth()));
+    };
+    clampToContainer();
+    window.addEventListener("resize", clampToContainer);
+    return () => window.removeEventListener("resize", clampToContainer);
+  }, [currentMaxWidth]);
+
   return {
     railWidth,
     isDragging,
+    containerRef,
     separatorProps: {
       role: "separator",
       "aria-orientation": "vertical",

--- a/src/lib/rail-width.test.ts
+++ b/src/lib/rail-width.test.ts
@@ -4,10 +4,11 @@ import {
   clampRailWidth,
   DEFAULT_RAIL_WIDTH,
   loadPersistedRailWidth,
-  MAX_RAIL_WIDTH,
+  MIN_CANVAS_WIDTH,
   MIN_RAIL_WIDTH,
   persistRailWidth,
   RAIL_WIDTH_STORAGE_KEY,
+  railWidthMaxFor,
 } from "./rail-width";
 
 beforeEach(() => {
@@ -27,8 +28,20 @@ describe("clampRailWidth", () => {
     expect(clampRailWidth(MIN_RAIL_WIDTH - 50)).toBe(MIN_RAIL_WIDTH);
   });
 
-  it("clamps a width above the maximum down to the maximum", () => {
-    expect(clampRailWidth(MAX_RAIL_WIDTH + 50)).toBe(MAX_RAIL_WIDTH);
+  it("does not cap a wide width when no maximum is given", () => {
+    // Free expansion: with no dynamic ceiling, a wide value passes through so a
+    // width set on a roomy window survives a persistence round-trip.
+    expect(clampRailWidth(900)).toBe(900);
+  });
+
+  it("clamps a width above the given dynamic maximum down to it", () => {
+    expect(clampRailWidth(900, 634)).toBe(634);
+  });
+
+  it("never returns below the minimum even when the dynamic maximum is smaller", () => {
+    // A very narrow container can drive the ceiling below the floor; the floor
+    // wins so the rail stays usable.
+    expect(clampRailWidth(900, 100)).toBe(MIN_RAIL_WIDTH);
   });
 
   it("rounds a fractional width to a whole pixel", () => {
@@ -37,7 +50,19 @@ describe("clampRailWidth", () => {
 
   it("falls back to the default for a non-finite width", () => {
     expect(clampRailWidth(Number.NaN)).toBe(DEFAULT_RAIL_WIDTH);
-    expect(clampRailWidth(Number.POSITIVE_INFINITY)).toBe(MAX_RAIL_WIDTH);
+    expect(clampRailWidth(Number.POSITIVE_INFINITY)).toBe(DEFAULT_RAIL_WIDTH);
+  });
+});
+
+describe("railWidthMaxFor", () => {
+  it("reserves MIN_CANVAS_WIDTH for the canvas beside the separator", () => {
+    expect(railWidthMaxFor(1000, 6)).toBe(1000 - 6 - MIN_CANVAS_WIDTH);
+  });
+
+  it("returns +Infinity when the container is not yet measured", () => {
+    // Width 0 (unlaid-out shell, e.g. jsdom before layout) must not clamp the
+    // rail to a degenerate value before the real geometry is known.
+    expect(railWidthMaxFor(0, 0)).toBe(Number.POSITIVE_INFINITY);
   });
 });
 
@@ -51,9 +76,14 @@ describe("loadPersistedRailWidth", () => {
     expect(loadPersistedRailWidth()).toBe(420);
   });
 
-  it("clamps an out-of-range stored width", () => {
-    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "9999");
-    expect(loadPersistedRailWidth()).toBe(MAX_RAIL_WIDTH);
+  it("preserves a wide stored width (the canvas-min clamp happens on layout)", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "900");
+    expect(loadPersistedRailWidth()).toBe(900);
+  });
+
+  it("clamps a below-minimum stored width up to the minimum", () => {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, "100");
+    expect(loadPersistedRailWidth()).toBe(MIN_RAIL_WIDTH);
   });
 
   it("returns the default for a non-numeric stored value", () => {
@@ -75,7 +105,12 @@ describe("persistRailWidth", () => {
     expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe("380");
   });
 
-  it("clamps the width before writing", () => {
+  it("preserves a wide width when writing", () => {
+    persistRailWidth(900);
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe("900");
+  });
+
+  it("clamps a below-minimum width up before writing", () => {
     persistRailWidth(50);
     expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe(
       String(MIN_RAIL_WIDTH),

--- a/src/lib/rail-width.ts
+++ b/src/lib/rail-width.ts
@@ -7,17 +7,45 @@ export const DEFAULT_RAIL_WIDTH = 320;
 /** Minimum left-rail width in px — keeps the setup controls from collapsing. */
 export const MIN_RAIL_WIDTH = 240;
 
-/** Maximum left-rail width in px — keeps the right canvas usable. */
-export const MAX_RAIL_WIDTH = 560;
+/**
+ * Minimum width in px reserved for the right canvas. The rail can widen freely
+ * to the right until the canvas would shrink below this, so the queue stays
+ * usable on any window width instead of being capped at a fixed rail width.
+ */
+export const MIN_CANVAS_WIDTH = 360;
 
 /**
- * Clamp an arbitrary width to the [MIN, MAX] range and round it to a whole
- * pixel. A non-finite input (NaN) falls back to the default; ±Infinity clamps
- * to the corresponding bound via Math.min/Math.max.
+ * The largest left-rail width that still leaves {@link MIN_CANVAS_WIDTH} for the
+ * right canvas, given the live container (body) and separator widths in px.
+ *
+ * Returns +Infinity when the container is unmeasured (width <= 0) — e.g. an
+ * unlaid-out shell, or jsdom before layout — so the rail is never clamped to a
+ * degenerate value before the real geometry is known.
  */
-export function clampRailWidth(width: number): number {
-  if (Number.isNaN(width)) return DEFAULT_RAIL_WIDTH;
-  return Math.min(MAX_RAIL_WIDTH, Math.max(MIN_RAIL_WIDTH, Math.round(width)));
+export function railWidthMaxFor(
+  containerWidth: number,
+  separatorWidth: number,
+): number {
+  if (!(containerWidth > 0)) return Number.POSITIVE_INFINITY;
+  return containerWidth - separatorWidth - MIN_CANVAS_WIDTH;
+}
+
+/**
+ * Clamp an arbitrary width to [MIN_RAIL_WIDTH, maxWidth] and round it to a whole
+ * pixel. `maxWidth` defaults to +Infinity (no ceiling) so a width set on a roomy
+ * window survives a persistence round-trip; callers that know the live geometry
+ * pass a {@link railWidthMaxFor} value to keep the canvas usable. The ceiling
+ * can never fall below the floor, so even a very narrow container yields a width
+ * >= MIN_RAIL_WIDTH. A non-finite width (NaN/±Infinity) falls back to the
+ * default.
+ */
+export function clampRailWidth(
+  width: number,
+  maxWidth: number = Number.POSITIVE_INFINITY,
+): number {
+  if (!Number.isFinite(width)) return DEFAULT_RAIL_WIDTH;
+  const ceiling = Math.max(MIN_RAIL_WIDTH, maxWidth);
+  return Math.min(ceiling, Math.max(MIN_RAIL_WIDTH, Math.round(width)));
 }
 
 /**
@@ -43,9 +71,11 @@ export function loadPersistedRailWidth(): number {
 }
 
 /**
- * Persist the rail width to localStorage, clamped to the valid range so a
- * corrupt out-of-range value can never be stored. Never throws (storage may be
- * disabled).
+ * Persist the rail width to localStorage, clamped to at least MIN_RAIL_WIDTH so
+ * a corrupt below-minimum value can never be stored. No upper bound is applied
+ * here (it depends on the live window size); an over-wide stored value is
+ * corrected against the canvas-min bound once the shell lays out. Never throws
+ * (storage may be disabled).
  */
 export function persistRailWidth(width: number): void {
   try {


### PR DESCRIPTION
## Summary

The pane separator between the **OUTPUT** settings rail and the queue canvas was capped at a fixed **560 px**, so it could not be dragged any further right even on a wide window. This removes the fixed cap: the rail now expands to the right until the right canvas reaches its **minimum usable width (360 px)**, and it re-clamps on window resize so the canvas is never squeezed below that.

## Background / Motivation

- `MAX_RAIL_WIDTH` (560 px) was a static ceiling unrelated to the actual window size, so the divider stopped well short of the right edge no matter how wide the window was.
- A fixed cap also makes the rail feel arbitrarily limited on large displays, where there is plenty of room to widen the OUTPUT path / naming preview without crowding the queue.
- The right canvas only needs a floor to stay usable, so the natural model is "rail grows freely, canvas keeps a minimum" rather than "rail capped at a magic number".

## Changes

### Width model

- `src/lib/rail-width.ts`: removed the fixed `MAX_RAIL_WIDTH` (560) constant; added `MIN_CANVAS_WIDTH` (360) reserved for the right canvas, plus a pure `railWidthMaxFor(containerWidth, separatorWidth)` helper that returns the largest rail width still leaving the canvas its minimum (and `+Infinity` when the container is unmeasured, e.g. an unlaid-out shell or jsdom before layout).
- `clampRailWidth(width, maxWidth = +Infinity)` now takes a dynamic ceiling; the ceiling can never fall below `MIN_RAIL_WIDTH`, so even a very narrow container still yields a width `>= MIN_RAIL_WIDTH`. A non-finite width (NaN/±Infinity) falls back to the default.
- Persistence: `loadPersistedRailWidth` / `persistRailWidth` now enforce only the lower bound. A wide width set on a roomy window survives a round-trip instead of being clipped to 560, and an over-wide stored value is corrected against the canvas-min bound once the shell lays out.

### Resize behavior

- `src/hooks/usePaneResize.ts`: exposes a new `containerRef` (the two-pane body) and measures the live container + separator widths during drag, clamping to `railWidthMaxFor(...)` instead of a constant. A `useEffect` re-clamps the width on mount and on every `window` `resize` event, so shrinking the window (or restoring a width persisted on a wider one) never pushes the canvas below `MIN_CANVAS_WIDTH`.

### Shell wiring

- `src/components/AppShell.tsx`: attaches the hook's `containerRef` to the `app-body` element so the rail's live ceiling tracks the actual body width.

### Tests

- `src/lib/rail-width.test.ts`: `railWidthMaxFor` geometry + unmeasured `+Infinity`, dynamic-ceiling clamping, ceiling-never-below-floor, and persistence enforcing only the lower bound.
- `src/hooks/usePaneResize.test.ts`: drag clamps to the dynamic max, expansion past the old 560 cap, canvas-min clamp, and the mount / window-resize re-clamp.
- `src/components/AppShell.test.tsx`: `containerRef` wiring, free expansion past 560, and the resize re-clamp keeping the canvas at its minimum.

## Verification

- Drag the separator (`[role="separator"][data-testid="pane-separator"]`) to the right: the rail pane (`[data-testid="rail-pane"]`) grows past 560 px and stops once the right canvas is at ~360 px. Shrink the window and the rail re-clamps so the canvas stays usable.
- No backend / DTO change → no `src/bindings/*.ts` regeneration.
- Frontend gates green by exit code: `pnpm test` (420 passed), `pnpm fmt:check` (oxfmt --check), `pnpm lint:ci` (oxlint --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 420 passed (incl. dynamic max, free expansion past the old cap, canvas-min clamp, resize re-clamp)
- [x] `pnpm fmt:check`
- [x] `pnpm lint:ci`
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual: drag the separator right and confirm the rail pane grows past 560 px and stops leaving the canvas ~360 px; resize the window and confirm the canvas never drops below its minimum
