### PR TITLE
feat(ui): soft-fill the Clear button so it reads as a button

### DIFF
--- a/src/components/ResetButton.test.tsx
+++ b/src/components/ResetButton.test.tsx
@@ -229,3 +229,20 @@ describe("ResetButton – confirm dialog", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 });
+
+describe("ResetButton – affordance", () => {
+  beforeEach(() => resetJobStore());
+
+  // Soft-fill (secondary) gives the button visible mass so it reads as a button,
+  // while staying chromatically quiet so it does not compete with the brand Run.
+  it("uses the secondary soft-fill variant", () => {
+    useJobStore.setState({
+      draft: draftWith([ITEM]),
+      running: false,
+      summary: null,
+    });
+    render(<ResetButton />);
+    const btn = screen.getByRole("button", { name: /^clear$/i });
+    expect(btn.className).toContain("bg-secondary");
+  });
+});

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -35,9 +35,12 @@ const NEW_BATCH_CONFIG: ResetDialogConfig = {
  * the store's reset() so the user never accidentally clears the queue.
  *
  * Copy is summary-aware: "Clear" while a batch is being assembled, "New batch"
- * once a run summary is present. It now sits at the left of the queue toolbar in
- * the right canvas (the ghost variant keeps it visually subordinate to the
- * outline Add buttons sharing that row and the brand Run in the left rail).
+ * once a run summary is present. It sits at the left of the queue toolbar in the
+ * right canvas. The secondary variant gives it a calm, zero-saturation soft fill
+ * so it clearly reads as a button (unlike the old ghost variant, which had no
+ * border or fill and went unnoticed) while staying chromatically quiet — it does
+ * not compete with the brand-red Run in the left rail, keeping red reserved for
+ * the primary action.
  *
  * It is fully self-contained (no props): it reads its visibility and the reset
  * action from the store, so it is a drop-in wherever the run row is composed.
@@ -78,7 +81,7 @@ export function ResetButton() {
     <>
       <Button
         type="button"
-        variant="ghost"
+        variant="secondary"
         size="sm"
         onClick={handleResetClick}
       >


### PR DESCRIPTION
## Summary

PR #138 moved Clear into the queue toolbar and restyled it to the `ghost` variant to keep it subordinate to the brand-red Run — but `ghost` has no border and no fill, so the button stopped reading as a button and was easy to miss. This switches the Clear / New-batch button (`ResetButton`) to the `secondary` soft-fill variant: a calm, zero-saturation fill that gives it visible mass so it clearly reads as a button, while staying chromatically quiet so it still does not compete with the brand-red Run.

## Background / Motivation

- After #138 the Clear button used `variant="ghost"`: no border, no fill — it floated next to the bordered **Add files / Add folder** buttons and did not look clickable, the exact discoverability gap this PR closes.
- The constraint from #138's review still holds: red is reserved for the single Run CTA, so a `destructive` / red Clear is off the table — the fix must raise affordance **without adding colour**.
- A principal UI/UX review compared five affordance options (outline parity, recessive outline, soft fill, danger-on-hover, icon-led zoning). **Soft fill** was chosen: the fill makes it unmistakably a button, and because it is fully desaturated it does not dilute the brand red. The `ConfirmDialog` inside `ResetButton` remains the real guard against accidental clears, so the calmer-than-Run styling costs no safety.
- Resulting hierarchy: **Run** (brand red, strongest) > **Add** (outline) ≈ **Clear** (soft fill) — Clear and Add sit at a similar weight but are differentiated by *texture* (fill vs. border), not colour.

## Changes

### Clear button styling (`ResetButton.tsx`)

- `variant="ghost"` → `variant="secondary"`. `size="sm"`, the `RotateCcw` icon, the summary-aware `Clear` / `New batch` labels, the visibility logic (`itemCount > 0 && !running`), and the `ConfirmDialog` flow are all unchanged.
- Rewrote the docstring's placement paragraph from the stale "the ghost variant keeps it visually subordinate" wording to describe the soft-fill rationale (reads as a button; stays chromatically quiet; keeps red reserved for Run).
- Light and dark modes both inherit the change through the existing `--secondary` tokens (`#f5f5f5` / `#232327`) — no token edits.

### Tests (`ResetButton.test.tsx`)

- Added a `ResetButton – affordance` block asserting the rendered Clear button's `className` contains `bg-secondary`, matching the variant-assertion idiom in `ui/button.test.tsx`. Verified RED first (the old `ghost` variant has no `bg-secondary`), then GREEN after the variant flip.
- Existing visibility / label / `ConfirmDialog` cases are unchanged — they query by `name: /clear|new batch/i` (variant-independent) and still pass.

## Verification

- Add 2+ items: the Clear button at the **left** of the queue toolbar now shows a soft fill (it reads as a button), while Add files / Add folder keep their outline and Run keeps its red — Clear no longer blends into the toolbar.
- DOM: in the queued phase the Clear control resolves via `getByRole("button", { name: /clear/i })` and its `className` contains `bg-secondary` (no `bg-brand`, no red).
- Light and dark: the fill is `--secondary` in both themes; no other control changes.
- No backend / DTO change → no `src/bindings/*.ts` regeneration.
- Frontend gates green by exit code: `pnpm test` (442 passed), `pnpm fmt:check` (oxfmt 0.55.0 --check), `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings), `pnpm build` (tsc && vite build), `pnpm knip`.

## Test plan

- [x] `pnpm test` — 442 passed (incl. the new `bg-secondary` affordance assertion; confirmed RED on the old `ghost` variant first)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): add items and confirm the Clear button shows a soft fill that reads as a button, distinct from the outline Add buttons and the brand-red Run, in both light and dark mode
