### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3796,7 +3796,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.5.0"
+version = "0.6.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Bump version `0.5.0` → `0.6.0` for the v0.6.0 release.

This release is a major UI overhaul of the archive workflow, centered on a new
two-pane shell and an inline, per-row ledger that replaces the old run summary.

### Highlights since v0.5.0

- **Two-pane shell** — fixed left rail + morphing right canvas (#118), with a
  draggable divider to resize the left output panel (#127) that can expand right
  up to the canvas minimum width (#131).
- **Inline ledger** — per-row results replace the run summary (#120), surfacing
  per-task output paths with an open-folder action (#117), a Ledger Clear button,
  a last-batch chip, and a start-number control (#121).
- **Queue row management** — drag-and-drop reorder for queue rows (#123), now
  driven by pointer events instead of HTML5 DnD so it works in the Tauri webview
  (#132), plus per-row delete in the queue and a Clear/New batch action beside Run
  (#124).
- **Naming** — the default name template is now a two-digit sequence (`n:02`)
  (#130).
- **Chrome** — the app header was removed and the window title cleared (#112), and
  the app now follows the OS color scheme only (#111).
- **Dependencies** — backend (cargo, incl. `zip` 8 / `ts-rs` 12) and frontend
  (npm) bumps, plus `mise` 11.8.0.

## Changes

- Bump the version string in `package.json`, `src-tauri/Cargo.toml`,
  `crates/core/Cargo.toml`, `src-tauri/tauri.conf.json`, and both `Cargo.lock`
  entries (`simple-archiver`, `simple-archiver-core`).

## Verification

- `cargo metadata --locked` — exit 0 (lockfile consistent with the bumped manifests)
- The full Rust gate (`cargo fmt --check`, `clippy -D warnings`, `cargo nextest`)
  and the full frontend gate (`pnpm fmt:check`, `lint:ci`, `test`, `build`, `knip`)
  run on this PR in CI and must be green before merge.
