### PR TITLE
fix(tauri): scope opener open_path so Open folder button works

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,10 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "opener:allow-open-path",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "**" }]
+    },
     "opener:allow-reveal-item-in-dir",
     "dialog:default",
     "clipboard-manager:allow-write-text"

--- a/src-tauri/tests/capabilities_open_path_scope.rs
+++ b/src-tauri/tests/capabilities_open_path_scope.rs
@@ -1,0 +1,59 @@
+//! Guard: the `opener:allow-open-path` grant must carry a non-empty path scope.
+//!
+//! The opener plugin's `open_path` command (used by the Ledger's "Open folder"
+//! button via `lib/reveal.ts`) is scope-checked: `is_path_allowed` returns false
+//! whenever the allowed path scope is empty, so the call is rejected at runtime
+//! with `ForbiddenPath` ("Not allowed to open path ..."). A bare-string grant
+//! (`"opener:allow-open-path"`) only enables the command "without any
+//! pre-configured scope", so it leaves that scope empty and breaks the button.
+//!
+//! This differs from `reveal_item_in_dir` (the per-row Reveal action), which the
+//! plugin runs without any scope check — which is why Reveal worked while
+//! "Open folder" did not.
+//!
+//! The fix is to grant `opener:allow-open-path` in object form with a path
+//! `allow` list. This test fails on the bare-string form and passes once a
+//! non-empty path scope is present.
+
+use serde_json::Value;
+
+const CAPABILITY: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/capabilities/default.json"
+));
+
+#[test]
+fn open_path_grant_carries_a_non_empty_path_scope() {
+    let capability: Value =
+        serde_json::from_str(CAPABILITY).expect("capabilities/default.json is valid JSON");
+
+    let permissions = capability["permissions"]
+        .as_array()
+        .expect("capability has a `permissions` array");
+
+    let open_path_is_scoped = permissions.iter().any(|permission| {
+        let is_open_path =
+            permission.get("identifier").and_then(Value::as_str) == Some("opener:allow-open-path");
+
+        let has_path_scope = permission
+            .get("allow")
+            .and_then(Value::as_array)
+            .is_some_and(|entries| {
+                entries.iter().any(|entry| {
+                    entry
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .is_some_and(|path| !path.is_empty())
+                })
+            });
+
+        is_open_path && has_path_scope
+    });
+
+    assert!(
+        open_path_is_scoped,
+        "opener:allow-open-path must be granted as an object with a non-empty `allow` path \
+         scope; a bare-string grant leaves the scope empty and the opener plugin rejects \
+         open_path with \"Not allowed to open path ...\""
+    );
+}


### PR DESCRIPTION
## Summary

The Ledger's **Open folder** button (and the OUTPUT summary's open action) errored with `Not allowed to open path /Users/.../Downloads` instead of opening the run's output directory. The opener plugin's `open_path` command is scope-checked, but the capability granted it without a path scope, so every call was rejected. This grants `opener:allow-open-path` an explicit path scope so the button opens the destination folder.

## Background / Motivation

- `lib/reveal.ts` `openPath()` calls the opener plugin's `open_path`, which is scope-checked: `is_path_allowed` returns false whenever the allowed path scope is empty, and the command then fails with `ForbiddenPath` → `Not allowed to open path ...`.
- In `src-tauri/capabilities/default.json` the grant was the bare string `"opener:allow-open-path"`. That permission is documented by the plugin as enabling the command "without any pre-configured scope", so it left the path scope empty and broke the button.
- The per-row **Reveal** action kept working because it routes through `reveal_item_in_dir`, which the plugin runs with no scope check at all — which is why Reveal worked while Open folder did not.
- The output destination is any folder the user picks in the native dialog (default: the OS Downloads dir), so the scope must cover arbitrary absolute paths, not just `$HOME`.

## Changes

### Opener path scope (`src-tauri/capabilities/default.json`)

- Replaced the bare-string `"opener:allow-open-path"` grant with the object form carrying a path `allow` list: `{ "identifier": "opener:allow-open-path", "allow": [{ "path": "**" }] }`. `reveal_item_in_dir`, dialog, and clipboard grants are unchanged.
- `**` matches any absolute path under the plugin's match options (`require_literal_separator: true`), so it covers the Downloads default and any other folder the user selects (verified against `/Users/.../Downloads`, nested paths, and `/Volumes/...`).

### Regression test (`src-tauri/tests/capabilities_open_path_scope.rs`)

- New integration test that parses `capabilities/default.json` and asserts `opener:allow-open-path` is granted in object form with a non-empty `allow` path scope. It fails on the bare-string form (reproducing the bug) and passes once a path scope is present, guarding against a future revert to the unscoped grant.

## Verification

- In the packaged/dev app, run a batch and click **Open folder** (or the OUTPUT open action): Finder opens the destination directory instead of showing the red `Not allowed to open path ...` banner. The per-row Reveal/Copy actions are unaffected.
- Config: `capabilities/default.json` lists `opener:allow-open-path` as an object with `"allow": [{ "path": "**" }]`, not a bare string.

## Test plan

- [x] `cargo nextest run -p simple-archiver --profile ci` — 101 passed (incl. new `open_path_grant_carries_a_non_empty_path_scope`; confirmed RED on the bare-string grant first)
- [x] `cargo clippy -p simple-archiver --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] No DTO/contract change → no `src/bindings/*.ts` regeneration
- [ ] Manual (packaged app): run a batch, click Open folder, confirm Finder opens the output directory with no error banner
