### PR TITLE
feat(ui): drag to resize queue table columns

### DIFF
--- a/src/components/ColumnResizeHandle.tsx
+++ b/src/components/ColumnResizeHandle.tsx
@@ -1,0 +1,36 @@
+import type { TaskColumnKey } from "@/components/task-columns";
+import type { ColumnSeparatorProps } from "@/hooks/useColumnResize";
+import { cn } from "@/lib/utils";
+
+interface Props extends ColumnSeparatorProps {
+  /** Column this handle resizes — used for the test id. */
+  columnKey: TaskColumnKey;
+  /** True while this column's drag is in progress — renders the highlight. */
+  isDragging: boolean;
+}
+
+/**
+ * The draggable handle on a queue-table column's right edge. It is a thin
+ * vertical bar absolutely positioned over the column boundary (its parent `<th>`
+ * is `position: relative`). It is invisible at rest so it does not clutter the
+ * header, highlights to the primary color on hover, and stays highlighted while
+ * dragging. The `col-resize` cursor and the `separator` role communicate the
+ * resize affordance.
+ *
+ * Keyboard interaction is intentionally omitted: like {@link ./PaneSeparator},
+ * this is a non-focusable structural divider (role=separator + aria-orientation +
+ * aria-label), so it carries no aria-value* properties.
+ */
+export function ColumnResizeHandle({ columnKey, isDragging, ...props }: Props) {
+  return (
+    <span
+      {...props}
+      data-testid={`column-resize-${columnKey}`}
+      data-dragging={isDragging ? "true" : undefined}
+      className={cn(
+        "absolute top-0 right-0 z-10 h-full w-1.5 translate-x-1/2 cursor-col-resize touch-none select-none bg-transparent transition-colors hover:bg-primary/70",
+        isDragging && "bg-primary",
+      )}
+    />
+  );
+}

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
+import { COLUMN_BY_KEY, TASK_COLUMNS } from "./task-columns";
 import { TaskList } from "./TaskList";
 
 beforeEach(() => {
@@ -594,5 +595,84 @@ describe("TaskList drag-and-drop reorder", () => {
     fireEvent.drop(rows[2]);
 
     expect(reorder).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Column resize
+// ---------------------------------------------------------------------------
+
+describe("TaskList column resize", () => {
+  function setItems(n: number) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(n),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+    });
+  }
+
+  // The <col> at the same ordinal as `key` in TASK_COLUMNS.
+  function colWidth(container: HTMLElement, key: string) {
+    const index = TASK_COLUMNS.findIndex((c) => c.key === key);
+    const cols = container.querySelectorAll("col");
+    return (cols[index] as HTMLElement).style.width;
+  }
+
+  it("renders a colgroup with each column at its default width", () => {
+    setItems(1);
+    const { container } = render(<TaskList />);
+
+    const cols = container.querySelectorAll("col");
+    expect(cols.length).toBe(TASK_COLUMNS.length);
+    expect(colWidth(container, "source")).toBe(
+      `${COLUMN_BY_KEY.source.defaultWidth}px`,
+    );
+    expect(colWidth(container, "kind")).toBe(
+      `${COLUMN_BY_KEY.kind.defaultWidth}px`,
+    );
+  });
+
+  it("renders resize handles only for the resizable columns", () => {
+    setItems(1);
+    render(<TaskList />);
+
+    const resizable = TASK_COLUMNS.filter((c) => c.resizable);
+    expect(screen.getAllByRole("separator").length).toBe(resizable.length);
+
+    // Fixed columns carry no handle.
+    expect(screen.queryByTestId("column-resize-index")).toBeNull();
+    expect(screen.queryByTestId("column-resize-actions")).toBeNull();
+    // Resizable columns do.
+    expect(screen.getByTestId("column-resize-source")).toBeTruthy();
+    expect(
+      screen.getByRole("separator", { name: "Resize Source column" }),
+    ).toBeTruthy();
+  });
+
+  it("widens the Source column when its handle is dragged right", () => {
+    setItems(1);
+    const { container } = render(<TaskList />);
+
+    expect(colWidth(container, "source")).toBe(
+      `${COLUMN_BY_KEY.source.defaultWidth}px`,
+    );
+
+    const handle = screen.getByTestId("column-resize-source");
+    fireEvent.pointerDown(handle, { clientX: 100, buttons: 1, pointerId: 1 });
+    expect(handle.getAttribute("data-dragging")).toBe("true");
+
+    fireEvent.pointerMove(handle, { clientX: 180, buttons: 1, pointerId: 1 });
+    expect(colWidth(container, "source")).toBe(
+      `${COLUMN_BY_KEY.source.defaultWidth + 80}px`,
+    );
+
+    fireEvent.pointerUp(handle, { clientX: 180, buttons: 1, pointerId: 1 });
+    expect(handle.getAttribute("data-dragging")).toBeNull();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,5 +1,9 @@
+import { ColumnResizeHandle } from "@/components/ColumnResizeHandle";
 import { ReorderDndProvider } from "@/components/reorder-dnd";
+import { TASK_COLUMNS } from "@/components/task-columns";
 import { TaskRow } from "@/components/TaskRow";
+import { useColumnResize } from "@/hooks/useColumnResize";
+import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
 // ---------------------------------------------------------------------------
@@ -16,6 +20,9 @@ export function TaskList() {
   // Only the item count drives the chrome (header + which rows exist); the rows
   // themselves read everything else they need directly from the store.
   const items = useJobStore((s) => s.draft.items);
+  // Column widths are owned here so the hook state survives the empty-state
+  // toggle below (the hook must run before any early return).
+  const { widths, draggingKey, getSeparatorProps } = useColumnResize();
 
   if (items.length === 0) {
     return (
@@ -25,18 +32,40 @@ export function TaskList() {
     );
   }
 
+  // Fixed layout honors the per-column widths exactly; sizing the table to their
+  // sum keeps each column predictable and lets the wrapper scroll horizontally
+  // when the user widens a column past the canvas.
+  const totalWidth = TASK_COLUMNS.reduce((sum, c) => sum + widths[c.key], 0);
+
   return (
     <ReorderDndProvider>
       <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table
+          className="text-sm"
+          style={{ tableLayout: "fixed", width: totalWidth }}
+        >
+          <colgroup>
+            {TASK_COLUMNS.map((c) => (
+              <col key={c.key} style={{ width: widths[c.key] }} />
+            ))}
+          </colgroup>
           <thead>
             <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              <th className="pb-2 pr-3 w-8">#</th>
-              <th className="pb-2 pr-3">Kind</th>
-              <th className="pb-2 pr-3">Source</th>
-              <th className="pb-2 pr-3">Output</th>
-              <th className="pb-2 pr-3">Status</th>
-              <th className="pb-2">Actions</th>
+              {TASK_COLUMNS.map((c) => (
+                <th
+                  key={c.key}
+                  className={cn("pb-2 pr-3", c.resizable && "relative")}
+                >
+                  {c.label}
+                  {c.resizable && (
+                    <ColumnResizeHandle
+                      columnKey={c.key}
+                      isDragging={draggingKey === c.key}
+                      {...getSeparatorProps(c.key)}
+                    />
+                  )}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -140,15 +140,16 @@ function TaskRowImpl({ index }: TaskRowProps) {
         </span>
       </td>
 
-      {/* Source basename */}
-      <td className="py-2 pr-3 font-mono text-foreground">
+      {/* Source basename — break long names so they wrap within the column's
+          fixed width instead of forcing it wider. */}
+      <td className="py-2 pr-3 font-mono text-foreground break-words">
         {basename(row.path)}
       </td>
 
       {/* Output preview name */}
       <td
         data-testid={`output-cell-${index}`}
-        className="py-2 pr-3 font-mono text-muted-foreground"
+        className="py-2 pr-3 font-mono text-muted-foreground break-words"
       >
         {row.previewName}
       </td>

--- a/src/components/task-columns.ts
+++ b/src/components/task-columns.ts
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------------
+// Queue table column model
+// ---------------------------------------------------------------------------
+//
+// Single source of truth for the queue table's columns: their order, header
+// labels, and resize bounds. `TaskList` renders the header (and the matching
+// `<colgroup>`) from this list, and `useColumnResize` reads the bounds from it.
+// `TaskRow` emits its `<td>` cells in the same order, so the column widths set
+// here drive the body cells too under `table-layout: fixed`.
+
+/** Stable identifiers for the queue table's columns, in render order. */
+export type TaskColumnKey =
+  | "index"
+  | "kind"
+  | "source"
+  | "output"
+  | "status"
+  | "actions";
+
+export interface TaskColumnDef {
+  /** Stable key used for widths, handles, and the `<col>`/`<td>` ordering. */
+  key: TaskColumnKey;
+  /** Header text shown in the `<th>`. */
+  label: string;
+  /** Initial width in px (also the double-click reset target). */
+  defaultWidth: number;
+  /** Smallest width a drag may shrink the column to, in px. */
+  minWidth: number;
+  /** Whether the column carries a drag-to-resize handle on its right edge. */
+  resizable: boolean;
+}
+
+/** Largest width a drag may grow any column to, in px — keeps the table sane. */
+export const MAX_COLUMN_WIDTH = 800;
+
+/**
+ * The queue table columns in render order. `#` and `Actions` are fixed-width
+ * (no handle); the four content columns between them are resizable. Defaults sum
+ * to a comfortable table width that fills a typical canvas without forcing a
+ * horizontal scroll.
+ */
+export const TASK_COLUMNS: TaskColumnDef[] = [
+  {
+    key: "index",
+    label: "#",
+    defaultWidth: 48,
+    minWidth: 48,
+    resizable: false,
+  },
+  {
+    key: "kind",
+    label: "Kind",
+    defaultWidth: 88,
+    minWidth: 64,
+    resizable: true,
+  },
+  {
+    key: "source",
+    label: "Source",
+    defaultWidth: 360,
+    minWidth: 120,
+    resizable: true,
+  },
+  {
+    key: "output",
+    label: "Output",
+    defaultWidth: 200,
+    minWidth: 120,
+    resizable: true,
+  },
+  {
+    key: "status",
+    label: "Status",
+    defaultWidth: 176,
+    minWidth: 120,
+    resizable: true,
+  },
+  {
+    key: "actions",
+    label: "Actions",
+    defaultWidth: 150,
+    minWidth: 150,
+    resizable: false,
+  },
+];
+
+/** Lookup by key — avoids repeated `.find()` and non-null assertions. */
+export const COLUMN_BY_KEY: Record<TaskColumnKey, TaskColumnDef> =
+  Object.fromEntries(TASK_COLUMNS.map((c) => [c.key, c])) as Record<
+    TaskColumnKey,
+    TaskColumnDef
+  >;
+
+/**
+ * Clamp a candidate width to the column's [minWidth, MAX_COLUMN_WIDTH] range and
+ * round it to a whole pixel. A non-finite input (NaN) falls back to the column
+ * default. Mirrors the validate-before-use shape of {@link ../lib/rail-width}.
+ */
+export function clampColumnWidth(def: TaskColumnDef, width: number): number {
+  if (Number.isNaN(width)) return def.defaultWidth;
+  return Math.min(MAX_COLUMN_WIDTH, Math.max(def.minWidth, Math.round(width)));
+}

--- a/src/hooks/useColumnResize.test.ts
+++ b/src/hooks/useColumnResize.test.ts
@@ -1,0 +1,284 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { COLUMN_BY_KEY, MAX_COLUMN_WIDTH } from "@/components/task-columns";
+
+import { useColumnResize } from "./useColumnResize";
+
+/**
+ * Build a minimal stand-in for a React pointer event the hook reads from.
+ * `buttons` defaults to 1 (primary button held) so a move continues a drag;
+ * pass 0 to model a button-released / lost-capture move.
+ */
+function pointerEvent(clientX: number, buttons = 1): ReactPointerEvent {
+  return {
+    clientX,
+    buttons,
+    pointerId: 1,
+    preventDefault: () => {},
+    currentTarget: {
+      setPointerCapture: () => {},
+      releasePointerCapture: () => {},
+    },
+  } as unknown as ReactPointerEvent;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useColumnResize", () => {
+  it("starts every column at its default width with no active drag", () => {
+    const { result } = renderHook(() => useColumnResize());
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+    expect(result.current.widths.kind).toBe(COLUMN_BY_KEY.kind.defaultWidth);
+    expect(result.current.draggingKey).toBeNull();
+  });
+
+  it("exposes a non-focusable structural separator (no aria-value props)", () => {
+    const { result } = renderHook(() => useColumnResize());
+    const props = result.current.getSeparatorProps("source");
+    expect(props.role).toBe("separator");
+    expect(props["aria-orientation"]).toBe("vertical");
+    expect(props["aria-label"]).toBe("Resize Source column");
+    expect("aria-valuenow" in props).toBe(false);
+    expect("aria-valuemin" in props).toBe(false);
+    expect("aria-valuemax" in props).toBe(false);
+  });
+
+  it("widens a column as its handle drags right", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    expect(result.current.draggingKey).toBe("source");
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(160));
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth + 60,
+    );
+  });
+
+  it("narrows a column as its handle drags left", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(200));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(160));
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth - 40,
+    );
+  });
+
+  it("clamps the width while dragging past the column minimum", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(500));
+    });
+    act(() => {
+      result.current.getSeparatorProps("source").onPointerMove(pointerEvent(0));
+    });
+    expect(result.current.widths.source).toBe(COLUMN_BY_KEY.source.minWidth);
+  });
+
+  it("clamps the width while dragging past the maximum", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current.getSeparatorProps("source").onPointerDown(pointerEvent(0));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(9000));
+    });
+    expect(result.current.widths.source).toBe(MAX_COLUMN_WIDTH);
+  });
+
+  it("resizes only the dragged column, leaving the others untouched", () => {
+    const { result } = renderHook(() => useColumnResize());
+    const outputBefore = result.current.widths.output;
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(180));
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth + 80,
+    );
+    expect(result.current.widths.output).toBe(outputBefore);
+  });
+
+  it("ignores a move for a column whose handle is not the active drag", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    // A stray move on a different column's handle must not resize it.
+    act(() => {
+      result.current
+        .getSeparatorProps("output")
+        .onPointerMove(pointerEvent(400));
+    });
+    expect(result.current.widths.output).toBe(
+      COLUMN_BY_KEY.output.defaultWidth,
+    );
+  });
+
+  it("ignores pointer movement when no drag is in progress", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(999));
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+  });
+
+  it("ends the drag on pointer up", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(140));
+    });
+    act(() => {
+      result.current.getSeparatorProps("source").onPointerUp(pointerEvent(140));
+    });
+    expect(result.current.draggingKey).toBeNull();
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth + 40,
+    );
+  });
+
+  it("ends a stuck drag on pointer cancel", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerCancel(pointerEvent(140));
+    });
+    expect(result.current.draggingKey).toBeNull();
+    // A later hover (no drag in progress) must not move the column.
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(300));
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+  });
+
+  it("ends a stuck drag on lost pointer capture", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onLostPointerCapture(pointerEvent(100));
+    });
+    expect(result.current.draggingKey).toBeNull();
+  });
+
+  it("self-heals when a move arrives with no button held", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(300, 0));
+    });
+    expect(result.current.draggingKey).toBeNull();
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+  });
+
+  it("resets a column to its default width on double-click", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(260));
+    });
+    expect(result.current.widths.source).not.toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+    act(() => {
+      result.current.getSeparatorProps("source").onDoubleClick();
+    });
+    expect(result.current.widths.source).toBe(
+      COLUMN_BY_KEY.source.defaultWidth,
+    );
+  });
+
+  it("keeps widths in-session only — never writes to localStorage", () => {
+    const { result } = renderHook(() => useColumnResize());
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerDown(pointerEvent(100));
+    });
+    act(() => {
+      result.current
+        .getSeparatorProps("source")
+        .onPointerMove(pointerEvent(180));
+    });
+    act(() => {
+      result.current.getSeparatorProps("source").onPointerUp(pointerEvent(180));
+    });
+    act(() => {
+      result.current.getSeparatorProps("source").onDoubleClick();
+    });
+    // Nothing about column widths is ever persisted.
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/src/hooks/useColumnResize.ts
+++ b/src/hooks/useColumnResize.ts
@@ -1,0 +1,126 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useRef, useState } from "react";
+
+import type { TaskColumnKey } from "@/components/task-columns";
+import {
+  clampColumnWidth,
+  COLUMN_BY_KEY,
+  TASK_COLUMNS,
+} from "@/components/task-columns";
+
+/** ARIA + pointer handlers a column's resize handle spreads to become draggable. */
+export interface ColumnSeparatorProps {
+  role: "separator";
+  "aria-orientation": "vertical";
+  "aria-label": string;
+  onPointerDown: (event: ReactPointerEvent) => void;
+  onPointerMove: (event: ReactPointerEvent) => void;
+  onPointerUp: (event: ReactPointerEvent) => void;
+  onPointerCancel: (event: ReactPointerEvent) => void;
+  onLostPointerCapture: (event: ReactPointerEvent) => void;
+  onDoubleClick: () => void;
+}
+
+export interface ColumnResize {
+  /** Current width per column key, in px, each clamped to its own bounds. */
+  widths: Record<TaskColumnKey, number>;
+  /** The column currently being dragged, or null when no drag is in progress. */
+  draggingKey: TaskColumnKey | null;
+  /** Build the props to spread onto a column's right-edge resize handle. */
+  getSeparatorProps: (key: TaskColumnKey) => ColumnSeparatorProps;
+}
+
+/** Seed every column to its configured default width. */
+function defaultWidths(): Record<TaskColumnKey, number> {
+  return Object.fromEntries(
+    TASK_COLUMNS.map((c) => [c.key, c.defaultWidth]),
+  ) as Record<TaskColumnKey, number>;
+}
+
+/**
+ * Owns the per-column widths of the queue table: a pointer-drag resize on each
+ * resizable column's right edge and a double-click reset to its default. Each
+ * column is clamped to its own [minWidth, MAX_COLUMN_WIDTH] range and the
+ * columns are independent — dragging one never moves another.
+ *
+ * Widths live only in component state for the current session; nothing is
+ * persisted, so a restart returns every column to its default. The drag is
+ * tracked relative to its origin (pointer X and column width at pointerdown),
+ * so it is robust regardless of where the handle sits. Pointer capture keeps the
+ * gesture flowing even when the cursor leaves the thin handle; environments
+ * without it (e.g. jsdom) simply skip it. Teardown is shared by pointerup,
+ * pointercancel, and lost capture, and a move with no button held self-heals, so
+ * a drag can never get stuck active.
+ */
+export function useColumnResize(): ColumnResize {
+  const [widths, setWidths] =
+    useState<Record<TaskColumnKey, number>>(defaultWidths);
+  const [draggingKey, setDraggingKey] = useState<TaskColumnKey | null>(null);
+  // Drag origin captured at pointerdown; null when no drag is in progress.
+  const dragOrigin = useRef<{
+    key: TaskColumnKey;
+    pointerX: number;
+    width: number;
+  } | null>(null);
+  // Mirror the latest widths so a pointerdown can read the starting width
+  // without re-creating the handlers on every drag frame.
+  const widthsRef = useRef(widths);
+  widthsRef.current = widths;
+
+  const endDrag = useCallback(() => {
+    if (dragOrigin.current === null) return;
+    dragOrigin.current = null;
+    setDraggingKey(null);
+  }, []);
+
+  const getSeparatorProps = useCallback(
+    (key: TaskColumnKey): ColumnSeparatorProps => {
+      const def = COLUMN_BY_KEY[key];
+      return {
+        role: "separator",
+        "aria-orientation": "vertical",
+        "aria-label": `Resize ${def.label} column`,
+        onPointerDown: (event) => {
+          event.preventDefault();
+          dragOrigin.current = {
+            key,
+            pointerX: event.clientX,
+            width: widthsRef.current[key],
+          };
+          setDraggingKey(key);
+          try {
+            event.currentTarget.setPointerCapture?.(event.pointerId);
+          } catch (reason) {
+            // Pointer capture is unsupported in some environments (e.g. jsdom);
+            // the origin-relative math still tracks the drag, so ignore it.
+            void reason;
+          }
+        },
+        onPointerMove: (event) => {
+          const origin = dragOrigin.current;
+          if (origin === null || origin.key !== key) return;
+          // Self-heal a stuck drag: a move with no button held (interrupted
+          // gesture / lost capture) ends the drag instead of resizing on hover.
+          if (event.buttons === 0) {
+            endDrag();
+            return;
+          }
+          const next = clampColumnWidth(
+            def,
+            origin.width + (event.clientX - origin.pointerX),
+          );
+          setWidths((prev) => ({ ...prev, [key]: next }));
+        },
+        onPointerUp: endDrag,
+        onPointerCancel: endDrag,
+        onLostPointerCapture: endDrag,
+        onDoubleClick: () => {
+          setWidths((prev) => ({ ...prev, [key]: def.defaultWidth }));
+        },
+      };
+    },
+    [endDrag],
+  );
+
+  return { widths, draggingKey, getSeparatorProps };
+}


