### PR TITLE
feat(ui): make queue row drag-to-reorder discoverable

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -592,6 +592,26 @@ describe("TaskList pointer reorder", () => {
 
     expect(rows[2].getAttribute("data-drop-edge")).toBe("top");
     expect(rows[0].getAttribute("data-dragging")).toBe("true");
+    // Non-target rows must carry no insertion line.
+    expect(rows[0].getAttribute("data-drop-edge")).toBeNull();
+    expect(rows[1].getAttribute("data-drop-edge")).toBeNull();
+  });
+
+  it("shows a top drop-line on an interior row hovered at its upper half", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[1], 20);
+    // Drag row 0 and hover the upper half of row 1.
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[1], { clientY: topHalf(20) });
+
+    // Only row 1 should show the insertion line.
+    expect(rows[1].getAttribute("data-drop-edge")).toBe("top");
+    // Row 0 is the dragged row — fix #2 ensures no line on it.
+    expect(rows[0].getAttribute("data-drop-edge")).toBeNull();
+    expect(rows[2].getAttribute("data-drop-edge")).toBeNull();
   });
 
   it("shows a bottom drop-line on the last row when its lower half is hovered", () => {

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -607,6 +607,19 @@ describe("TaskList pointer reorder", () => {
 
     expect(reorder).not.toHaveBeenCalled();
   });
+
+  it("renders the grip in a dedicated leading drag column", () => {
+    setItems(2);
+    render(<TaskList />);
+
+    // The drag column is first in the model and the first <col>/<td>.
+    expect(TASK_COLUMNS[0].key).toBe("drag");
+
+    const firstRow = bodyRows()[0];
+    const firstCell = firstRow.querySelector("td");
+    // The grip lives in the first cell of each row.
+    expect(firstCell?.contains(handle(0))).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -723,6 +723,49 @@ describe("TaskList pointer reorder", () => {
 
     expect(reorder).not.toHaveBeenCalled();
   });
+
+  // Task-3 regression: aria-roledescription, grab cursor, and conditional touch-none.
+
+  it("marks every body row with aria-roledescription='draggable item'", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    for (const row of rows) {
+      expect(row.getAttribute("aria-roledescription")).toBe("draggable item");
+    }
+  });
+
+  it("applies cursor-grab at rest and never touch-none before a drag starts", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    for (const row of rows) {
+      // cursor-grab must be present at rest (dnd.enabled=true, no active drag).
+      expect(row.className).toContain("cursor-grab");
+      // touch-none must NOT appear at rest — it must only be applied mid-drag.
+      expect(row.className).not.toContain("touch-none");
+    }
+  });
+
+  it("applies cursor-grabbing, touch-none, and select-none on all rows while a drag is active", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    // Start a drag from the grip of row 0 to arm isDraggingAny on every row.
+    fireEvent.pointerDown(handle(0));
+
+    const rows = bodyRows();
+    for (const row of rows) {
+      // Mid-drag: cursor switches to grabbing.
+      expect(row.className).toContain("cursor-grabbing");
+      // touch-none suppresses touch-scroll only while dragging.
+      expect(row.className).toContain("touch-none");
+      // select-none prevents text selection mid-drag.
+      expect(row.className).toContain("select-none");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -766,6 +766,59 @@ describe("TaskList pointer reorder", () => {
       expect(row.className).toContain("select-none");
     }
   });
+
+  // Task-4 regression: interior bottom-half coalesces to next row's top edge
+  // (single-line-per-gap invariant), and pointercancel backstop resets drag.
+
+  it("bottom-half hover on an interior row draws a top line on the NEXT row (single-line-per-gap invariant)", () => {
+    // The insertion-gap logic maps gap g to row[g]'s top edge for interior gaps,
+    // and to the last row's bottom edge for the trailing gap only.
+    // Hovering the bottom half of an interior row (rows[1]) yields gap = 2, which
+    // must render as rows[2].data-drop-edge="top" — NOT a bottom line on rows[1].
+    // This test fails if the implementation draws "bottom" on rows[1] instead of
+    // coalescing to the equivalent "top" on rows[2].
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[1], 20);
+
+    fireEvent.pointerDown(handle(0));
+    // Bottom half of interior row 1 -> gap = 1 + 1 = 2.
+    fireEvent.pointerMove(rows[1], { clientY: bottomHalf(20) });
+
+    // Gap 2 is interior (not the trailing gap), so it renders as rows[2]'s top edge.
+    expect(rows[2].getAttribute("data-drop-edge")).toBe("top");
+    // rows[1] must carry no insertion line (it is the hovered row, not the gap marker).
+    expect(rows[1].getAttribute("data-drop-edge")).toBeNull();
+    // rows[0] is the dragged row — never shows an edge.
+    expect(rows[0].getAttribute("data-drop-edge")).toBeNull();
+  });
+
+  it("pointercancel mid-drag clears dragging and drop-edge state", () => {
+    // The window-level pointercancel listener in ReorderDndProvider is the backstop
+    // for OS-interrupt scenarios (e.g. incoming call, focus loss on mobile).
+    // This test fails if that listener is absent or does not call reset().
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[2], 40);
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2], { clientY: topHalf(40) });
+
+    // Verify drag is active before cancelling.
+    expect(rows[0].getAttribute("data-dragging")).toBe("true");
+    expect(rows[2].getAttribute("data-drop-edge")).toBe("top");
+
+    // Simulate an OS-level pointer cancel (bubbles up to window).
+    fireEvent.pointerCancel(document.body);
+
+    const after = bodyRows();
+    // Both dragging and drop-edge flags must be cleared after cancel.
+    expect(after[0].getAttribute("data-dragging")).toBeNull();
+    expect(after[2].getAttribute("data-drop-edge")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -676,6 +676,52 @@ describe("TaskList pointer reorder", () => {
     const firstCell = firstRow.querySelector("td");
     // The grip lives in the first cell of each row.
     expect(firstCell?.contains(handle(0))).toBe(true);
+  });
+
+  it("reorders when the row body is dragged past the threshold", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[2], 40);
+    // Press the row body (not the grip), then move well past 5px to arm + drop.
+    fireEvent.pointerDown(rows[0], { clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(rows[2], { clientX: 0, clientY: bottomHalf(40) });
+    fireEvent.pointerUp(rows[2], { clientX: 0, clientY: bottomHalf(40) });
+
+    expect(reorder).toHaveBeenCalledWith(0, 2);
+  });
+
+  it("treats a sub-threshold row-body press as a click, not a drag", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[1], 20);
+    fireEvent.pointerDown(rows[0], { clientX: 0, clientY: 0 });
+    // Move only 3px — below DRAG_THRESHOLD_PX (5).
+    fireEvent.pointerMove(rows[1], { clientX: 0, clientY: 3 });
+    fireEvent.pointerUp(rows[1], { clientX: 0, clientY: 3 });
+
+    expect(reorder).not.toHaveBeenCalled();
+  });
+
+  it("does not start a row drag when a button in the row is pressed", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    setItems(3, { reorder });
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[2], 40);
+    // Press the 'Move down' button, then move the pointer over a far row.
+    const moveDown = within(rows[0]).getByLabelText("Move down");
+    fireEvent.pointerDown(moveDown, { clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(rows[2], { clientX: 0, clientY: bottomHalf(40) });
+    fireEvent.pointerUp(rows[2], { clientX: 0, clientY: bottomHalf(40) });
+
+    expect(reorder).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -509,6 +509,27 @@ describe("TaskList pointer reorder", () => {
     return screen.getByTestId(`reorder-handle-${index}`);
   }
 
+  // jsdom has no layout, so getBoundingClientRect returns zeros. Stub a row's rect
+  // so the pointer-Y vs midpoint math (insert-above vs insert-below) is exercised.
+  function stubRect(row: HTMLElement, top: number, height = 20) {
+    row.getBoundingClientRect = () =>
+      ({
+        top,
+        height,
+        bottom: top + height,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: top,
+        toJSON() {},
+      }) as DOMRect;
+  }
+  // Pointer Y in the TOP half of a row whose rect starts at `top`.
+  const topHalf = (top: number) => top + 4;
+  // Pointer Y in the BOTTOM half of a row whose rect starts at `top`.
+  const bottomHalf = (top: number) => top + 16;
+
   it("exposes an enabled drag handle for each item row when idle", () => {
     setItems(3);
     render(<TaskList />);
@@ -518,28 +539,32 @@ describe("TaskList pointer reorder", () => {
     }
   });
 
-  it("calls reorder(from, to) when a row is dragged onto a lower row", () => {
+  it("reorders a row downward when dropped on the lower half of a lower row", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, { reorder });
     render(<TaskList />);
 
     const rows = bodyRows();
+    stubRect(rows[2], 40);
     fireEvent.pointerDown(handle(0));
-    fireEvent.pointerMove(rows[2]);
-    fireEvent.pointerUp(rows[2]);
+    // Bottom half of the last row -> gap = 3 (after last). from=0 -> to=2.
+    fireEvent.pointerMove(rows[2], { clientY: bottomHalf(40) });
+    fireEvent.pointerUp(rows[2], { clientY: bottomHalf(40) });
 
     expect(reorder).toHaveBeenCalledWith(0, 2);
   });
 
-  it("calls reorder(from, to) when a row is dragged onto a higher row", () => {
+  it("reorders a row upward when dropped on the upper half of a higher row", () => {
     const reorder = vi.fn().mockResolvedValue(undefined);
     setItems(3, { reorder });
     render(<TaskList />);
 
     const rows = bodyRows();
+    stubRect(rows[0], 0);
     fireEvent.pointerDown(handle(2));
-    fireEvent.pointerMove(rows[0]);
-    fireEvent.pointerUp(rows[0]);
+    // Top half of the first row -> gap = 0. from=2, gap<=from -> to=0.
+    fireEvent.pointerMove(rows[0], { clientY: topHalf(0) });
+    fireEvent.pointerUp(rows[0], { clientY: topHalf(0) });
 
     expect(reorder).toHaveBeenCalledWith(2, 0);
   });
@@ -556,17 +581,29 @@ describe("TaskList pointer reorder", () => {
     expect(reorder).not.toHaveBeenCalled();
   });
 
-  it("marks the hovered row as the drop target while dragging another row", () => {
+  it("shows a top drop-line on the row whose upper half is hovered", () => {
     setItems(3);
     render(<TaskList />);
 
     const rows = bodyRows();
+    stubRect(rows[2], 40);
     fireEvent.pointerDown(handle(0));
-    fireEvent.pointerMove(rows[2]);
+    fireEvent.pointerMove(rows[2], { clientY: topHalf(40) });
 
-    expect(rows[2].getAttribute("data-drop-target")).toBe("true");
-    expect(rows[0].getAttribute("data-drop-target")).toBeNull();
+    expect(rows[2].getAttribute("data-drop-edge")).toBe("top");
     expect(rows[0].getAttribute("data-dragging")).toBe("true");
+  });
+
+  it("shows a bottom drop-line on the last row when its lower half is hovered", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    stubRect(rows[2], 40);
+    fireEvent.pointerDown(handle(0));
+    fireEvent.pointerMove(rows[2], { clientY: bottomHalf(40) });
+
+    expect(rows[2].getAttribute("data-drop-edge")).toBe("bottom");
   });
 
   it("clears the drag state when the pointer is released off the rows", () => {
@@ -574,14 +611,14 @@ describe("TaskList pointer reorder", () => {
     render(<TaskList />);
 
     const rows = bodyRows();
+    stubRect(rows[2], 40);
     fireEvent.pointerDown(handle(0));
-    fireEvent.pointerMove(rows[2]);
-    // Release outside any row (e.g. on the surrounding page chrome).
+    fireEvent.pointerMove(rows[2], { clientY: topHalf(40) });
     fireEvent.pointerUp(document.body);
 
     const after = bodyRows();
     expect(after[0].getAttribute("data-dragging")).toBeNull();
-    expect(after[2].getAttribute("data-drop-target")).toBeNull();
+    expect(after[2].getAttribute("data-drop-edge")).toBeNull();
   });
 
   it("does not reorder while a job is running", () => {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -128,6 +128,28 @@ function TaskRowImpl({ index }: TaskRowProps) {
       data-drop-target={dnd.isOver || undefined}
       className={rowClassName}
     >
+      {/* Drag column: the grip is the explicit reorder signifier. Pointer-based (not
+          HTML5) so it survives Tauri's webview drag-drop handler; keyboard users
+          reorder with the up/down buttons, so the grip stays aria-hidden. `touch-none`
+          keeps a touch drag from scrolling the list; `select-none` keeps the press
+          from starting a text selection (mirrors PaneSeparator). */}
+      <td className="py-2 pl-1">
+        <span
+          {...dnd.handleProps}
+          data-testid={`reorder-handle-${index}`}
+          data-reorder-handle
+          data-disabled={!dnd.enabled || undefined}
+          aria-hidden
+          className={`flex items-center justify-center touch-none select-none transition-colors ${
+            dnd.enabled
+              ? "cursor-grab active:cursor-grabbing text-muted-foreground/70 hover:text-foreground"
+              : "cursor-not-allowed text-muted-foreground/40"
+          }`}
+        >
+          <GripVertical className="size-4 shrink-0" />
+        </span>
+      </td>
+
       {/* Sequence number */}
       <td className="py-2 pr-3 text-muted-foreground font-mono">{index + 1}</td>
 
@@ -174,28 +196,9 @@ function TaskRowImpl({ index }: TaskRowProps) {
         )}
       </td>
 
-      {/* Actions: drag handle + keyboard-accessible up/down buttons + delete */}
+      {/* Actions: keyboard-accessible up/down buttons + delete */}
       <td className="py-2">
         <div className="flex items-center gap-1">
-          {/* Grip handle: starts a pointer drag to reorder this row. The drag is
-              pointer-based (not HTML5) so it survives Tauri's webview drag-drop
-              handler; keyboard users reorder with the up/down buttons instead,
-              so the handle stays aria-hidden. `touch-none` keeps a touch drag
-              from scrolling the list; `select-none` keeps the press from
-              starting a text selection (mirrors PaneSeparator). */}
-          <span
-            {...dnd.handleProps}
-            data-testid={`reorder-handle-${index}`}
-            data-disabled={!dnd.enabled || undefined}
-            aria-hidden
-            className={`flex items-center touch-none select-none text-muted-foreground/60 ${
-              dnd.enabled
-                ? "cursor-grab active:cursor-grabbing"
-                : "cursor-not-allowed opacity-30"
-            }`}
-          >
-            <GripVertical className="size-4 shrink-0" />
-          </span>
           <button
             type="button"
             aria-label="Move up"

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -110,16 +110,19 @@ function TaskRowImpl({ index }: TaskRowProps) {
 
   // Drag affordances: dim the row being dragged; draw a 2px insertion line on the
   // edge where the row would land. A box-shadow (not a real element) avoids table
-  // layout shift. The grab cursor lives on the grip; the whole-row drag cursor is
-  // added in the row-body task.
+  // layout shift.
   const rowClassName = [
     "border-b border-border/50 transition-colors",
+    // The whole row is a drag surface; show grab at rest, grabbing mid-drag.
+    dnd.enabled && (dnd.isDraggingAny ? "cursor-grabbing" : "cursor-grab"),
     dnd.isDragging ? "opacity-40" : "hover:bg-muted/30",
     dnd.dropEdge === "top" && "shadow-[inset_0_2px_0_0_var(--color-primary)]",
     dnd.dropEdge === "bottom" &&
       "shadow-[inset_0_-2px_0_0_var(--color-primary)]",
-    // Suppress text selection across the list while any row is being dragged.
-    dnd.isDraggingAny && "select-none",
+    // While a drag is active, suppress text selection and stop touch-scroll from
+    // hijacking the gesture. Applied only mid-drag so the list stays scrollable
+    // and filenames stay selectable at rest.
+    dnd.isDraggingAny && "select-none touch-none",
   ]
     .filter(Boolean)
     .join(" ");
@@ -129,6 +132,7 @@ function TaskRowImpl({ index }: TaskRowProps) {
       {...dnd.rowProps}
       data-dragging={dnd.isDragging || undefined}
       data-drop-edge={dnd.dropEdge ?? undefined}
+      aria-roledescription="draggable item"
       className={rowClassName}
     >
       {/* Drag column: the grip is the explicit reorder signifier. Pointer-based (not

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -108,13 +108,16 @@ function TaskRowImpl({ index }: TaskRowProps) {
   // reflow cannot strip the right-align padding spaces formatBytes emits.
   const liveLabel = `${formatBytes(row.liveBytesDone ?? 0, row.liveBytesTotal ?? 0)} · ETA ${formatEta(row.liveEtaMs)}`;
 
-  // Drag affordances: dim the row being dragged and highlight the row the
-  // pointer is currently over as the drop target. The grab cursor lives on the
-  // grip handle (the only element that starts a drag), not the whole row.
+  // Drag affordances: dim the row being dragged; draw a 2px insertion line on the
+  // edge where the row would land. A box-shadow (not a real element) avoids table
+  // layout shift. The grab cursor lives on the grip; the whole-row drag cursor is
+  // added in the row-body task.
   const rowClassName = [
     "border-b border-border/50 transition-colors",
     dnd.isDragging ? "opacity-40" : "hover:bg-muted/30",
-    dnd.isOver && "bg-primary/10",
+    dnd.dropEdge === "top" && "shadow-[inset_0_2px_0_0_var(--color-primary)]",
+    dnd.dropEdge === "bottom" &&
+      "shadow-[inset_0_-2px_0_0_var(--color-primary)]",
     // Suppress text selection across the list while any row is being dragged.
     dnd.isDraggingAny && "select-none",
   ]
@@ -125,7 +128,7 @@ function TaskRowImpl({ index }: TaskRowProps) {
     <tr
       {...dnd.rowProps}
       data-dragging={dnd.isDragging || undefined}
-      data-drop-target={dnd.isOver || undefined}
+      data-drop-edge={dnd.dropEdge ?? undefined}
       className={rowClassName}
     >
       {/* Drag column: the grip is the explicit reorder signifier. Pointer-based (not

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -12,34 +12,29 @@ import {
 
 import { useJobStore } from "@/store/jobStore";
 
-// ---------------------------------------------------------------------------
-// Context
-// ---------------------------------------------------------------------------
-
 type RowPointerEvent = ReactPointerEvent<HTMLElement>;
 
+/** Smallest pointer travel (px) that turns a row-body press into a drag. */
+const DRAG_THRESHOLD_PX = 5;
+
 interface ReorderDndContextValue {
-  /** Whether rows may be reordered at all (false while a job is running). */
   enabled: boolean;
-  /** Index of the row currently being dragged, or null. */
   draggingIndex: number | null;
-  /** Index of the row currently hovered as the drop target, or null. */
-  overIndex: number | null;
-  start: (index: number, event: RowPointerEvent) => void;
-  over: (index: number) => void;
-  drop: (index: number) => void;
+  /** Insertion gap g in [0, count]: the dragged row lands before row g. */
+  overGap: number | null;
+  count: number;
+  startImmediate: (index: number, event: RowPointerEvent) => void;
+  startDeferred: (index: number, event: RowPointerEvent) => void;
+  pointerMoveOnRow: (index: number, event: RowPointerEvent) => void;
+  drop: () => void;
 }
 
 const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
 
-// ---------------------------------------------------------------------------
-// Provider
-// ---------------------------------------------------------------------------
-
 /**
  * ReorderDndProvider owns the ephemeral drag state (which row is being dragged,
- * which row is the current drop target) and translates a pointer-drag gesture
- * into a single `reorder(from, to)` store action.
+ * which insertion gap is the current drop target) and translates a pointer-drag
+ * gesture into a single `reorder(from, to)` store action.
  *
  * Pointer events — not HTML5 drag-and-drop — drive the gesture on purpose: the
  * app needs Tauri's native webview drag-drop handler enabled so files/folders
@@ -56,57 +51,95 @@ const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
 export function ReorderDndProvider({ children }: { children: ReactNode }) {
   const running = useJobStore((s) => s.running);
   const reorder = useJobStore((s) => s.reorder);
+  const count = useJobStore((s) => s.draft.items.length);
 
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
-  const [overIndex, setOverIndex] = useState<number | null>(null);
-  // Mirror the active drag source synchronously so the pointer handlers (and the
-  // window-level teardown below) read it without waiting for a state flush.
+  const [overGap, setOverGap] = useState<number | null>(null);
+  // Mirror the active drag source and gap synchronously so the pointer handlers
+  // (and the window-level teardown) read them without waiting for a state flush.
   const draggingRef = useRef<number | null>(null);
+  const overGapRef = useRef<number | null>(null);
+  // Origin of a row-body press that has not yet passed the drag threshold.
+  const pendingRef = useRef<{ index: number; x: number; y: number } | null>(
+    null,
+  );
 
   const enabled = !running;
 
   const reset = useCallback(() => {
     draggingRef.current = null;
+    overGapRef.current = null;
+    pendingRef.current = null;
     setDraggingIndex(null);
-    setOverIndex(null);
+    setOverGap(null);
   }, []);
 
-  const start = useCallback(
+  const arm = useCallback((index: number) => {
+    pendingRef.current = null;
+    draggingRef.current = index;
+    setDraggingIndex(index);
+  }, []);
+
+  // Grip handle: there is nothing to click or select there, so start at once.
+  const startImmediate = useCallback(
     (index: number, event: RowPointerEvent) => {
-      // Guard so a stray pointerdown can never begin a drag mid-run.
       if (!enabled) return;
-      // Stop the press from starting a text selection while dragging.
       event.preventDefault();
-      draggingRef.current = index;
-      setDraggingIndex(index);
+      arm(index);
+    },
+    [enabled, arm],
+  );
+
+  // Row body: record the origin but defer arming until the pointer moves past the
+  // threshold, so a plain click or a text selection is not mistaken for a drag.
+  const startDeferred = useCallback(
+    (index: number, event: RowPointerEvent) => {
+      if (!enabled) return;
+      pendingRef.current = { index, x: event.clientX, y: event.clientY };
     },
     [enabled],
   );
 
-  const over = useCallback((index: number) => {
-    // Only track a hover target while a drag is actually in progress.
-    if (draggingRef.current === null) return;
-    setOverIndex(index);
-  }, []);
-
-  const drop = useCallback(
-    (index: number) => {
-      const from = draggingRef.current;
-      // Dropping a row onto index `to` lands it exactly at `to` (the store's
-      // reorder is a remove-then-insert), so the drop target index maps
-      // directly to the destination. Skip no-op and mid-run drops.
-      if (from !== null && from !== index && enabled) {
-        void reorder(from, index);
+  const pointerMoveOnRow = useCallback(
+    (index: number, event: RowPointerEvent) => {
+      // Promote a pending row-body press to a real drag once it passes threshold.
+      const pending = pendingRef.current;
+      if (pending && draggingRef.current === null) {
+        const moved = Math.hypot(
+          event.clientX - pending.x,
+          event.clientY - pending.y,
+        );
+        if (moved < DRAG_THRESHOLD_PX) return;
+        // Cancel any nascent native text-selection now that this is a drag.
+        event.preventDefault();
+        arm(pending.index);
       }
-      reset();
+      if (draggingRef.current === null) return;
+      // Insert-above when the pointer is in the row's upper half, else below.
+      const rect = event.currentTarget.getBoundingClientRect();
+      const gap =
+        event.clientY < rect.top + rect.height / 2 ? index : index + 1;
+      overGapRef.current = gap;
+      setOverGap(gap);
     },
-    [enabled, reorder, reset],
+    [arm],
   );
 
-  // End the gesture on any pointer release (or cancel) anywhere, so a release
-  // off the rows — or an OS-interrupted drag — never leaves a row stuck in the
-  // dragging state. A drop onto a row resets first (React's root handler runs
-  // before this window listener), so this is the idempotent backstop.
+  const drop = useCallback(() => {
+    const from = draggingRef.current;
+    const gap = overGapRef.current;
+    if (from !== null && gap !== null && enabled) {
+      // The store's reorder is remove-then-insert: removing `from` shifts every
+      // gap after it left by one, so a gap past `from` maps to `gap - 1`.
+      const to = gap <= from ? gap : gap - 1;
+      if (to !== from) void reorder(from, to);
+    }
+    reset();
+  }, [enabled, reorder, reset]);
+
+  // End the gesture on any release/cancel anywhere so a drag never gets stuck.
+  // A still-pending (un-armed) press needs no window backstop: the row's own
+  // onPointerUp -> drop() clears it, and the next press overwrites pendingRef.
   useEffect(() => {
     if (draggingIndex === null) return;
     const end = () => reset();
@@ -119,8 +152,26 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
   }, [draggingIndex, reset]);
 
   const value = useMemo<ReorderDndContextValue>(
-    () => ({ enabled, draggingIndex, overIndex, start, over, drop }),
-    [enabled, draggingIndex, overIndex, start, over, drop],
+    () => ({
+      enabled,
+      draggingIndex,
+      overGap,
+      count,
+      startImmediate,
+      startDeferred,
+      pointerMoveOnRow,
+      drop,
+    }),
+    [
+      enabled,
+      draggingIndex,
+      overGap,
+      count,
+      startImmediate,
+      startDeferred,
+      pointerMoveOnRow,
+      drop,
+    ],
   );
 
   return (
@@ -130,24 +181,18 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Row consumer hook
-// ---------------------------------------------------------------------------
+type DropEdge = "top" | "bottom" | null;
 
 interface ReorderRow {
-  /** Whether this row's grip handle may start a drag. */
   enabled: boolean;
   isDragging: boolean;
-  isOver: boolean;
-  /** Whether any row is currently being dragged (drives drag-wide styling). */
   isDraggingAny: boolean;
-  /** Props for the grip handle that starts a drag. */
-  handleProps: {
-    onPointerDown: (event: RowPointerEvent) => void;
-  };
-  /** Props for the row element that acts as a drop target. */
+  /** Which edge of this row to paint the insertion line on, if any. */
+  dropEdge: DropEdge;
+  handleProps: { onPointerDown: (event: RowPointerEvent) => void };
   rowProps: {
-    onPointerMove: () => void;
+    onPointerDown: (event: RowPointerEvent) => void;
+    onPointerMove: (event: RowPointerEvent) => void;
     onPointerUp: () => void;
   };
 }
@@ -157,10 +202,14 @@ interface ReorderRow {
 const NON_DRAGGABLE_ROW: ReorderRow = {
   enabled: false,
   isDragging: false,
-  isOver: false,
   isDraggingAny: false,
+  dropEdge: null,
   handleProps: { onPointerDown: () => {} },
-  rowProps: { onPointerMove: () => {}, onPointerUp: () => {} },
+  rowProps: {
+    onPointerDown: () => {},
+    onPointerMove: () => {},
+    onPointerUp: () => {},
+  },
 };
 
 /**
@@ -170,22 +219,48 @@ const NON_DRAGGABLE_ROW: ReorderRow = {
  */
 export function useReorderRow(index: number): ReorderRow {
   const ctx = useContext(ReorderDndContext);
-  if (ctx === null) {
-    return NON_DRAGGABLE_ROW;
-  }
-  const { enabled, draggingIndex, overIndex, start, over, drop } = ctx;
+  if (ctx === null) return NON_DRAGGABLE_ROW;
+  const {
+    enabled,
+    draggingIndex,
+    overGap,
+    count,
+    startImmediate,
+    startDeferred,
+    pointerMoveOnRow,
+    drop,
+  } = ctx;
+
+  // Interior gap g renders as row g's top edge; the trailing gap (== count)
+  // renders as the last row's bottom edge, so each gap draws exactly one line.
+  const isLast = index === count - 1;
+  const dropEdge: DropEdge =
+    overGap === null
+      ? null
+      : overGap === index
+        ? "top"
+        : isLast && overGap === index + 1
+          ? "bottom"
+          : null;
+
   return {
     enabled,
     isDragging: draggingIndex === index,
-    // The dragged row is never its own drop target.
-    isOver: overIndex === index && draggingIndex !== index,
     isDraggingAny: draggingIndex !== null,
+    dropEdge,
     handleProps: {
-      onPointerDown: (event) => start(index, event),
+      onPointerDown: (event) => startImmediate(index, event),
     },
     rowProps: {
-      onPointerMove: () => over(index),
-      onPointerUp: () => drop(index),
+      onPointerDown: (event) => {
+        // The grip starts its own immediate drag, and the action buttons must
+        // stay clickable; exclude both so a row-body press never double-fires.
+        const target = event.target as HTMLElement;
+        if (target.closest("button, a, input, [data-reorder-handle]")) return;
+        startDeferred(index, event);
+      },
+      onPointerMove: (event) => pointerMoveOnRow(index, event),
+      onPointerUp: () => drop(),
     },
   };
 }

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -102,6 +102,9 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
 
   const pointerMoveOnRow = useCallback(
     (index: number, event: RowPointerEvent) => {
+      // Do nothing while reordering is disabled; a pending press must not arm
+      // into a drag mid-run even if the pointer has traveled far enough.
+      if (!enabled) return;
       // Promote a pending row-body press to a real drag once it passes threshold.
       const pending = pendingRef.current;
       if (pending && draggingRef.current === null) {
@@ -122,7 +125,7 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
       overGapRef.current = gap;
       setOverGap(gap);
     },
-    [arm],
+    [enabled, arm],
   );
 
   const drop = useCallback(() => {
@@ -233,9 +236,10 @@ export function useReorderRow(index: number): ReorderRow {
 
   // Interior gap g renders as row g's top edge; the trailing gap (== count)
   // renders as the last row's bottom edge, so each gap draws exactly one line.
+  // The dragged row itself never shows an insertion line (it is already dimmed).
   const isLast = index === count - 1;
   const dropEdge: DropEdge =
-    overGap === null
+    overGap === null || draggingIndex === index
       ? null
       : overGap === index
         ? "top"

--- a/src/components/task-columns.ts
+++ b/src/components/task-columns.ts
@@ -10,6 +10,7 @@
 
 /** Stable identifiers for the queue table's columns, in render order. */
 export type TaskColumnKey =
+  | "drag"
   | "index"
   | "kind"
   | "source"
@@ -40,6 +41,15 @@ export const MAX_COLUMN_WIDTH = 800;
  * horizontal scroll.
  */
 export const TASK_COLUMNS: TaskColumnDef[] = [
+  {
+    // Dedicated drag affordance: a fixed, narrow leftmost column whose grip is
+    // the explicit "grab here to reorder" signifier. No handle, no header label.
+    key: "drag",
+    label: "",
+    defaultWidth: 36,
+    minWidth: 36,
+    resizable: false,
+  },
   {
     key: "index",
     label: "#",


### PR DESCRIPTION
## Summary

Queue rows could already be reordered by a pointer-drag, but the only drag-start affordance was a small, low-contrast grip icon parked in the far-right **Actions** column next to the ▲▼/trash buttons — users did not notice it, and their instinct (grab the file **name** / the row itself) did nothing. This makes reordering discoverable: the grip moves to a dedicated, prominent **left-edge column**, the **whole row becomes a drag surface** (grab anywhere and move to reorder), and an unambiguous **2px insertion line** shows exactly where the row will land. Reordering stays pointer-event-based, the ▲▼ keyboard path is preserved, and the OS file-drop is untouched.

## Background / Motivation

- #132 reworked reordering to **pointer events** (grab a row's grip handle, drop onto another row) because Tauri's webview drag-drop handler — needed for file-drop-to-add (`useFileDrop` → `getCurrentWebview().onDragDropEvent`) — swallows in-page HTML5 `drop` on macOS WKWebView. That fix worked, but the grip was the *only* drag-start affordance and was easy to miss.
- The visually dominant element in a row is the **source name**, which carried no drag affordance, while the only affordance sat at the right edge — a Norman-style affordance/signifier mismatch. Users tried to grab the name and nothing happened.
- This builds on #134's column model (`task-columns.ts`, `<colgroup>`, fixed-layout table) to add a dedicated drag column, and keeps the pointer-event approach (no HTML5 DnD, no new dependency).

## Changes

### Dedicated left drag column
- `src/components/task-columns.ts`: add a leading `drag` column (36px, fixed-width, no label) as the first entry.
- `src/components/TaskRow.tsx`: render the grip in the new leftmost cell (relocated from Actions); Actions keeps ▲▼ + trash.

### Whole-row drag surface
- `src/components/reorder-dnd.tsx`: two drag-start entry points resolving to the same `reorder(from, to)`:
  - the **grip** starts a drag immediately;
  - the **row body** starts a drag once the pointer moves ≥ 5px (`DRAG_THRESHOLD_PX`), so a plain click and text selection are not mistaken for a drag. Presses on `button, a, input` or the grip are excluded.
- `src/components/TaskRow.tsx`: row gets `cursor-grab` / `cursor-grabbing`; `touch-none` is applied **only while dragging** (the list stays touch-scrollable and names stay selectable at rest); `aria-roledescription="draggable item"`.

### Precise insertion line (gap model)
- `src/components/reorder-dnd.tsx`: replaces the ambiguous full-row highlight with an insertion-**gap** model. The pointer's vertical position within the hovered row picks the gap (above/below); exactly one 2px line is drawn per gap (interior gaps on the next row's top edge, the trailing gap on the last row's bottom edge), and never on the row being dragged. Drop maps the gap to the store index with `to = gap <= from ? gap : gap - 1` (no-op when `to === from`).
- `src/components/TaskRow.tsx`: `data-drop-edge="top|bottom"` renders the line via an inset box-shadow (no table layout shift).

## Constraints honored

- **Pointer events only** — no HTML5 `draggable`/`onDrop`; the OS file-drop and its "Drop to add" overlay are unaffected (pointer events do not emit Tauri's `onDragDropEvent`).
- Keyboard reorder via the **▲▼ buttons** preserved; the grip stays `aria-hidden`.
- The store action `reorder(from, to)` is unchanged; per-row render isolation in `TaskRow` (scalar selectors) is preserved.

## Testing

- `pnpm test` — **450 passing** (37 cover this feature: grip + row-body drag, 5px threshold vs click, button exclusion, gap→index math, drop-line top/bottom edges, `pointercancel` teardown, disabled-while-running).
- `pnpm lint:ci`, `pnpm fmt:check`, `pnpm build`, `pnpm knip` — all green (oxfmt 0.55.0 / oxlint 1.70.0, matching the lockfile).
- ⚠️ **Manual macOS smoke test (real WKWebView) still recommended before merge** — vitest cannot catch a Tauri drag-drop regression.
