### PR TITLE
feat(ui): move the reorder grip to a leading drag rail

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -610,6 +610,75 @@ describe("TaskList pointer reorder", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Drag-handle column (leading grip rail)
+//
+// The reorder grip lives in a dedicated leading column at the row's left edge —
+// a recognizable "drag rail" — rather than tucked into the trailing Actions
+// column. The rail carries a strong, discoverable affordance (grab cursor + a
+// hover background) so it reads as grabbable at rest.
+// ---------------------------------------------------------------------------
+
+describe("TaskList drag-handle column", () => {
+  function setItems(n: number, extra: Record<string, unknown> = {}) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(n),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      ...extra,
+    });
+  }
+
+  it("orders the drag-handle column first and the actions column last", () => {
+    expect(TASK_COLUMNS[0].key).toBe("drag");
+    expect(TASK_COLUMNS[0].resizable).toBe(false);
+    expect(TASK_COLUMNS[TASK_COLUMNS.length - 1].key).toBe("actions");
+  });
+
+  it("renders the grip in each row's leading cell (left of the number)", () => {
+    setItems(2);
+    render(<TaskList />);
+
+    const rows = screen.getAllByRole("row").slice(1);
+    rows.forEach((row, i) => {
+      const firstCell = row.querySelector("td");
+      expect(
+        firstCell?.querySelector(`[data-testid="reorder-handle-${i}"]`),
+      ).toBeTruthy();
+    });
+  });
+
+  it("no longer renders the grip in the trailing Actions cell", () => {
+    setItems(2);
+    render(<TaskList />);
+
+    const rows = screen.getAllByRole("row").slice(1);
+    rows.forEach((row, i) => {
+      const cells = row.querySelectorAll("td");
+      const lastCell = cells[cells.length - 1];
+      expect(
+        lastCell.querySelector(`[data-testid="reorder-handle-${i}"]`),
+      ).toBeNull();
+    });
+  });
+
+  it("gives the idle grip a strong, grabbable affordance", () => {
+    setItems(1);
+    render(<TaskList />);
+
+    const grip = screen.getByTestId("reorder-handle-0");
+    expect(grip.className).toContain("cursor-grab");
+    // The rail darkens on hover so the grab zone is discoverable at a glance.
+    expect(grip.className).toContain("hover:bg-");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Keyboard selection + delete
 //
 // The queue region owns a scoped keydown handler: Cmd/Ctrl+A selects every row,

--- a/src/components/TaskRow.test.tsx
+++ b/src/components/TaskRow.test.tsx
@@ -38,6 +38,26 @@ describe("TaskRow", () => {
     expect(screen.getByText("out_001.zip")).toBeTruthy();
   });
 
+  it("renders the reorder grip as the row's leading cell", () => {
+    useJobStore.setState({
+      draft: {
+        items: [{ path: "/home/user/archive.rar", kind: "rar" }],
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: ["out_001.zip"],
+    });
+    renderRow(0);
+
+    const firstCell = screen.getByRole("row").querySelector("td");
+    expect(
+      firstCell?.querySelector('[data-testid="reorder-handle-0"]'),
+    ).toBeTruthy();
+  });
+
   it("renders the kind badge with text 'zip' for a zip item", () => {
     useJobStore.setState({
       draft: {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -8,6 +8,7 @@ import { Progress } from "@/components/ui/progress";
 import { formatBytes, formatEta, progressPercent } from "@/lib/format";
 import { basename } from "@/lib/path";
 import { computeStatus } from "@/lib/status";
+import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
 // ---------------------------------------------------------------------------
@@ -154,6 +155,30 @@ function TaskRowImpl({ index }: TaskRowProps) {
       data-drop-target={dnd.isOver || undefined}
       className={rowClassName}
     >
+      {/* Reorder rail: the row's leading grab surface. The drag is pointer-based
+          (not HTML5) so it survives Tauri's webview drag-drop handler; keyboard
+          users reorder with the Actions up/down buttons, so the handle stays
+          aria-hidden. The whole cell is the grab zone — a grab cursor plus a
+          hover background give it a strong, discoverable affordance at rest.
+          `touch-none` keeps a touch drag from scrolling the list; `select-none`
+          keeps the press from starting a text selection (mirrors PaneSeparator). */}
+      <td className="py-2 pr-1 pl-1">
+        <span
+          {...dnd.handleProps}
+          data-testid={`reorder-handle-${index}`}
+          data-disabled={!dnd.enabled || undefined}
+          aria-hidden
+          className={cn(
+            "flex items-center justify-center rounded py-1.5 touch-none select-none transition-colors",
+            dnd.enabled
+              ? "cursor-grab active:cursor-grabbing text-muted-foreground hover:bg-muted hover:text-foreground"
+              : "cursor-not-allowed text-muted-foreground/30",
+          )}
+        >
+          <GripVertical className="size-4 shrink-0" />
+        </span>
+      </td>
+
       {/* Sequence number */}
       <td className="py-2 pr-3 text-muted-foreground font-mono">{index + 1}</td>
 
@@ -200,28 +225,10 @@ function TaskRowImpl({ index }: TaskRowProps) {
         )}
       </td>
 
-      {/* Actions: drag handle + keyboard-accessible up/down buttons + delete */}
+      {/* Actions: keyboard-accessible up/down buttons + delete. The reorder grip
+          now lives in the leading rail cell, not here. */}
       <td className="py-2">
         <div className="flex items-center gap-1">
-          {/* Grip handle: starts a pointer drag to reorder this row. The drag is
-              pointer-based (not HTML5) so it survives Tauri's webview drag-drop
-              handler; keyboard users reorder with the up/down buttons instead,
-              so the handle stays aria-hidden. `touch-none` keeps a touch drag
-              from scrolling the list; `select-none` keeps the press from
-              starting a text selection (mirrors PaneSeparator). */}
-          <span
-            {...dnd.handleProps}
-            data-testid={`reorder-handle-${index}`}
-            data-disabled={!dnd.enabled || undefined}
-            aria-hidden
-            className={`flex items-center touch-none select-none text-muted-foreground/60 ${
-              dnd.enabled
-                ? "cursor-grab active:cursor-grabbing"
-                : "cursor-not-allowed opacity-30"
-            }`}
-          >
-            <GripVertical className="size-4 shrink-0" />
-          </span>
           <button
             type="button"
             aria-label="Move up"

--- a/src/components/task-columns.ts
+++ b/src/components/task-columns.ts
@@ -10,6 +10,7 @@
 
 /** Stable identifiers for the queue table's columns, in render order. */
 export type TaskColumnKey =
+  | "drag"
   | "index"
   | "kind"
   | "source"
@@ -34,12 +35,22 @@ export interface TaskColumnDef {
 export const MAX_COLUMN_WIDTH = 800;
 
 /**
- * The queue table columns in render order. `#` and `Actions` are fixed-width
- * (no handle); the four content columns between them are resizable. Defaults sum
- * to a comfortable table width that fills a typical canvas without forcing a
- * horizontal scroll.
+ * The queue table columns in render order. The leading `drag` rail, `#`, and
+ * `Actions` are fixed-width (no handle); the four content columns between `#`
+ * and `Actions` are resizable. Defaults sum to a comfortable table width that
+ * fills a typical canvas without forcing a horizontal scroll.
  */
 export const TASK_COLUMNS: TaskColumnDef[] = [
+  {
+    // Leading reorder rail: holds only the drag grip, at the row's left edge.
+    // Empty header label — the grip is aria-hidden and keyboard users reorder
+    // with the Actions up/down buttons.
+    key: "drag",
+    label: "",
+    defaultWidth: 40,
+    minWidth: 40,
+    resizable: false,
+  },
   {
     key: "index",
     label: "#",
@@ -76,10 +87,12 @@ export const TASK_COLUMNS: TaskColumnDef[] = [
     resizable: true,
   },
   {
+    // The grip moved to the leading `drag` rail, so Actions now holds only the
+    // up/down and delete controls and tightens accordingly.
     key: "actions",
     label: "Actions",
-    defaultWidth: 150,
-    minWidth: 150,
+    defaultWidth: 120,
+    minWidth: 120,
     resizable: false,
   },
 ];


### PR DESCRIPTION
Moves the queue table's reorder grip handle from the trailing Actions column to a new dedicated leading drag-rail column at each row's left edge, with a stronger affordance (grab cursor + hover background). The Actions column tightens since it now holds only the up/down and delete controls.