### PR TITLE
feat(ui): move Clear button to the queue toolbar

### DIFF
--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -35,9 +35,9 @@ const NEW_BATCH_CONFIG: ResetDialogConfig = {
  * the store's reset() so the user never accidentally clears the queue.
  *
  * Copy is summary-aware: "Clear" while a batch is being assembled, "New batch"
- * once a run summary is present. This action used to live in the StatusBar
- * footer; it now sits beside the Run control in the left rail so the queue's two
- * verbs (reset vs run) share one row.
+ * once a run summary is present. It now sits at the left of the queue toolbar in
+ * the right canvas (the ghost variant keeps it visually subordinate to the
+ * outline Add buttons sharing that row and the brand Run in the left rail).
  *
  * It is fully self-contained (no props): it reads its visibility and the reset
  * action from the store, so it is a drop-in wherever the run row is composed.
@@ -78,7 +78,7 @@ export function ResetButton() {
     <>
       <Button
         type="button"
-        variant="outline"
+        variant="ghost"
         size="sm"
         onClick={handleResetClick}
       >

--- a/src/components/RightCanvas.test.tsx
+++ b/src/components/RightCanvas.test.tsx
@@ -69,6 +69,38 @@ describe("RightCanvas", () => {
     expect(screen.getByRole("button", { name: /add folder/i })).toBeTruthy();
   });
 
+  it("offers the Clear action in the queued-phase toolbar", () => {
+    // The reset (Clear) action now lives at the left of the queue toolbar, so it
+    // must render whenever the queue is populated and idle.
+    setItems(2);
+    render(<RightCanvas />);
+    expect(screen.getByRole("button", { name: /^clear$/i })).toBeTruthy();
+  });
+
+  it("does not render the Clear action in the empty phase", () => {
+    render(<RightCanvas />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
+  it("does not render the Clear action while running", () => {
+    setItems(2);
+    useJobStore.setState({
+      running: true,
+      progress: {
+        overall: { bytesDone: 5, bytesTotal: 10 },
+        perTask: [{ taskId: 1, bytesDone: 5, bytesTotal: 10, etaMs: null }],
+        elapsedMs: 1,
+        overallEtaMs: null,
+      },
+    });
+    render(<RightCanvas />);
+    expect(
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
+  });
+
   it("renders overall progress and the task list while running", () => {
     setItems(2);
     useJobStore.setState({

--- a/src/components/RightCanvas.tsx
+++ b/src/components/RightCanvas.tsx
@@ -3,6 +3,7 @@ import { EmptyQueue } from "@/components/EmptyQueue";
 import { LastBatchChip } from "@/components/LastBatchChip";
 import { Ledger } from "@/components/Ledger";
 import { OverallProgress } from "@/components/OverallProgress";
+import { ResetButton } from "@/components/ResetButton";
 import { TaskList } from "@/components/TaskList";
 import { canvasPhase } from "@/lib/canvas-phase";
 import { useJobStore } from "@/store/jobStore";
@@ -42,10 +43,13 @@ export function RightCanvas() {
       {phase === "empty" ? <EmptyQueue /> : null}
       {phase === "queued" ? (
         <div className="flex flex-col gap-4">
-          {/* Browse fallback for adding more sources once the queue is no longer
-              empty (drag-and-drop still works via the app-level DropOverlay). The
-              empty-state drop zone owns this affordance while the queue is empty. */}
-          <div className="flex justify-end">
+          {/* Queue toolbar: the destructive Clear (ResetButton) anchors the left
+              edge, while the browse fallback for adding more sources sits at the
+              right (drag-and-drop still works via the app-level DropOverlay). The
+              empty-state drop zone owns the browse affordance while the queue is
+              empty; ResetButton renders nothing until the queue is populated. */}
+          <div className="flex items-center justify-between gap-2">
+            <ResetButton />
             <AddSourceButtons />
           </div>
           <TaskList />

--- a/src/components/RunControls.test.tsx
+++ b/src/components/RunControls.test.tsx
@@ -476,8 +476,10 @@ describe("RunControls – overwrite confirmation", () => {
   });
 });
 
-describe("RunControls – reset action placement", () => {
-  it("renders the Clear action beside Run when idle with items", () => {
+describe("RunControls – reset action moved out", () => {
+  // The reset action (Clear / New batch) has moved to the queue toolbar in the
+  // right canvas, so RunControls must no longer render it in any state.
+  it("does not render the Clear action when idle with items", () => {
     useJobStore.setState({
       draft: {
         items: [ITEM],
@@ -492,18 +494,14 @@ describe("RunControls – reset action placement", () => {
       summary: null,
     });
     render(<RunControls />);
-    const clear = screen.getByRole("button", { name: /^clear$/i });
-    const run = screen.getByRole("button", { name: /^run$/i });
-    expect(clear).toBeTruthy();
-    expect(run).toBeTruthy();
-    // Approved layout: the destructive reset sits left of the primary Run, so
-    // Clear must precede Run in document order.
+    // Run still anchors the row; the reset action is gone.
+    expect(screen.getByRole("button", { name: /^run$/i })).toBeTruthy();
     expect(
-      clear.compareDocumentPosition(run) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: /clear|new batch/i }),
+    ).toBeNull();
   });
 
-  it("renders the New batch action beside Run when a summary is present", () => {
+  it("does not render the New batch action when a summary is present", () => {
     useJobStore.setState({
       draft: {
         items: [ITEM],
@@ -516,24 +514,6 @@ describe("RunControls – reset action placement", () => {
       running: false,
       error: null,
       summary: { succeeded: [1], cancelled: [], failed: [], results: [] },
-    });
-    render(<RunControls />);
-    expect(screen.getByRole("button", { name: /^new batch$/i })).toBeTruthy();
-  });
-
-  it("does not render the reset action when the queue is empty", () => {
-    useJobStore.setState({
-      draft: {
-        items: [],
-        namingTemplate: null,
-        startNumber: 1,
-        outputDir: "/out",
-        outputMode: "zip",
-        conflictPolicy: "autoRename",
-      },
-      running: false,
-      error: null,
-      summary: null,
     });
     render(<RunControls />);
     expect(

--- a/src/components/RunControls.tsx
+++ b/src/components/RunControls.tsx
@@ -1,7 +1,6 @@
 import { Check, CircleDot, Play } from "lucide-react";
 import * as React from "react";
 
-import { ResetButton } from "@/components/ResetButton";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -46,14 +45,14 @@ function ReadinessChip({ readiness }: { readiness: Readiness }) {
 
 /**
  * RunControls renders the queue's run row for the current state:
- *   - idle  (running === false): the reset action (Clear / New batch) anchored
- *     left, with the readiness chip + Run grouped at the right edge.
+ *   - idle  (running === false): the readiness chip + Run grouped at the right
+ *     edge.
  *   - active (running === true): Cancel only (Run is not in the DOM), kept at the
  *     right edge so the primary button does not jump when toggling Run↔Cancel.
  *
- * The destructive reset action and the primary brand Run sit at opposite ends of
- * the row to minimise misclicks; the right group is pushed right with `ml-auto`
- * so Run stays anchored even when the reset action is hidden (empty queue).
+ * Both states anchor the primary button (Run / Cancel) at the right edge so it
+ * never shifts position. The reset action (Clear / New batch) lives in the queue
+ * toolbar in the right canvas, not here.
  *
  * Run retains full accessible-disabled semantics (aria-disabled / aria-describedby /
  * sr-only reason span / title / handler guard) so assistive technology can announce
@@ -122,12 +121,8 @@ export function RunControls() {
   }
 
   return (
-    <div className="flex items-center gap-2">
-      {/* Destructive reset at the left edge, kept clear of the primary CTA. It
-          renders nothing when the queue is empty; the right group's ml-auto then
-          keeps Run anchored right with no positional jump. */}
-      <ResetButton />
-      <div className="ml-auto flex items-center gap-2">
+    <div className="flex items-center justify-end gap-2">
+      <div className="flex items-center gap-2">
         <ReadinessChip readiness={readiness} />
         <Button
           type="button"


### PR DESCRIPTION
## Summary

The Clear action lived in the **OUTPUT** rail footer next to Run, so the queue's two verbs were split across panes — you added items from the right-canvas toolbar but cleared them from the left rail. This moves Clear (`ResetButton`) into the right-canvas queued-phase toolbar, anchored at the **left edge** opposite the **Add files / Add folder** browse buttons, and restyles it from `outline` to the `ghost` variant so the destructive action stays visually subordinate to the outline Add buttons and the brand-red Run.

## Background / Motivation

- The Clear button rendered inside `RunControls` in the left rail footer, while the only other queue-mutating affordance (Add files / Add folder) sat in the right-canvas toolbar — so the "remove everything" and "add more" verbs were split across the two panes.
- The queued-phase toolbar (`<div className="flex justify-end">`) right-aligned the Add buttons and left a wide empty band on its left, the natural home for a queue-level Clear.
- A principal UI/UX review confirmed the placement: keep the rail's established "destructive at the left edge, primary at the right edge" spatial rule and transplant it to the toolbar (Clear left, Add right), so users reuse a mental model they already have.
- The review also called for `ghost` over `outline`: three equal `outline` buttons on one row would flatten the hierarchy, and a `destructive`/red Clear would dilute the brand red reserved for the single Run CTA. The ConfirmDialog (already inside `ResetButton`) remains the real guard against accidental clears, so the muted styling costs no safety.

## Changes

### Queue toolbar placement (`RightCanvas.tsx`)

- The queued-phase toolbar changes from `flex justify-end` to `flex items-center justify-between gap-2`, with `<ResetButton />` at the left edge and `<AddSourceButtons />` at the right. Added the `ResetButton` import. In the queued phase `itemCount > 0` is always true, so Clear always renders and the left edge is never empty; the toolbar comment was rewritten to describe the destructive-left / browse-right split.

### Clear button styling (`ResetButton.tsx`)

- `variant="outline"` → `variant="ghost"` (`size="sm"` and the `RotateCcw` icon kept). The component docstring's placement paragraph was rewritten from the stale "left rail / beside Run / StatusBar footer" wording to "now sits at the left of the queue toolbar in the right canvas", noting the ghost-variant rationale. Logic is unchanged — it is still self-contained (no props), reads its visibility and `reset()` from the store, and owns its ConfirmDialog.

### Run row cleanup (`RunControls.tsx`)

- Removed the `ResetButton` import and its JSX from the run row. The idle branch's outer container changes from `flex items-center gap-2` to `flex items-center justify-end gap-2` and the inner Run group drops its `ml-auto`, so idle now anchors Run at the right edge exactly like the running branch anchors Cancel — no positional jump on Run↔Cancel toggle, and no leftover empty left half. The docstring and the destructive-reset / `ml-auto` comments were updated to drop the reset-action description.

### Tests

- `RightCanvas.test.tsx`: added three cases — Clear shows in the queued toolbar (`name: /^clear$/i`), Clear is absent in the empty phase, and Clear is absent while running. The existing Add files / Add folder assertion is kept.
- `RunControls.test.tsx`: replaced the "reset action placement (Clear beside Run)" block with a regression block — Clear is absent when idle-with-items (Run still present), New batch is absent when a summary is present, and the reset action is absent while running. The RUN / ReadinessChip / Cancel / overwrite cases are untouched.
- `ResetButton.test.tsx`: unchanged — all queries use `name: /clear/i` (variant-independent) and still pass.

The `Ledger` "Clear results" button (results phase, `clearResults()`) is intentionally left as-is — it is a separate, results-phase affordance outside this change's scope.

## Verification

- Add 2+ items: Clear appears at the **left** of the queue toolbar with Add files / Add folder at the right; the rail footer now shows only the readiness chip + Run, right-anchored. Click Clear and the ConfirmDialog still gates the reset.
- Empty queue and mid-run: Clear is not rendered (the empty-state drop zone owns the browse affordance; the rail footer shows Cancel only while running).
- DOM: in the queued phase, the Clear control resolves via `getByRole("button", { name: /clear/i })` inside the right-canvas toolbar (a `ghost`-variant button), and is no longer present in `RunControls`.
- No backend / DTO change → no `src/bindings/*.ts` regeneration.
- Frontend gates green by exit code: `pnpm test` (441 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 441 passed (incl. the new RightCanvas Clear-visibility cases and the RunControls reset-moved-out regression)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): add items and confirm Clear sits at the left of the queue toolbar with Add files / Add folder at the right; confirm the ConfirmDialog still gates Clear; confirm the rail footer shows only Run (idle) / Cancel (running) with no positional jump
