### PR TITLE
feat(ui): move If exists control above the destination in output rail

### DIFF
--- a/src/components/LeftRail.test.tsx
+++ b/src/components/LeftRail.test.tsx
@@ -81,6 +81,20 @@ describe("LeftRail", () => {
     expect(screen.queryByLabelText("Start #")).toBeNull();
   });
 
+  it("places the If exists control above the Destination section in folder mode", () => {
+    setMode("folder", "/out");
+    render(<LeftRail />);
+    const conflictPolicy = screen.getByRole("radiogroup", {
+      name: /a folder already exists/i,
+    });
+    const destination = screen.getByText("Destination");
+    // The conflict policy must precede the Destination block in document order.
+    expect(
+      conflictPolicy.compareDocumentPosition(destination) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("renders the Output as mode toggle", () => {
     render(<LeftRail />);
     expect(screen.getByRole("radiogroup", { name: /output as/i })).toBeTruthy();

--- a/src/components/LeftRail.tsx
+++ b/src/components/LeftRail.tsx
@@ -12,9 +12,10 @@ import { selectFirstPreview, useJobStore } from "@/store/jobStore";
 /**
  * The left rail: the fixed, never-moving column of OUTPUT settings and the run
  * action. It composes the existing OUTPUT sub-controls in a vertical stack —
- * the collapsed Destination summary, a compact full-path preview, the mode
- * toggle, the zip-mode naming/start fields (or the folder-mode collision
- * policy), and RunControls (readiness chip + Run / Cancel).
+ * the mode toggle, the folder-mode collision policy (pinned under the header,
+ * above the destination), the collapsed Destination summary, a compact
+ * full-path preview, the zip-mode naming/start fields (or a folder-mode
+ * extraction note), and RunControls (readiness chip + Run / Cancel).
  *
  * This is a relayout of the controls that previously lived in OutputSettings +
  * SetupToolbar: the controls and their store wiring are unchanged; only their
@@ -66,6 +67,18 @@ export function LeftRail() {
         <OutputModeToggle />
       </div>
 
+      {/* Folder-mode collision policy: pinned directly under the OUTPUT header,
+          ahead of the destination, so the "if a folder already exists" choice is
+          the first decision seen when extracting to folders. */}
+      {outputMode === "folder" ? (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            If exists
+          </span>
+          <ConflictPolicySelect />
+        </div>
+      ) : null}
+
       {/* Collapsed Destination: path or "(not set)" + Required, with Change. */}
       <OutputDirPicker />
 
@@ -103,25 +116,16 @@ export function LeftRail() {
       </div>
 
       {/* Mode-specific editing controls: naming + start number in zip mode, the
-          collision policy (and an extraction note) in folder mode. */}
+          extraction note in folder mode (the collision policy sits up top). */}
       {outputMode === "zip" ? (
         <div className="flex flex-col gap-3">
           <NamingRuleForm />
           <StartNumberForm />
         </div>
       ) : (
-        <div className="flex flex-col gap-2">
-          <p className="text-xs text-muted-foreground">
-            Each archive is extracted into its own folder named after the
-            archive.
-          </p>
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-muted-foreground">
-              If exists
-            </span>
-            <ConflictPolicySelect />
-          </div>
-        </div>
+        <p className="text-xs text-muted-foreground">
+          Each archive is extracted into its own folder named after the archive.
+        </p>
       )}
 
       {/* The run action lives at the foot of the rail, pushed to the bottom so it


### PR DESCRIPTION
## Summary

In folder mode the **If exists** conflict policy (`Auto-rename` / `Skip` / `Overwrite`) sat at the bottom of the rail's mode-specific section — below the destination, the full-path preview, and the extraction note — so the collision decision was the last thing seen. This pins the control directly under the **OUTPUT** header, above the Destination block, so "what happens if a folder already exists" is the first decision when extracting to folders. It stays folder-mode only and keeps its existing store wiring; only its placement moves.

## Background / Motivation

- The `ConflictPolicySelect` ("If exists") rendered inside the folder-mode branch *after* the extraction note, leaving the policy — the only behavioural choice in folder mode — buried at the very bottom of the OUTPUT settings.
- Reading order put the destination, the `▸ <archive name>/` preview, and the prose note ahead of the one control that changes what the run actually does on a name clash.
- Promoting the policy to the top, right under the mode toggle, surfaces the collision decision before the destination, matching the intent in the design (move the boxed control up to the line under the OUTPUT header).

## Changes

### Conflict policy placement (`LeftRail.tsx`)

- Moved the `If exists` block (the `text-xs font-medium` label + `<ConflictPolicySelect />`) out of the folder-mode mode-specific branch and rendered it directly after the OUTPUT header, gated on `outputMode === "folder"` (`null` in zip mode), above `<OutputDirPicker />`.
- The folder-mode branch now renders only the extraction note, collapsed from a `flex flex-col gap-2` wrapper around two children to a single `<p>`.
- Updated the component docstring's layout summary and the two block comments to reflect the new order (collision policy pinned under the header; the mode-specific branch holds the extraction note).

### Tests (`LeftRail.test.tsx`)

- Added a case asserting the placement: in folder mode the `radiogroup` named *"a folder already exists"* precedes the `Destination` block in document order (via `compareDocumentPosition` + `DOCUMENT_POSITION_FOLLOWING`). Verified RED first — it failed on the old bottom placement, then passed after the move.
- Existing folder/zip-mode cases are unchanged: the policy still renders only in folder mode and is absent in zip mode.

## Verification

- Switch the OUTPUT mode to **Folder**: the `If exists` segmented control (Auto-rename / Skip / Overwrite) now sits directly under the OUTPUT header, above DESTINATION; the extraction note remains below the path preview.
- Switch to **.zip file**: no `If exists` control appears at the top (the top slot renders `null` in zip mode); the naming / start-number fields are unchanged.
- DOM: `getByRole("radiogroup", { name: /a folder already exists/i })` resolves before `getByText("Destination")` in folder mode.
- No backend / DTO change → no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 442 passed (incl. the new placement assertion; confirmed RED on the old layout first)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): toggle Folder mode and confirm the If exists control sits under the OUTPUT header above DESTINATION, and is absent in .zip mode