### PR DESCRIPTION
## Summary

The queue table's columns were fixed-width: the `<table>` used auto layout with Tailwind width hints and no `<colgroup>`, so long bracketed source titles clipped/wrapped with no way to give them more room. This makes the boundaries draggable — each of the **Kind / Source / Output / Status** columns gets a thin handle on its right edge that resizes that column, with a double-click to reset to its default. The `#` and Actions columns stay fixed. Widths are **session-only** (not persisted) per the agreed scope.

## Background / Motivation

- The queue `<table>` rendered with auto layout and per-`<th>` Tailwind hints (`w-8`, `pr-3`); column widths were not user-adjustable, so long source names like `[20240418][一般コミック]…` wrapped or clipped and the user could not widen the column to read them.
- The app already ships a pointer-driven drag resizer for the left pane (`usePaneResize`, #127). Reusing that proven pattern keeps the gesture consistent and sidesteps Tauri's HTML5-`drop` interception that broke native DnD on macOS WKWebView (#132) — pointer events are not intercepted in this webview.
- Unlike the pane width (which persists to `localStorage`), column widths are scoped to the current session only, so a restart returns every column to its default.

## Changes

### Column model

- `src/components/task-columns.ts` (new): single source of truth for the queue columns — `TASK_COLUMNS` (key / label / `defaultWidth` / `minWidth` / `resizable`), a `COLUMN_BY_KEY` lookup, `MAX_COLUMN_WIDTH` (800), and `clampColumnWidth` (validate-before-use, NaN → default). `#` (48 px) and Actions (150 px) are fixed; Kind / Source / Output / Status are resizable with per-column minimums.

### Resize behavior

- `src/hooks/useColumnResize.ts` (new): owns per-column widths in component state via an origin-relative pointer drag, mirroring `usePaneResize`. Teardown is shared across `pointerup`, `pointercancel`, and `lostpointercapture`, plus a no-button self-heal in `pointermove`, so a drag can never get stuck active; each column clamps to its own bounds and columns are independent. `getSeparatorProps(key)` returns the separator ARIA + handlers; pointer capture is wrapped in a `try/catch` (unsupported in jsdom). Nothing is persisted — widths seed from the configured defaults each session, and double-click resets a column to its default.

### The handle

- `src/components/ColumnResizeHandle.tsx` (new): a non-focusable structural divider absolutely positioned over a column's right edge inside its `relative` `<th>` — `role="separator"` + `aria-orientation="vertical"` + `aria-label`, deliberately carrying no `aria-value*`. Transparent at rest, highlights to the primary color on hover, stays highlighted while dragging (`data-dragging`), with the `col-resize` cursor and `touch-none`.

### Table wiring

- `src/components/TaskList.tsx`: switches the table to `table-layout: fixed` with a `<colgroup>` sized from the hook, and sets the table width to the sum of the column widths so each width is honored exactly; the existing `overflow-x-auto` wrapper scrolls horizontally when a column is widened past the canvas. The header now maps over `TASK_COLUMNS`, giving each resizable `<th>` `relative` positioning and a `ColumnResizeHandle`. The hook runs before the empty-state early return so widths survive the empty/non-empty toggle.
- `src/components/TaskRow.tsx`: the Source and Output cells get `break-words` so long names wrap within the column's fixed width instead of forcing it wider.

### Tests

- `useColumnResize.test.ts` (new): drag widen/narrow, clamp min/max, per-column independence, ignoring stray / no-drag moves, the cancel / lost-capture / no-button teardown paths, double-click reset, and an assertion that `localStorage` stays empty (session-only).
- `TaskList.test.tsx`: the `<colgroup>` renders each column at its default width, resize handles appear only on the resizable columns (none on `#` / Actions), and an end-to-end pointer drag updates the Source `<col>` width.

## Verification

- Add 2+ items, then drag the handle at a column's right edge to widen/narrow it; double-click a handle to snap that column back to its default. Widen Source past the canvas and the queue scrolls horizontally. Reload/restart and every column returns to its default (no persistence).
- DOM: handles are `[role="separator"][data-testid="column-resize-<key>"]` on `kind` / `source` / `output` / `status` only; the active drag carries `data-dragging="true"`; each `<colgroup>` `<col>` carries the inline `width`.
- Frontend gates green by exit code: `pnpm test` (428 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 428 passed (incl. drag/clamp/independence/teardown/reset + TaskList colgroup & handle integration)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): drag each resizable column's handle to widen/narrow; double-click to reset; widen Source past the canvas to confirm horizontal scroll; restart to confirm columns return to defaults
