### PR TITLE
fix(ui): reorder queue rows with pointer drag instead of HTML5 DnD

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -472,10 +472,17 @@ describe("TaskList progress", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Drag-and-drop reorder
+// Pointer-driven reorder
+//
+// Rows reorder via pointer events rather than HTML5 drag-and-drop: Tauri's
+// webview drag-drop handler — which the file-drop-to-add feature relies on —
+// intercepts native drag gestures so the DOM `drop` event never fires in the
+// app. Pointer events are not intercepted, so dragging a row by its grip handle
+// reorders it. The grip starts the drag; the row under the pointer is the drop
+// target; releasing the pointer commits the move.
 // ---------------------------------------------------------------------------
 
-describe("TaskList drag-and-drop reorder", () => {
+describe("TaskList pointer reorder", () => {
   function setItems(n: number, extra: Record<string, unknown> = {}) {
     useJobStore.setState({
       draft: {
@@ -491,55 +498,59 @@ describe("TaskList drag-and-drop reorder", () => {
     });
   }
 
-  // The first <tr> is the header; the remaining rows are the draggable items.
+  // The first <tr> is the header; the remaining rows are the reorderable items.
   function bodyRows() {
     return screen.getAllByRole("row").slice(1) as HTMLTableRowElement[];
   }
 
-  it("marks item rows draggable when no job is running", () => {
+  // The grip handle that starts a drag for the row at `index`.
+  function handle(index: number) {
+    return screen.getByTestId(`reorder-handle-${index}`);
+  }
+
+  it("exposes an enabled drag handle for each item row when idle", () => {
     setItems(3);
     render(<TaskList />);
 
-    for (const row of bodyRows()) {
-      expect(row.getAttribute("draggable")).toBe("true");
+    for (let i = 0; i < 3; i++) {
+      expect(handle(i).getAttribute("data-disabled")).toBeNull();
     }
   });
 
-  it("calls reorder(from, to) when a row is dropped onto a lower row", () => {
+  it("calls reorder(from, to) when a row is dragged onto a lower row", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, { reorder });
     render(<TaskList />);
 
     const rows = bodyRows();
-    fireEvent.dragStart(rows[0]);
-    fireEvent.dragOver(rows[2]);
-    fireEvent.drop(rows[2]);
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2]);
+    fireEvent.pointerUp(rows[2]);
 
     expect(reorder).toHaveBeenCalledWith(0, 2);
   });
 
-  it("calls reorder(from, to) when a row is dropped onto a higher row", () => {
+  it("calls reorder(from, to) when a row is dragged onto a higher row", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, { reorder });
     render(<TaskList />);
 
     const rows = bodyRows();
-    fireEvent.dragStart(rows[2]);
-    fireEvent.dragOver(rows[0]);
-    fireEvent.drop(rows[0]);
+    fireEvent.pointerDown(handle(2));
+    fireEvent.pointerMove(rows[0]);
+    fireEvent.pointerUp(rows[0]);
 
     expect(reorder).toHaveBeenCalledWith(2, 0);
   });
 
-  it("does not call reorder when a row is dropped onto itself", () => {
+  it("does not call reorder when a row is released onto itself", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, { reorder });
     render(<TaskList />);
 
     const rows = bodyRows();
-    fireEvent.dragStart(rows[1]);
-    fireEvent.dragOver(rows[1]);
-    fireEvent.drop(rows[1]);
+    fireEvent.pointerDown(handle(1));
+    fireEvent.pointerUp(rows[1]);
 
     expect(reorder).not.toHaveBeenCalled();
   });
@@ -549,28 +560,30 @@ describe("TaskList drag-and-drop reorder", () => {
     render(<TaskList />);
 
     const rows = bodyRows();
-    fireEvent.dragStart(rows[0]);
-    fireEvent.dragOver(rows[2]);
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2]);
 
     expect(rows[2].getAttribute("data-drop-target")).toBe("true");
     expect(rows[0].getAttribute("data-drop-target")).toBeNull();
     expect(rows[0].getAttribute("data-dragging")).toBe("true");
   });
 
-  it("clears the drag state on drag end", () => {
+  it("clears the drag state when the pointer is released off the rows", () => {
     setItems(3);
     render(<TaskList />);
 
     const rows = bodyRows();
-    fireEvent.dragStart(rows[0]);
-    fireEvent.dragOver(rows[2]);
-    fireEvent.dragEnd(rows[0]);
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2]);
+    // Release outside any row (e.g. on the surrounding page chrome).
+    fireEvent.pointerUp(document.body);
 
-    expect(rows[0].getAttribute("data-dragging")).toBeNull();
-    expect(rows[2].getAttribute("data-drop-target")).toBeNull();
+    const after = bodyRows();
+    expect(after[0].getAttribute("data-dragging")).toBeNull();
+    expect(after[2].getAttribute("data-drop-target")).toBeNull();
   });
 
-  it("does not allow dragging while a job is running", () => {
+  it("does not reorder while a job is running", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, {
       reorder,
@@ -584,14 +597,12 @@ describe("TaskList drag-and-drop reorder", () => {
     });
     render(<TaskList />);
 
-    const rows = bodyRows();
-    for (const row of rows) {
-      expect(row.getAttribute("draggable")).toBe("false");
-    }
+    expect(handle(0).getAttribute("data-disabled")).toBe("true");
 
-    fireEvent.dragStart(rows[0]);
-    fireEvent.dragOver(rows[2]);
-    fireEvent.drop(rows[2]);
+    const rows = bodyRows();
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2]);
+    fireEvent.pointerUp(rows[2]);
 
     expect(reorder).not.toHaveBeenCalled();
   });

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -108,24 +108,22 @@ function TaskRowImpl({ index }: TaskRowProps) {
   // reflow cannot strip the right-align padding spaces formatBytes emits.
   const liveLabel = `${formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} · ETA ${formatEta(row.liveEtaMs)}`;
 
-  // Drag affordances: grab cursor while draggable, dim the row being dragged,
-  // and highlight the row the pointer is currently over as the drop target.
+  // Drag affordances: dim the row being dragged and highlight the row the
+  // pointer is currently over as the drop target. The grab cursor lives on the
+  // grip handle (the only element that starts a drag), not the whole row.
   const rowClassName = [
     "border-b border-border/50 transition-colors",
-    dnd.draggable && "cursor-grab active:cursor-grabbing",
     dnd.isDragging ? "opacity-40" : "hover:bg-muted/30",
     dnd.isOver && "bg-primary/10",
+    // Suppress text selection across the list while any row is being dragged.
+    dnd.isDraggingAny && "select-none",
   ]
     .filter(Boolean)
     .join(" ");
 
   return (
     <tr
-      draggable={dnd.draggable}
-      onDragStart={dnd.onDragStart}
-      onDragOver={dnd.onDragOver}
-      onDrop={dnd.onDrop}
-      onDragEnd={dnd.onDragEnd}
+      {...dnd.rowProps}
       data-dragging={dnd.isDragging || undefined}
       data-drop-target={dnd.isOver || undefined}
       className={rowClassName}
@@ -178,12 +176,25 @@ function TaskRowImpl({ index }: TaskRowProps) {
       {/* Actions: drag handle + keyboard-accessible up/down buttons + delete */}
       <td className="py-2">
         <div className="flex items-center gap-1">
-          <GripVertical
+          {/* Grip handle: starts a pointer drag to reorder this row. The drag is
+              pointer-based (not HTML5) so it survives Tauri's webview drag-drop
+              handler; keyboard users reorder with the up/down buttons instead,
+              so the handle stays aria-hidden. `touch-none` keeps a touch drag
+              from scrolling the list; `select-none` keeps the press from
+              starting a text selection (mirrors PaneSeparator). */}
+          <span
+            {...dnd.handleProps}
+            data-testid={`reorder-handle-${index}`}
+            data-disabled={!dnd.enabled || undefined}
             aria-hidden
-            className={`size-4 shrink-0 text-muted-foreground/60 ${
-              dnd.draggable ? "cursor-grab" : "opacity-30"
+            className={`flex items-center touch-none select-none text-muted-foreground/60 ${
+              dnd.enabled
+                ? "cursor-grab active:cursor-grabbing"
+                : "cursor-not-allowed opacity-30"
             }`}
-          />
+          >
+            <GripVertical className="size-4 shrink-0" />
+          </span>
           <button
             type="button"
             aria-label="Move up"

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -2,9 +2,11 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
-  type DragEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
 
@@ -14,19 +16,18 @@ import { useJobStore } from "@/store/jobStore";
 // Context
 // ---------------------------------------------------------------------------
 
-type RowDragEvent = DragEvent<HTMLTableRowElement>;
+type RowPointerEvent = ReactPointerEvent<HTMLElement>;
 
 interface ReorderDndContextValue {
-  /** Whether rows may be dragged at all (false while a job is running). */
-  draggable: boolean;
+  /** Whether rows may be reordered at all (false while a job is running). */
+  enabled: boolean;
   /** Index of the row currently being dragged, or null. */
   draggingIndex: number | null;
   /** Index of the row currently hovered as the drop target, or null. */
   overIndex: number | null;
-  start: (index: number, event: RowDragEvent) => void;
-  over: (index: number, event: RowDragEvent) => void;
-  drop: (index: number, event: RowDragEvent) => void;
-  end: () => void;
+  start: (index: number, event: RowPointerEvent) => void;
+  over: (index: number) => void;
+  drop: (index: number) => void;
 }
 
 const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
@@ -37,12 +38,20 @@ const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
 
 /**
  * ReorderDndProvider owns the ephemeral drag state (which row is being dragged,
- * which row is the current drop target) and translates a native HTML5
- * drag-and-drop gesture into a single `reorder(from, to)` store action.
+ * which row is the current drop target) and translates a pointer-drag gesture
+ * into a single `reorder(from, to)` store action.
  *
- * The state lives here rather than in the global job store because it is
- * purely transient UI state; it is only observed by the rows during an active
- * drag, which never overlaps a running job (dragging is disabled then).
+ * Pointer events — not HTML5 drag-and-drop — drive the gesture on purpose: the
+ * app needs Tauri's native webview drag-drop handler enabled so files/folders
+ * can be dropped onto the window to be added (see {@link useFileDrop}), and that
+ * handler intercepts native drag gestures over the webview, so the DOM `drop`
+ * event never fires for in-page HTML5 dragging. Pointer events are not
+ * intercepted, so reordering works alongside the file-drop affordance. This also
+ * mirrors how the pane divider drag is implemented (`usePaneResize`).
+ *
+ * The state lives here rather than in the global job store because it is purely
+ * transient UI state; it is only observed by the rows during an active drag,
+ * which never overlaps a running job (reordering is disabled then).
  */
 export function ReorderDndProvider({ children }: { children: ReactNode }) {
   const running = useJobStore((s) => s.running);
@@ -50,60 +59,68 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
 
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
+  // Mirror the active drag source synchronously so the pointer handlers (and the
+  // window-level teardown below) read it without waiting for a state flush.
+  const draggingRef = useRef<number | null>(null);
 
-  const draggable = !running;
+  const enabled = !running;
 
   const reset = useCallback(() => {
+    draggingRef.current = null;
     setDraggingIndex(null);
     setOverIndex(null);
   }, []);
 
   const start = useCallback(
-    (index: number, event: RowDragEvent) => {
-      // Guard so a synthetic dragstart can never begin a drag mid-run.
-      if (running) return;
+    (index: number, event: RowPointerEvent) => {
+      // Guard so a stray pointerdown can never begin a drag mid-run.
+      if (!enabled) return;
+      // Stop the press from starting a text selection while dragging.
+      event.preventDefault();
+      draggingRef.current = index;
       setDraggingIndex(index);
-      if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = "move";
-        // A payload makes the gesture a valid native drag in every browser.
-        event.dataTransfer.setData("text/plain", String(index));
-      }
     },
-    [running],
+    [enabled],
   );
 
-  const over = useCallback((index: number, event: RowDragEvent) => {
-    // preventDefault is what marks this row as a valid drop target.
-    event.preventDefault();
-    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  const over = useCallback((index: number) => {
+    // Only track a hover target while a drag is actually in progress.
+    if (draggingRef.current === null) return;
     setOverIndex(index);
   }, []);
 
   const drop = useCallback(
-    (index: number, event: RowDragEvent) => {
-      event.preventDefault();
+    (index: number) => {
+      const from = draggingRef.current;
       // Dropping a row onto index `to` lands it exactly at `to` (the store's
       // reorder is a remove-then-insert), so the drop target index maps
       // directly to the destination. Skip no-op and mid-run drops.
-      if (draggingIndex !== null && draggingIndex !== index && !running) {
-        void reorder(draggingIndex, index);
+      if (from !== null && from !== index && enabled) {
+        void reorder(from, index);
       }
       reset();
     },
-    [draggingIndex, running, reorder, reset],
+    [enabled, reorder, reset],
   );
 
+  // End the gesture on any pointer release (or cancel) anywhere, so a release
+  // off the rows — or an OS-interrupted drag — never leaves a row stuck in the
+  // dragging state. A drop onto a row resets first (React's root handler runs
+  // before this window listener), so this is the idempotent backstop.
+  useEffect(() => {
+    if (draggingIndex === null) return;
+    const end = () => reset();
+    window.addEventListener("pointerup", end);
+    window.addEventListener("pointercancel", end);
+    return () => {
+      window.removeEventListener("pointerup", end);
+      window.removeEventListener("pointercancel", end);
+    };
+  }, [draggingIndex, reset]);
+
   const value = useMemo<ReorderDndContextValue>(
-    () => ({
-      draggable,
-      draggingIndex,
-      overIndex,
-      start,
-      over,
-      drop,
-      end: reset,
-    }),
-    [draggable, draggingIndex, overIndex, start, over, drop, reset],
+    () => ({ enabled, draggingIndex, overIndex, start, over, drop }),
+    [enabled, draggingIndex, overIndex, start, over, drop],
   );
 
   return (
@@ -118,45 +135,57 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
 // ---------------------------------------------------------------------------
 
 interface ReorderRow {
-  draggable: boolean;
+  /** Whether this row's grip handle may start a drag. */
+  enabled: boolean;
   isDragging: boolean;
   isOver: boolean;
-  onDragStart: (event: RowDragEvent) => void;
-  onDragOver: (event: RowDragEvent) => void;
-  onDrop: (event: RowDragEvent) => void;
-  onDragEnd: () => void;
+  /** Whether any row is currently being dragged (drives drag-wide styling). */
+  isDraggingAny: boolean;
+  /** Props for the grip handle that starts a drag. */
+  handleProps: {
+    onPointerDown: (event: RowPointerEvent) => void;
+  };
+  /** Props for the row element that acts as a drop target. */
+  rowProps: {
+    onPointerMove: () => void;
+    onPointerUp: () => void;
+  };
 }
 
 // Fallback for a row rendered outside a provider (e.g. an isolated unit test):
 // the row is simply not reorderable; its up/down buttons still work.
 const NON_DRAGGABLE_ROW: ReorderRow = {
-  draggable: false,
+  enabled: false,
   isDragging: false,
   isOver: false,
-  onDragStart: () => {},
-  onDragOver: () => {},
-  onDrop: () => {},
-  onDragEnd: () => {},
+  isDraggingAny: false,
+  handleProps: { onPointerDown: () => {} },
+  rowProps: { onPointerMove: () => {}, onPointerUp: () => {} },
 };
 
 /**
- * useReorderRow returns the drag props and visual flags for the row at `index`.
- * Outside a {@link ReorderDndProvider} the row falls back to non-draggable.
+ * useReorderRow returns the pointer props and visual flags for the row at
+ * `index`. Outside a {@link ReorderDndProvider} the row falls back to
+ * non-draggable.
  */
 export function useReorderRow(index: number): ReorderRow {
   const ctx = useContext(ReorderDndContext);
   if (ctx === null) {
     return NON_DRAGGABLE_ROW;
   }
-  const { draggable, draggingIndex, overIndex, start, over, drop, end } = ctx;
+  const { enabled, draggingIndex, overIndex, start, over, drop } = ctx;
   return {
-    draggable,
+    enabled,
     isDragging: draggingIndex === index,
     // The dragged row is never its own drop target.
     isOver: overIndex === index && draggingIndex !== index,
-    onDragStart: (event) => start(index, event),
-    onDragOver: (event) => over(index, event),
-    onDrop: (event) => drop(index, event),
-    onDragEnd: end,
+    isDraggingAny: draggingIndex !== null,
+    handleProps: {
+      onPointerDown: (event) => start(index, event),
+    },
+    rowProps: {
+      onPointerMove: () => over(index),
+      onPointerUp: () => drop(index),
+    },
   };
 }


### PR DESCRIPTION
## Summary

The queue rows could be picked up and dragged, but dropping one did nothing — the order never changed. The drag was wired with native HTML5 drag-and-drop, whose `drop` event is swallowed by Tauri's webview before it reaches the page. This reworks reordering to use **pointer events** instead: grab a row by its grip handle and drop it onto another row to move it to that position. The ▲/▼ buttons stay for keyboard/accessible reordering, and no new dependency is introduced.

## Background / Motivation

- #123 made the rows draggable with HTML5 drag-and-drop, but in the running app dropping a row never reordered anything (`dragstart`/`dragover` fired, so the row *looked* draggable, but `drop` never did).
- The app enables Tauri's native webview drag-drop handler so files/folders can be dropped onto the window to be added (`useFileDrop` → `getCurrentWebview().onDragDropEvent`). On macOS WKWebView that handler intercepts drag gestures over the webview, so the in-page HTML5 `drop` event never fires and `reorder()` was never called. Disabling the handler is not an option — it would break folder-path drops, the primary way to add items.
- The HTML5 unit tests passed because they dispatched the `drop` event directly, which cannot reproduce the native interception — so the gap was invisible to CI.
- `usePaneResize` (the pane divider, #127) already drives a drag with pointer events in this same webview, proving pointer events are *not* intercepted and are the right primitive here.

## Changes

### Pointer-driven reorder (`reorder-dnd.tsx`)

- Reworked `ReorderDndProvider` + `useReorderRow(index)` from HTML5 drag handlers to pointer events. The grip handle starts the drag (`onPointerDown` → `start`), the row under the pointer becomes the drop target (`onPointerMove` → `over`), and releasing over a row commits the move (`onPointerUp` → `drop` → `reorder(from, to)`). No-op (`from === to`) and mid-run drops are skipped; the drop-target index still maps directly to the store's remove-then-insert `reorder`, so behavior is unchanged.
- A `draggingIndex` ref mirrors the drag source synchronously so the pointer handlers (and the teardown) read it without waiting for a state flush.
- A window-level `pointerup` / `pointercancel` effect (active only while dragging) clears the drag state when the pointer is released off the rows or the OS interrupts the gesture, so a row can never get stuck dimmed.
- `useReorderRow` now returns `handleProps` (grip) and `rowProps` (drop-target) plus `enabled` / `isDragging` / `isOver` / `isDraggingAny`; outside a provider it still falls back to non-draggable so `TaskRow` renders standalone.

### Queue row wiring (`TaskRow.tsx`)

- The `<tr>` drops the HTML5 `draggable` / `onDragStart` / `onDragOver` / `onDrop` / `onDragEnd` for `{...dnd.rowProps}` (pointer move/up), keeping `data-dragging` / `data-drop-target` and the dim/highlight feedback.
- The `GripVertical` (lucide) handle is now the only drag initiator: a `[data-testid="reorder-handle-<i>"]` span carrying `{...dnd.handleProps}`, `cursor-grab` / `active:cursor-grabbing`, `touch-none select-none`, and `data-disabled` while a job runs.
- `select-none` is applied across the rows while any drag is in progress (and on the grip itself) to avoid text-selection flicker, mirroring `PaneSeparator` / `AppShell`.

### Tests (`TaskList.test.tsx`)

- Replaced the HTML5 drag cases with pointer-gesture cases: an enabled grip handle per idle row; drag onto a lower/higher row calls `reorder(from, to)`; release onto self is a no-op; the hovered row is marked `data-drop-target`; releasing off the rows clears the drag state; no reorder while a job runs (grip `data-disabled`).

Unchanged: the store action `reorder(from, to)` and the Rust backend; the ▲/▼ buttons remain the keyboard-accessible reorder path.

## Verification

- Add 3+ items, then drag a row by its grip handle and drop it onto another row — it moves to that row's position and the output preview names recompute. The ▲/▼ buttons still reorder one step, and dropping a file/folder onto the window still adds it.
- While a run is in progress, the grip is disabled (`data-disabled="true"`) and dragging does nothing, consistent with the disabled ▲/▼ buttons.
- DOM: the row being dragged carries `data-dragging="true"`; the current drop target carries `data-drop-target="true"`; the grip is `[data-testid="reorder-handle-<index>"]`.
- Frontend gates green by exit code: `pnpm test` (410 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 410 passed, including the rewritten pointer-reorder cases
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): drag a row by its grip onto another and confirm it lands there; confirm file/folder drag-drop-to-add still works; confirm ▲/▼ still reorder and dragging is disabled mid-run
