### PR TITLE
feat(ui): select queue rows and delete them with the keyboard

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -610,6 +610,141 @@ describe("TaskList pointer reorder", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Keyboard selection + delete
+//
+// The queue region owns a scoped keydown handler: Cmd/Ctrl+A selects every row,
+// Delete/Backspace removes the selection, Escape clears it. The handler lives on
+// the focusable queue container (not the document) so it never hijacks Cmd+A or
+// Delete inside the naming-template input or elsewhere.
+// ---------------------------------------------------------------------------
+
+describe("TaskList keyboard selection", () => {
+  function setItems(n: number, extra: Record<string, unknown> = {}) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(n),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      ...extra,
+    });
+  }
+
+  function region() {
+    return screen.getByTestId("queue-region");
+  }
+
+  it("selects all rows on Cmd+A", () => {
+    const selectAll = vi.fn();
+    setItems(3, { selectAll });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "a", metaKey: true });
+
+    expect(selectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects all rows on Ctrl+A", () => {
+    const selectAll = vi.fn();
+    setItems(3, { selectAll });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "a", ctrlKey: true });
+
+    expect(selectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not select all on a bare 'a' without a modifier", () => {
+    const selectAll = vi.fn();
+    setItems(3, { selectAll });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "a" });
+
+    expect(selectAll).not.toHaveBeenCalled();
+  });
+
+  it("deletes the selection on Delete", () => {
+    const deleteSelected = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { selectedIndices: [0, 1], deleteSelected });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "Delete" });
+
+    expect(deleteSelected).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the selection on Backspace", () => {
+    const deleteSelected = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { selectedIndices: [2], deleteSelected });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "Backspace" });
+
+    expect(deleteSelected).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not delete when nothing is selected", () => {
+    const deleteSelected = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { selectedIndices: [], deleteSelected });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "Delete" });
+
+    expect(deleteSelected).not.toHaveBeenCalled();
+  });
+
+  it("clears the selection on Escape", () => {
+    const clearSelection = vi.fn();
+    setItems(3, { selectedIndices: [0], clearSelection });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "Escape" });
+
+    expect(clearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores the shortcuts while a job is running", () => {
+    const selectAll = vi.fn();
+    const deleteSelected = vi.fn().mockResolvedValue(undefined);
+    setItems(3, {
+      selectedIndices: [0],
+      selectAll,
+      deleteSelected,
+      running: true,
+      progress: {
+        overall: { bytesDone: 0, bytesTotal: 0 },
+        overallEtaMs: null,
+        perTask: [],
+        elapsedMs: 0,
+      },
+    });
+    render(<TaskList />);
+
+    fireEvent.keyDown(region(), { key: "a", metaKey: true });
+    fireEvent.keyDown(region(), { key: "Delete" });
+
+    expect(selectAll).not.toHaveBeenCalled();
+    expect(deleteSelected).not.toHaveBeenCalled();
+  });
+
+  it("does not respond to Cmd+A fired outside the queue region", () => {
+    const selectAll = vi.fn();
+    setItems(3, { selectAll });
+    render(<TaskList />);
+
+    // A keydown on the document body must not reach the scoped handler.
+    fireEvent.keyDown(document.body, { key: "a", metaKey: true });
+
+    expect(selectAll).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Column resize
 // ---------------------------------------------------------------------------
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -3,6 +3,7 @@ import { ReorderDndProvider } from "@/components/reorder-dnd";
 import { TASK_COLUMNS } from "@/components/task-columns";
 import { TaskRow } from "@/components/TaskRow";
 import { useColumnResize } from "@/hooks/useColumnResize";
+import { useQueueSelectionKeys } from "@/hooks/useQueueSelectionKeys";
 import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
@@ -23,6 +24,9 @@ export function TaskList() {
   // Column widths are owned here so the hook state survives the empty-state
   // toggle below (the hook must run before any early return).
   const { widths, draggingKey, getSeparatorProps } = useColumnResize();
+  // Queue-scoped keyboard shortcuts (select all / delete / clear). Stable across
+  // renders, so it is safe to call before the early return below.
+  const onKeyDown = useQueueSelectionKeys();
 
   if (items.length === 0) {
     return (
@@ -39,7 +43,23 @@ export function TaskList() {
 
   return (
     <ReorderDndProvider>
-      <div className="overflow-x-auto">
+      {/* The selectable queue: role="grid" + aria-multiselectable + per-row
+          aria-selected is the ARIA pattern for row selection, and makes this an
+          interactive element so tabIndex/onKeyDown are valid. tabIndex makes it
+          focusable — clicking a non-focusable row focuses this nearest focusable
+          ancestor — which scopes the shortcuts here so they never hijack Cmd+A /
+          Delete inside text inputs. The role lives on this wrapper (not the
+          <table>) so the table keeps its native semantics. */}
+      <div
+        className="overflow-x-auto outline-none"
+        role="grid"
+        aria-label="Queue rows"
+        aria-multiselectable
+        aria-keyshortcuts="Control+A Meta+A Delete Backspace"
+        tabIndex={0}
+        data-testid="queue-region"
+        onKeyDown={onKeyDown}
+      >
         <table
           className="text-sm"
           style={{ tableLayout: "fixed", width: totalWidth }}

--- a/src/components/TaskRow.test.tsx
+++ b/src/components/TaskRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -131,6 +131,142 @@ describe("TaskRow", () => {
     );
 
     expect(removeItem).toHaveBeenCalledWith(1);
+  });
+
+  it("selects the row when a non-interactive cell is clicked", () => {
+    const selectItem = vi.fn();
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      selectItem,
+    });
+    renderRow(0);
+
+    fireEvent.click(screen.getByText("archive.rar"));
+
+    expect(selectItem).toHaveBeenCalledWith(0, { meta: false, shift: false });
+  });
+
+  it("passes the Cmd/Ctrl and Shift modifiers from the click", () => {
+    const selectItem = vi.fn();
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      selectItem,
+    });
+    renderRow(0);
+
+    fireEvent.click(screen.getByText("archive.rar"), {
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(selectItem).toHaveBeenCalledWith(0, { meta: true, shift: true });
+  });
+
+  it("does not select the row when the delete button is clicked", async () => {
+    const selectItem = vi.fn();
+    const removeItem = vi.fn().mockResolvedValue(undefined);
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      selectItem,
+      removeItem,
+    });
+    const user = userEvent.setup();
+    renderRow(0);
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove archive.rar from queue" }),
+    );
+
+    expect(removeItem).toHaveBeenCalledWith(0);
+    expect(selectItem).not.toHaveBeenCalled();
+  });
+
+  it("does not select the row while a job is running", () => {
+    const selectItem = vi.fn();
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      running: true,
+      progress: {
+        overall: { bytesDone: 0, bytesTotal: 0 },
+        overallEtaMs: null,
+        perTask: [],
+        elapsedMs: 0,
+      },
+      selectItem,
+    });
+    renderRow(0);
+
+    fireEvent.click(screen.getByText("archive.rar"));
+
+    expect(selectItem).not.toHaveBeenCalled();
+  });
+
+  it("marks the row aria-selected when its index is in the selection", () => {
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      selectedIndices: [0],
+    });
+    renderRow(0);
+
+    expect(screen.getByRole("row").getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("is not aria-selected when its index is not in the selection", () => {
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+      selectedIndices: [],
+    });
+    renderRow(0);
+
+    expect(screen.getByRole("row").getAttribute("aria-selected")).toBe("false");
   });
 
   it("disables the delete button while a job is running", () => {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,5 +1,5 @@
 import { GripVertical, Trash2 } from "lucide-react";
-import { memo } from "react";
+import { memo, type MouseEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type { SourceKind } from "@/bindings/SourceKind";
@@ -79,11 +79,16 @@ function TaskRowImpl({ index }: TaskRowProps) {
         liveEtaMs: live?.etaMs ?? null,
         isFirst: index === 0,
         isLast: index === s.draft.items.length - 1,
+        // A flat boolean: only this row re-renders when its own selected state
+        // flips, leaving the rest of the list untouched.
+        isSelected: s.selectedIndices.includes(index),
         // The action reference is stable across renders, so it is safe to
         // return directly for shallow comparison.
         reorder: s.reorder,
         // Same stability guarantee as `reorder`, safe for the shallow compare.
         removeItem: s.removeItem,
+        // Stable action reference, safe for the shallow compare.
+        selectItem: s.selectItem,
         // Compute the text status here so the selector exposes a flat string
         // rather than the progress/summary/taskIdByIndex collections.
         status: computeStatus(
@@ -108,12 +113,31 @@ function TaskRowImpl({ index }: TaskRowProps) {
   // reflow cannot strip the right-align padding spaces formatBytes emits.
   const liveLabel = `${formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} · ETA ${formatEta(row.liveEtaMs)}`;
 
+  // Select this row on click. The action buttons (grip/up/down/delete) keep
+  // their own behavior, so clicks originating from a control are ignored; only
+  // a click on the row body selects. Selection is disabled while running, where
+  // the positional progress arrays must stay fixed.
+  const onRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
+    if (row.running) return;
+    if ((event.target as HTMLElement).closest("button")) return;
+    row.selectItem(index, {
+      meta: event.metaKey || event.ctrlKey,
+      shift: event.shiftKey,
+    });
+  };
+
   // Drag affordances: dim the row being dragged and highlight the row the
-  // pointer is currently over as the drop target. The grab cursor lives on the
-  // grip handle (the only element that starts a drag), not the whole row.
+  // pointer is currently over as the drop target. A selected row carries the
+  // accent highlight (the project's selected-state token); the grab cursor
+  // lives on the grip handle (the only element that starts a drag), not the row.
   const rowClassName = [
     "border-b border-border/50 transition-colors",
-    dnd.isDragging ? "opacity-40" : "hover:bg-muted/30",
+    !row.running && "cursor-pointer",
+    dnd.isDragging
+      ? "opacity-40"
+      : row.isSelected
+        ? "bg-accent"
+        : "hover:bg-muted/30",
     dnd.isOver && "bg-primary/10",
     // Suppress text selection across the list while any row is being dragged.
     dnd.isDraggingAny && "select-none",
@@ -124,6 +148,8 @@ function TaskRowImpl({ index }: TaskRowProps) {
   return (
     <tr
       {...dnd.rowProps}
+      onClick={onRowClick}
+      aria-selected={row.isSelected}
       data-dragging={dnd.isDragging || undefined}
       data-drop-target={dnd.isOver || undefined}
       className={rowClassName}

--- a/src/hooks/useQueueSelectionKeys.ts
+++ b/src/hooks/useQueueSelectionKeys.ts
@@ -1,0 +1,46 @@
+import { type KeyboardEvent, useCallback } from "react";
+
+import { useJobStore } from "@/store/jobStore";
+
+/**
+ * Returns a keydown handler implementing the queue's row-selection shortcuts:
+ * Cmd/Ctrl+A selects every row, Delete/Backspace removes the current selection,
+ * and Escape clears it.
+ *
+ * The handler reads the store via `getState()` so it stays referentially stable
+ * (no re-subscription per render) while always seeing the latest snapshot. It is
+ * attached to the focusable queue container — not the document — so it only
+ * fires when the queue is focused and never hijacks Cmd+A / Delete inside the
+ * naming-template input or anywhere else on the page.
+ */
+export function useQueueSelectionKeys(): (
+  event: KeyboardEvent<HTMLElement>,
+) => void {
+  return useCallback((event: KeyboardEvent<HTMLElement>) => {
+    const state = useJobStore.getState();
+    // The queue is read-only while a job runs: the positional progress arrays
+    // must stay fixed, so the selection shortcuts are inert.
+    if (state.running) return;
+
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a") {
+      // Nothing to select in an empty queue; leave the native behavior alone.
+      if (state.draft.items.length === 0) return;
+      // Override the browser's select-all-text default within the queue.
+      event.preventDefault();
+      state.selectAll();
+      return;
+    }
+
+    if (event.key === "Delete" || event.key === "Backspace") {
+      if (state.selectedIndices.length === 0) return;
+      // Also stop Backspace from triggering browser back-navigation.
+      event.preventDefault();
+      void state.deleteSelected();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      state.clearSelection();
+    }
+  }, []);
+}

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -1074,3 +1074,177 @@ describe("restoreResults", () => {
     expect(state.lastBatch).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Row selection (keyboard select + delete)
+// ---------------------------------------------------------------------------
+
+describe("selectItem", () => {
+  beforeEach(() => {
+    useJobStore.setState({ draft: makeDraft(5) });
+  });
+
+  it("plain click selects only that row and sets the anchor", () => {
+    useJobStore.getState().selectItem(2, { meta: false, shift: false });
+
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([2]);
+    expect(state.selectionAnchor).toBe(2);
+  });
+
+  it("plain click replaces any previous selection", () => {
+    useJobStore.setState({ selectedIndices: [0, 1, 4], selectionAnchor: 0 });
+
+    useJobStore.getState().selectItem(3, { meta: false, shift: false });
+
+    expect(useJobStore.getState().selectedIndices).toEqual([3]);
+  });
+
+  it("meta click toggles the row into the selection (sorted), updating the anchor", () => {
+    useJobStore.setState({ selectedIndices: [0, 2], selectionAnchor: 2 });
+
+    useJobStore.getState().selectItem(1, { meta: true, shift: false });
+
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([0, 1, 2]);
+    expect(state.selectionAnchor).toBe(1);
+  });
+
+  it("meta click toggles an already-selected row back out", () => {
+    useJobStore.setState({ selectedIndices: [0, 2], selectionAnchor: 0 });
+
+    useJobStore.getState().selectItem(2, { meta: true, shift: false });
+
+    expect(useJobStore.getState().selectedIndices).toEqual([0]);
+  });
+
+  it("shift click selects the inclusive range from the anchor", () => {
+    useJobStore.setState({ selectedIndices: [1], selectionAnchor: 1 });
+
+    useJobStore.getState().selectItem(4, { meta: false, shift: true });
+
+    // Anchor stays at 1; the range 1..4 is selected.
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([1, 2, 3, 4]);
+    expect(state.selectionAnchor).toBe(1);
+  });
+
+  it("shift click selects the range when clicking above the anchor", () => {
+    useJobStore.setState({ selectedIndices: [3], selectionAnchor: 3 });
+
+    useJobStore.getState().selectItem(1, { meta: false, shift: true });
+
+    expect(useJobStore.getState().selectedIndices).toEqual([1, 2, 3]);
+  });
+
+  it("shift click with no anchor behaves like a plain click", () => {
+    useJobStore.setState({ selectedIndices: [], selectionAnchor: null });
+
+    useJobStore.getState().selectItem(2, { meta: false, shift: true });
+
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([2]);
+    expect(state.selectionAnchor).toBe(2);
+  });
+});
+
+describe("selectAll", () => {
+  it("selects every row index", () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+
+    useJobStore.getState().selectAll();
+
+    expect(useJobStore.getState().selectedIndices).toEqual([0, 1, 2]);
+  });
+
+  it("is a no-op when the queue is empty", () => {
+    useJobStore.setState({ draft: makeDraft(0), selectedIndices: [] });
+
+    useJobStore.getState().selectAll();
+
+    expect(useJobStore.getState().selectedIndices).toEqual([]);
+  });
+});
+
+describe("clearSelection", () => {
+  it("empties the selection and the anchor", () => {
+    useJobStore.setState({ selectedIndices: [0, 1], selectionAnchor: 1 });
+
+    useJobStore.getState().clearSelection();
+
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([]);
+    expect(state.selectionAnchor).toBeNull();
+  });
+});
+
+describe("deleteSelected", () => {
+  it("removes the selected rows highest-index-first to avoid index shift", async () => {
+    useJobStore.setState({ draft: makeDraft(5), selectedIndices: [1, 3] });
+    mockArchive.removeItem.mockResolvedValue(makeDraft(4));
+
+    await useJobStore.getState().deleteSelected();
+
+    // Descending order so removing a higher index never shifts a lower one.
+    expect(mockArchive.removeItem.mock.calls.map((c) => c[0])).toEqual([3, 1]);
+    expect(mockArchive.clearItems).not.toHaveBeenCalled();
+  });
+
+  it("clears the whole queue in one call when every row is selected", async () => {
+    useJobStore.setState({ draft: makeDraft(3), selectedIndices: [0, 1, 2] });
+    mockArchive.clearItems.mockResolvedValue(makeDraft(0));
+
+    await useJobStore.getState().deleteSelected();
+
+    expect(mockArchive.clearItems).toHaveBeenCalledTimes(1);
+    expect(mockArchive.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("ends with an empty selection", async () => {
+    useJobStore.setState({ draft: makeDraft(3), selectedIndices: [0] });
+    mockArchive.removeItem.mockResolvedValue(makeDraft(2));
+
+    await useJobStore.getState().deleteSelected();
+
+    expect(useJobStore.getState().selectedIndices).toEqual([]);
+  });
+
+  it("is a no-op when nothing is selected", async () => {
+    useJobStore.setState({ draft: makeDraft(3), selectedIndices: [] });
+
+    await useJobStore.getState().deleteSelected();
+
+    expect(mockArchive.removeItem).not.toHaveBeenCalled();
+    expect(mockArchive.clearItems).not.toHaveBeenCalled();
+  });
+});
+
+describe("selection invalidation", () => {
+  it("clears the selection when the draft is structurally edited", async () => {
+    useJobStore.setState({
+      draft: makeDraft(3),
+      selectedIndices: [0, 2],
+      selectionAnchor: 0,
+    });
+    mockArchive.reorder.mockResolvedValue(makeDraft(3));
+
+    await useJobStore.getState().reorder(0, 1);
+
+    const state = useJobStore.getState();
+    expect(state.selectedIndices).toEqual([]);
+    expect(state.selectionAnchor).toBeNull();
+  });
+
+  it("clears the selection on reset", async () => {
+    useJobStore.setState({
+      draft: makeDraft(3),
+      selectedIndices: [1],
+      selectionAnchor: 1,
+    });
+    mockArchive.clearItems.mockResolvedValue(makeDraft(0));
+
+    await useJobStore.getState().reset();
+
+    expect(useJobStore.getState().selectedIndices).toEqual([]);
+  });
+});

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -27,6 +27,10 @@ function draftEdit(draft: DraftSnapshot): Partial<JobState> {
     summary: null,
     progress: null,
     taskIdByIndex: [],
+    // A structural draft change re-indexes the rows, so any index-based row
+    // selection now points at the wrong rows and is dropped.
+    selectedIndices: [],
+    selectionAnchor: null,
   };
 }
 
@@ -101,6 +105,17 @@ export interface JobState {
    * the next batch is queued/run or the clear is undone.
    */
   cleared: boolean;
+  /**
+   * Indices of the currently selected queue rows (sorted ascending). Drives the
+   * row highlight and the keyboard delete. Index-based, so it is cleared whenever
+   * the draft is structurally edited (see {@link draftEdit}).
+   */
+  selectedIndices: number[];
+  /**
+   * The anchor row for a Shift range selection (the row a range extends from),
+   * or null when there is no active selection to extend from.
+   */
+  selectionAnchor: number | null;
 
   /** Add file/folder paths to the draft, then recompute previews. */
   addItems: (paths: string[]) => Promise<void>;
@@ -152,6 +167,25 @@ export interface JobState {
    * there is no residual batch to restore.
    */
   restoreResults: () => void;
+  /**
+   * Select the row at `index`, interpreting the click modifiers:
+   * - plain (no modifier): select only this row, anchoring future Shift ranges
+   *   here;
+   * - meta (Cmd/Ctrl): toggle this row in/out of the selection, re-anchoring here;
+   * - shift: select the inclusive range from the current anchor to this row
+   *   (behaves like a plain click when there is no anchor).
+   */
+  selectItem: (index: number, mods: { meta: boolean; shift: boolean }) => void;
+  /** Select every queued row. No-op when the queue is empty. */
+  selectAll: () => void;
+  /** Clear the row selection and its anchor. */
+  clearSelection: () => void;
+  /**
+   * Remove every selected row. Deleting all rows takes the single-call `reset()`
+   * path (same as Clear, without its dialog); otherwise the rows are removed
+   * highest-index-first so a removal never shifts a not-yet-removed index.
+   */
+  deleteSelected: () => Promise<void>;
 }
 
 export const useJobStore = create<JobState>()((set, get) => ({
@@ -173,6 +207,8 @@ export const useJobStore = create<JobState>()((set, get) => ({
   error: null,
   lastBatch: null,
   cleared: false,
+  selectedIndices: [],
+  selectionAnchor: null,
 
   addItems: async (paths) => {
     try {
@@ -277,6 +313,10 @@ export const useJobStore = create<JobState>()((set, get) => ({
       error: null,
       lastBatch: null,
       cleared: false,
+      // A run owns the positional progress arrays; drop any pending row selection
+      // so a stale highlight cannot linger over a now-running queue.
+      selectedIndices: [],
+      selectionAnchor: null,
     });
     try {
       const summary = await archive.runJob();
@@ -381,6 +421,8 @@ export const useJobStore = create<JobState>()((set, get) => ({
         taskIdByIndex: [],
         previewNames: [],
         firstPreview: null,
+        selectedIndices: [],
+        selectionAnchor: null,
       });
     } catch (reason) {
       set({ error: messageFromReason(reason) });
@@ -421,6 +463,8 @@ export const useJobStore = create<JobState>()((set, get) => ({
       progress: null,
       taskIdByIndex: [],
       previewNames: [],
+      selectedIndices: [],
+      selectionAnchor: null,
     });
   },
 
@@ -430,6 +474,60 @@ export const useJobStore = create<JobState>()((set, get) => ({
     if (lastBatch === null) return;
     // Return to the results/Ledger phase with the previously cleared summary.
     set({ summary: lastBatch.summary, cleared: false, lastBatch: null });
+  },
+
+  selectItem: (index, mods) => {
+    set((s) => {
+      // Shift extends the inclusive range from the anchor; with no anchor yet it
+      // degrades to a plain single-row selection.
+      if (mods.shift && s.selectionAnchor !== null) {
+        const lo = Math.min(s.selectionAnchor, index);
+        const hi = Math.max(s.selectionAnchor, index);
+        const range = Array.from({ length: hi - lo + 1 }, (_, i) => lo + i);
+        // Keep the anchor where it is so a further Shift click re-extends from it.
+        return { selectedIndices: range };
+      }
+      // Meta (Cmd/Ctrl) toggles a single row, re-anchoring on it.
+      if (mods.meta) {
+        const next = s.selectedIndices.includes(index)
+          ? s.selectedIndices.filter((i) => i !== index)
+          : [...s.selectedIndices, index].sort((a, b) => a - b);
+        return { selectedIndices: next, selectionAnchor: index };
+      }
+      // Plain click: select only this row and anchor here.
+      return { selectedIndices: [index], selectionAnchor: index };
+    });
+  },
+
+  selectAll: () => {
+    set((s) => {
+      const count = s.draft.items.length;
+      if (count === 0) return {};
+      return {
+        selectedIndices: Array.from({ length: count }, (_, i) => i),
+        selectionAnchor: 0,
+      };
+    });
+  },
+
+  clearSelection: () => set({ selectedIndices: [], selectionAnchor: null }),
+
+  deleteSelected: async () => {
+    const { selectedIndices, draft } = get();
+    if (selectedIndices.length === 0) return;
+    // Removing every row is exactly the Clear action: do it in one backend call
+    // (no per-row recompute) and skip the per-row loop below.
+    if (selectedIndices.length === draft.items.length) {
+      await get().reset();
+      return;
+    }
+    // Snapshot the targets before mutating: each removeItem clears the selection
+    // via draftEdit, and removing highest-index-first keeps the still-pending
+    // indices valid (a lower index never shifts when a higher row is removed).
+    const targets = [...selectedIndices].sort((a, b) => b - a);
+    for (const index of targets) {
+      await get().removeItem(index);
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary

Adds keyboard selection and bulk deletion to the queue rows. Click a row to select it, refine with Cmd/Ctrl+click (toggle) and Shift+click (range), select every row with **Cmd+A** (macOS) / **Ctrl+A** (Windows/Linux), and remove the selected rows with **Delete** / **Backspace** (Escape clears the selection). This gives a fast keyboard path to prune the queue alongside the per-row trash button and the **Clear** button.

## Background / Motivation

- The only ways to drop queued items were the per-row trash button (one at a time) and **Clear** (everything, behind a confirm dialog); pruning a few rows out of a long queue meant repeated single clicks.
- The queue had no notion of row selection at all — no click-to-select, no multi-select, and no keyboard delete.
- Queued items are not files on disk and are trivially re-added, so the keyboard delete is intentionally immediate (no confirmation), unlike the queue-wide Clear.

## Changes

### Selection state + actions (`store/jobStore.ts`)

- New state `selectedIndices: number[]` (sorted) and `selectionAnchor: number | null` (the Shift range origin).
- `selectItem(index, { meta, shift })` — plain click selects only that row and anchors here; `meta` (Cmd/Ctrl) toggles a single row; `shift` selects the inclusive range from the anchor (falls back to a plain click with no anchor).
- `selectAll()` (no-op on an empty queue), `clearSelection()`.
- `deleteSelected()` — deleting every row takes the single-call `reset()` path (same as Clear, without its dialog); a subset is removed highest-index-first via the existing `removeItem` so a removal never shifts a not-yet-removed index. The targets are snapshotted up front because each removal clears the selection.
- Selection is index-based, so it is dropped on any structural draft edit: inside `draftEdit()` (add / reorder / single remove) and in `reset()`, `clearResults()`, and at the start of `runJob()`.

### Queue-scoped keyboard handler (`hooks/useQueueSelectionKeys.ts`, new)

- A stable `onKeyDown` reading the store via `getState()`: Cmd/Ctrl+A → `selectAll()`, Delete/Backspace → `deleteSelected()` (only with a non-empty selection), Escape → `clearSelection()`. Inert while a job runs; `preventDefault()` suppresses the browser select-all-text and Backspace-navigation defaults.
- Attached to the focusable queue container, not the document, so the shortcuts fire only when the queue is focused — they never hijack Cmd+A / Delete inside the naming-template input.

### Row rendering (`components/TaskRow.tsx`)

- Row-level `onClick` calls `selectItem` with the click modifiers; clicks from an action button (grip / up / down / delete) are ignored via `closest("button")`, and selection is disabled while running.
- Selected rows carry the project's selected-state token (`bg-accent`) and `aria-selected`; the selected flag is a flat boolean in the `useShallow` selector, so only a row whose own selected state flips re-renders.

### Queue container (`components/TaskList.tsx`)

- The scroll container becomes the selectable region: `role="grid"` + `aria-multiselectable` + per-row `aria-selected` is the ARIA row-selection pattern and makes `tabIndex={0}` / `onKeyDown` valid. The role lives on the wrapper so the `<table>` keeps its native semantics; `aria-keyshortcuts` advertises the shortcuts.

### Tests

- `jobStore.test.ts` (+16): `selectItem` plain / meta-toggle / shift-range, `selectAll`, `clearSelection`, `deleteSelected` (subset → `removeItem` descending; all → `reset`), selection cleared on draft edit and reset.
- `TaskRow.test.tsx` (+6): row click selects with modifiers, delete-button click does not select, no select while running, `aria-selected` reflects selection.
- `TaskList.test.tsx` (+8): Cmd+A / Ctrl+A select all, Delete / Backspace delete, bare `a` and empty-selection are no-ops, Escape clears, inert while running, no response to keydown fired outside the region.
- Each new test was confirmed RED before implementation.

## Verification

- Click a row → only that row highlights (`bg-accent`, `aria-selected="true"`). Cmd/Ctrl+click toggles rows; Shift+click selects a contiguous range from the anchor.
- With the queue focused: Cmd+A (mac) / Ctrl+A highlights every row; Delete or Backspace removes the selected rows; Escape clears.
- Deleting every selected row empties the queue in one call (no dialog); deleting a subset removes exactly those rows and renumbers the rest.
- Shortcuts are inert while a job runs and do not fire while typing in the naming-template input.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 473 passed (30 new; each confirmed RED first)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): click / Cmd-click / Shift-click to select, Cmd/Ctrl+A to select all, Delete/Backspace to remove; confirm shortcuts do not fire while typing in the naming input
