### PR TITLE
feat(ui): make queue reorder moves visible (slide, settle highlight, announce)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -173,3 +173,18 @@
     -moz-osx-font-smoothing: grayscale;
   }
 }
+
+/* One-shot settle highlight for a row that was just reordered: a brief accent
+   wash that fades out, drawing the eye to where the row landed. */
+@keyframes row-settle {
+  from {
+    background-color: var(--color-accent);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.row-settle {
+  animation: row-settle 700ms ease-out;
+}

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -1,6 +1,13 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
@@ -1032,5 +1039,184 @@ describe("TaskList column resize", () => {
 
     fireEvent.pointerUp(handle, { clientX: 180, buttons: 1, pointerId: 1 });
     expect(handle.getAttribute("data-dragging")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FLIP slide
+// ---------------------------------------------------------------------------
+
+// A reorder action that actually mutates the draft so the slide's layout effect
+// fires (the real store does this via the backend; here we splice locally).
+function installReorderingStore(n: number) {
+  const reorder = vi.fn(async (from: number, to: number) => {
+    useJobStore.setState((s) => {
+      const items = [...s.draft.items];
+      const [moved] = items.splice(from, 1);
+      items.splice(to, 0, moved);
+      return { draft: { ...s.draft, items } };
+    });
+  });
+  useJobStore.setState({
+    draft: {
+      items: makeItems(n),
+      namingTemplate: null,
+      startNumber: 1,
+      outputDir: null,
+      outputMode: "zip",
+      conflictPolicy: "autoRename",
+    },
+    previewNames: [],
+    reorder,
+  });
+  return reorder;
+}
+
+// jsdom has no Element.prototype.animate (Web Animations API), so install a mock
+// to give the FLIP slide a surface to call and assert against.
+function installAnimateMock() {
+  const animate = vi.fn(
+    (_keyframes?: unknown, _options?: unknown) =>
+      ({
+        finished: Promise.resolve(),
+        cancel: vi.fn(),
+      }) as unknown as Animation,
+  );
+  (HTMLElement.prototype as unknown as { animate: unknown }).animate = animate;
+  return animate;
+}
+
+function restoreAnimateMock() {
+  delete (HTMLElement.prototype as unknown as { animate?: unknown }).animate;
+}
+
+// A reduced-motion matchMedia stub (matches: true).
+function stubReducedMotion() {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+}
+
+describe("TaskList reorder slide", () => {
+  afterEach(() => {
+    restoreAnimateMock();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("animates the moved rows with a translateY slide on reorder", async () => {
+    // jsdom has no layout, so stand in distinct tops keyed by data-row-index.
+    vi.spyOn(
+      HTMLTableRowElement.prototype,
+      "getBoundingClientRect",
+    ).mockImplementation(function (this: HTMLElement) {
+      const i = Number(this.dataset.rowIndex ?? 0);
+      return { top: i * 20, height: 20 } as DOMRect;
+    });
+    const animate = installAnimateMock();
+
+    installReorderingStore(3);
+    const user = userEvent.setup();
+    render(<TaskList />);
+
+    await user.click(screen.getAllByRole("button", { name: /move down/i })[0]);
+
+    await waitFor(() => expect(animate).toHaveBeenCalled());
+    const [keyframes] = animate.mock.calls[0];
+    expect(JSON.stringify(keyframes)).toContain("translateY");
+  });
+
+  it("does not slide when the user prefers reduced motion", async () => {
+    stubReducedMotion();
+    const animate = installAnimateMock();
+
+    const reorder = installReorderingStore(3);
+    const user = userEvent.setup();
+    render(<TaskList />);
+
+    await user.click(screen.getAllByRole("button", { name: /move down/i })[0]);
+
+    await waitFor(() => expect(reorder).toHaveBeenCalledWith(0, 1));
+    expect(animate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settle highlight + announcement
+// ---------------------------------------------------------------------------
+
+describe("TaskList reorder feedback", () => {
+  afterEach(() => {
+    restoreAnimateMock();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("marks the moved row as just-moved then clears it", async () => {
+    // Fake timers drive the clear; fireEvent (not userEvent) avoids the
+    // userEvent/fake-timer interaction that hangs the async click.
+    vi.useFakeTimers();
+    installReorderingStore(3);
+    render(<TaskList />);
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: /move down/i })[0]);
+    });
+
+    // archive1.rar (was row 0) is now at row 1 and flagged just-moved.
+    const movedRow = screen.getByText("archive1.rar").closest("tr");
+    expect(movedRow?.getAttribute("data-just-moved")).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(movedRow?.getAttribute("data-just-moved")).toBeNull();
+  });
+
+  it("announces the move in the polite live region", async () => {
+    installReorderingStore(3);
+    const user = userEvent.setup();
+    render(<TaskList />);
+
+    await user.click(screen.getAllByRole("button", { name: /move down/i })[0]);
+
+    await waitFor(() =>
+      // Strip the zero-width re-announce pad before comparing the spoken text.
+      expect(
+        screen.getByTestId("reorder-live").textContent?.replace(/\u200B/g, ""),
+      ).toBe("Moved archive1.rar to position 2"),
+    );
+  });
+
+  it("still highlights and announces under reduced motion", async () => {
+    stubReducedMotion();
+    const animate = installAnimateMock();
+
+    installReorderingStore(3);
+    const user = userEvent.setup();
+    render(<TaskList />);
+
+    await user.click(screen.getAllByRole("button", { name: /move down/i })[0]);
+
+    await waitFor(() =>
+      // Strip the zero-width re-announce pad before comparing the spoken text.
+      expect(
+        screen.getByTestId("reorder-live").textContent?.replace(/\u200B/g, ""),
+      ).toBe("Moved archive1.rar to position 2"),
+    );
+    const movedRow = screen.getByText("archive1.rar").closest("tr");
+    expect(movedRow?.getAttribute("data-just-moved")).toBe("true");
+    expect(animate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,10 @@
+import { useRef } from "react";
+
 import { ColumnResizeHandle } from "@/components/ColumnResizeHandle";
+import {
+  ReorderAnimationProvider,
+  useReorderAnimation,
+} from "@/components/reorder-animation";
 import { ReorderDndProvider } from "@/components/reorder-dnd";
 import { TASK_COLUMNS } from "@/components/task-columns";
 import { TaskRow } from "@/components/TaskRow";
@@ -27,6 +33,11 @@ export function TaskList() {
   // Queue-scoped keyboard shortcuts (select all / delete / clear). Stable across
   // renders, so it is safe to call before the early return below.
   const onKeyDown = useQueueSelectionKeys();
+  // The table ref lets the reorder animation measure rows; the hook owns the
+  // FLIP slide and exposes the animated reorder both reorder paths route through.
+  const tableRef = useRef<HTMLTableElement>(null);
+  const { animatedReorder, justMovedIndex, liveMessage } =
+    useReorderAnimation(tableRef);
 
   if (items.length === 0) {
     return (
@@ -42,62 +53,73 @@ export function TaskList() {
   const totalWidth = TASK_COLUMNS.reduce((sum, c) => sum + widths[c.key], 0);
 
   return (
-    <ReorderDndProvider>
-      {/* The selectable queue: role="grid" + aria-multiselectable + per-row
+    <ReorderAnimationProvider
+      animatedReorder={animatedReorder}
+      justMovedIndex={justMovedIndex}
+    >
+      <ReorderDndProvider>
+        {/* The selectable queue: role="grid" + aria-multiselectable + per-row
           aria-selected is the ARIA pattern for row selection, and makes this an
           interactive element so tabIndex/onKeyDown are valid. tabIndex makes it
           focusable — clicking a non-focusable row focuses this nearest focusable
           ancestor — which scopes the shortcuts here so they never hijack Cmd+A /
           Delete inside text inputs. The role lives on this wrapper (not the
           <table>) so the table keeps its native semantics. */}
-      <div
-        className="overflow-x-auto outline-none"
-        role="grid"
-        aria-label="Queue rows"
-        aria-multiselectable
-        aria-keyshortcuts="Control+A Meta+A Delete Backspace"
-        tabIndex={0}
-        data-testid="queue-region"
-        onKeyDown={onKeyDown}
-      >
-        <table
-          className="text-sm"
-          style={{ tableLayout: "fixed", width: totalWidth }}
+        <div
+          className="overflow-x-auto outline-none"
+          role="grid"
+          aria-label="Queue rows"
+          aria-multiselectable
+          aria-keyshortcuts="Control+A Meta+A Delete Backspace"
+          tabIndex={0}
+          data-testid="queue-region"
+          onKeyDown={onKeyDown}
         >
-          <colgroup>
-            {TASK_COLUMNS.map((c) => (
-              <col key={c.key} style={{ width: widths[c.key] }} />
-            ))}
-          </colgroup>
-          <thead>
-            <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <table
+            ref={tableRef}
+            className="text-sm"
+            style={{ tableLayout: "fixed", width: totalWidth }}
+          >
+            <colgroup>
               {TASK_COLUMNS.map((c) => (
-                <th
-                  key={c.key}
-                  className={cn("pb-2 pr-3", c.resizable && "relative")}
-                >
-                  {c.label}
-                  {c.resizable && (
-                    <ColumnResizeHandle
-                      columnKey={c.key}
-                      isDragging={draggingKey === c.key}
-                      {...getSeparatorProps(c.key)}
-                    />
-                  )}
-                </th>
+                <col key={c.key} style={{ width: widths[c.key] }} />
               ))}
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((_item, i) => (
-              // rows are a positional, backend-ordered list with no per-row local state;
-              // item paths may legitimately duplicate, so index keys are correct here.
-              // oxlint-disable-next-line react/no-array-index-key
-              <TaskRow index={i} key={i} />
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </ReorderDndProvider>
+            </colgroup>
+            <thead>
+              <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {TASK_COLUMNS.map((c) => (
+                  <th
+                    key={c.key}
+                    className={cn("pb-2 pr-3", c.resizable && "relative")}
+                  >
+                    {c.label}
+                    {c.resizable && (
+                      <ColumnResizeHandle
+                        columnKey={c.key}
+                        isDragging={draggingKey === c.key}
+                        {...getSeparatorProps(c.key)}
+                      />
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((_item, i) => (
+                // rows are a positional, backend-ordered list with no per-row local state;
+                // item paths may legitimately duplicate, so index keys are correct here.
+                // oxlint-disable-next-line react/no-array-index-key
+                <TaskRow index={i} key={i} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ReorderDndProvider>
+      {/* Polite, visually-hidden announcement of the last reorder. `output` has
+          an implicit status (polite live) role; aria-live is kept explicit. */}
+      <output data-testid="reorder-live" aria-live="polite" className="sr-only">
+        {liveMessage}
+      </output>
+    </ReorderAnimationProvider>
   );
 }

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -3,6 +3,7 @@ import { memo, type MouseEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import type { SourceKind } from "@/bindings/SourceKind";
+import { useReorderAnimationRow } from "@/components/reorder-animation";
 import { useReorderRow } from "@/components/reorder-dnd";
 import { Progress } from "@/components/ui/progress";
 import { formatBytes, formatEta, progressPercent } from "@/lib/format";
@@ -82,10 +83,7 @@ function TaskRowImpl({ index }: TaskRowProps) {
         // A flat boolean: only this row re-renders when its own selected state
         // flips, leaving the rest of the list untouched.
         isSelected: s.selectedIndices.includes(index),
-        // The action reference is stable across renders, so it is safe to
-        // return directly for shallow comparison.
-        reorder: s.reorder,
-        // Same stability guarantee as `reorder`, safe for the shallow compare.
+        // Stable action reference, safe for the shallow compare.
         removeItem: s.removeItem,
         // Stable action reference, safe for the shallow compare.
         selectItem: s.selectItem,
@@ -106,6 +104,11 @@ function TaskRowImpl({ index }: TaskRowProps) {
   // row during an active drag only; a drag never overlaps a running job, so
   // this does not interact with the per-tick render isolation above.
   const dnd = useReorderRow(index);
+
+  // Both reorder paths (these buttons and the drag drop) route through the
+  // animated reorder so the slide + settle highlight fire identically;
+  // `justMoved` flags this row right after it landed.
+  const { animatedReorder, justMoved } = useReorderAnimationRow(index);
 
   if (!row.exists) return null;
 
@@ -148,6 +151,9 @@ function TaskRowImpl({ index }: TaskRowProps) {
     // hijacking the gesture. Applied only mid-drag so the list stays scrollable
     // and filenames stay selectable at rest.
     dnd.isDraggingAny && "select-none touch-none",
+    // A one-shot accent fade on the row that was just moved, so the eye lands on
+    // where it settled. Kept under prefers-reduced-motion (the slide is not).
+    justMoved && "row-settle",
   ]
     .filter(Boolean)
     .join(" ");
@@ -157,6 +163,8 @@ function TaskRowImpl({ index }: TaskRowProps) {
       {...dnd.rowProps}
       onClick={onRowClick}
       aria-selected={row.isSelected}
+      data-row-index={index}
+      data-just-moved={justMoved || undefined}
       data-dragging={dnd.isDragging || undefined}
       data-drop-edge={dnd.dropEdge ?? undefined}
       aria-roledescription="draggable item"
@@ -237,7 +245,7 @@ function TaskRowImpl({ index }: TaskRowProps) {
             type="button"
             aria-label="Move up"
             disabled={row.isFirst || row.running}
-            onClick={() => row.reorder(index, index - 1)}
+            onClick={() => void animatedReorder(index, index - 1)}
             className={REORDER_BUTTON_CLASS}
           >
             ▲
@@ -246,7 +254,7 @@ function TaskRowImpl({ index }: TaskRowProps) {
             type="button"
             aria-label="Move down"
             disabled={row.isLast || row.running}
-            onClick={() => row.reorder(index, index + 1)}
+            onClick={() => void animatedReorder(index, index + 1)}
             className={REORDER_BUTTON_CLASS}
           >
             ▼

--- a/src/components/flip.test.ts
+++ b/src/components/flip.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { computeFlipDeltas, reorderPermutation } from "./flip";
+
+describe("reorderPermutation", () => {
+  it("moves the first row to the last", () => {
+    // [0,1,2] -> remove 0 -> [1,2] -> insert at 2 -> [1,2,0]
+    expect(reorderPermutation(0, 2, 3)).toEqual([1, 2, 0]);
+  });
+
+  it("moves the last row to the first", () => {
+    expect(reorderPermutation(2, 0, 3)).toEqual([2, 0, 1]);
+  });
+
+  it("swaps two adjacent rows", () => {
+    expect(reorderPermutation(0, 1, 3)).toEqual([1, 0, 2]);
+  });
+
+  it("is the identity for a no-op move", () => {
+    expect(reorderPermutation(1, 1, 3)).toEqual([0, 1, 2]);
+  });
+
+  it("handles an interior move", () => {
+    // [0,1,2,3,4] move index 1 to 3 -> [0,2,3,1,4]
+    expect(reorderPermutation(1, 3, 5)).toEqual([0, 2, 3, 1, 4]);
+  });
+});
+
+describe("computeFlipDeltas", () => {
+  it("inverts the moved row and the rows it displaces (move down)", () => {
+    const perm = reorderPermutation(0, 2, 3); // [1,2,0]
+    const tops = [0, 20, 40];
+    // new0<-old1: 20-0; new1<-old2: 40-20; new2<-old0(moved): 0-40
+    expect(computeFlipDeltas(perm, tops, tops)).toEqual([20, 20, -40]);
+  });
+
+  it("inverts correctly for a move up", () => {
+    const perm = reorderPermutation(2, 0, 3); // [2,0,1]
+    const tops = [0, 20, 40];
+    // new0<-old2(moved): 40-0; new1<-old0: 0-20; new2<-old1: 20-40
+    expect(computeFlipDeltas(perm, tops, tops)).toEqual([40, -20, -20]);
+  });
+
+  it("yields all-zero deltas for the identity permutation", () => {
+    const perm = reorderPermutation(1, 1, 3);
+    const tops = [0, 20, 40];
+    expect(computeFlipDeltas(perm, tops, tops)).toEqual([0, 0, 0]);
+  });
+
+  it("treats a missing measurement as zero", () => {
+    const perm = [1, 0];
+    // afterTops has no entry for new index 1 -> that row's delta guards to 0.
+    expect(computeFlipDeltas(perm, [0, 20], [0])).toEqual([20, 0]);
+  });
+});

--- a/src/components/flip.ts
+++ b/src/components/flip.ts
@@ -1,0 +1,44 @@
+// Pure geometry helpers for the position-based FLIP reorder animation.
+//
+// The queue rows are keyed by list index and have no stable per-row id, so a
+// classic identity-keyed FLIP does not apply. Instead, because a reorder is a
+// known (from, to), we reproduce the post-move permutation and use measured row
+// tops to compute how far each row must be inverted before it plays back to its
+// settled position. These functions are pure (no DOM, no IO).
+
+/**
+ * Reproduce the index permutation of moving the item at `from` to `to`, using
+ * the same remove-then-insert semantics as the store's `reorder`. Returns an
+ * array `perm` where `perm[newIndex] === oldIndex`: the element shown at
+ * `newIndex` after the move was at `oldIndex` before it.
+ */
+export function reorderPermutation(
+  from: number,
+  to: number,
+  count: number,
+): number[] {
+  const indices = Array.from({ length: count }, (_, i) => i);
+  const [moved] = indices.splice(from, 1);
+  indices.splice(to, 0, moved);
+  return indices;
+}
+
+/**
+ * Compute each row's vertical FLIP delta (px) from before/after tops.
+ * `beforeTops` is indexed by old index, `afterTops` by new index, and `perm`
+ * maps new index to old index. The delta is where the row *was* minus where it
+ * *is*, so applying `translateY(delta)` then animating to 0 makes the row glide
+ * from its old position to its new one. A missing measurement counts as 0.
+ */
+export function computeFlipDeltas(
+  perm: number[],
+  beforeTops: number[],
+  afterTops: number[],
+): number[] {
+  return perm.map((oldIndex, newIndex) => {
+    const before = beforeTops[oldIndex];
+    const after = afterTops[newIndex];
+    if (before === undefined || after === undefined) return 0;
+    return before - after;
+  });
+}

--- a/src/components/reorder-animation.tsx
+++ b/src/components/reorder-animation.tsx
@@ -1,0 +1,221 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+import { computeFlipDeltas, reorderPermutation } from "@/components/flip";
+import { basename } from "@/lib/path";
+import { useJobStore } from "@/store/jobStore";
+
+/** Slide duration (ms) for the FLIP reorder animation. */
+const SLIDE_MS = 200;
+
+/** How long the moved row stays flagged as just-moved (ms). Outlasts the CSS
+ * settle keyframe so the fade completes before the flag clears. */
+const HIGHLIGHT_CLEAR_MS = 800;
+
+type AnimatedReorder = (from: number, to: number) => Promise<void>;
+
+interface ReorderAnimationContextValue {
+  animatedReorder: AnimatedReorder;
+  justMovedIndex: number | null;
+}
+
+const ReorderAnimationContext =
+  createContext<ReorderAnimationContextValue | null>(null);
+
+// Fallback for a consumer rendered outside the provider (e.g. an isolated unit
+// test): reorder without animation, mirroring useReorderRow's non-draggable
+// fallback.
+const plainReorder: AnimatedReorder = (from, to) =>
+  useJobStore.getState().reorder(from, to);
+
+/** True only when the user asked for reduced motion (and matchMedia exists). */
+function prefersReducedMotion(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+interface PendingFlip {
+  beforeTops: number[];
+  from: number;
+  to: number;
+}
+
+/**
+ * useReorderAnimation owns the FLIP slide for the queue table. `containerRef`
+ * must point at the element wrapping the rows (the <table>); rows expose
+ * `data-row-index` so their tops can be measured. Returns `animatedReorder`,
+ * which both reorder paths route through.
+ */
+export function useReorderAnimation(
+  containerRef: RefObject<HTMLElement | null>,
+): {
+  animatedReorder: AnimatedReorder;
+  justMovedIndex: number | null;
+  liveMessage: string;
+} {
+  // The committed draft items; a reorder swaps this reference, which is our
+  // signal to play the captured FLIP once the new order has rendered.
+  const items = useJobStore((s) => s.draft.items);
+  // Pre-commit measurement + the move, stashed by animatedReorder and consumed
+  // by the layout effect after the re-render.
+  const pendingRef = useRef<PendingFlip | null>(null);
+  // WAAP animations we started, tracked so a rapid second move can cancel them
+  // (settling rows to their final layout) before measuring again.
+  const activeRef = useRef<Set<Animation>>(new Set());
+  const [justMovedIndex, setJustMovedIndex] = useState<number | null>(null);
+  const [liveMessage, setLiveMessage] = useState("");
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Flips each announcement so the live-region text always differs from the
+  // previous one; React bails out of an identical string update, and an
+  // unchanged live region is not re-announced by assistive tech. The padding is
+  // a zero-width space — invisible and not spoken — so only the DOM text changes.
+  const announceSeqRef = useRef(0);
+
+  const measureTops = useCallback((): number[] => {
+    const container = containerRef.current;
+    const tops: number[] = [];
+    if (!container) return tops;
+    container
+      .querySelectorAll<HTMLElement>("tr[data-row-index]")
+      .forEach((el) => {
+        tops[Number(el.dataset.rowIndex)] = el.getBoundingClientRect().top;
+      });
+    return tops;
+  }, [containerRef]);
+
+  const settleActive = useCallback(() => {
+    activeRef.current.forEach((a) => a.cancel());
+    activeRef.current.clear();
+  }, []);
+
+  // Play the captured FLIP: measure the settled tops, invert each row by its
+  // delta, then animate the transform back to zero so it glides into place.
+  useLayoutEffect(() => {
+    const pending = pendingRef.current;
+    pendingRef.current = null;
+    if (!pending) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const afterTops: number[] = [];
+    const elByIndex: HTMLElement[] = [];
+    container
+      .querySelectorAll<HTMLElement>("tr[data-row-index]")
+      .forEach((el) => {
+        const i = Number(el.dataset.rowIndex);
+        afterTops[i] = el.getBoundingClientRect().top;
+        elByIndex[i] = el;
+      });
+    const perm = reorderPermutation(pending.from, pending.to, afterTops.length);
+    const deltas = computeFlipDeltas(perm, pending.beforeTops, afterTops);
+    deltas.forEach((dy, newIndex) => {
+      const el = elByIndex[newIndex];
+      if (!dy || !el || typeof el.animate !== "function") return;
+      const anim = el.animate(
+        [{ transform: `translateY(${dy}px)` }, { transform: "translateY(0)" }],
+        { duration: SLIDE_MS, easing: "ease-out" },
+      );
+      activeRef.current.add(anim);
+      anim.finished
+        .then(() => activeRef.current.delete(anim))
+        .catch(() => activeRef.current.delete(anim));
+    });
+  }, [items, containerRef]);
+
+  useEffect(
+    () => () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    },
+    [],
+  );
+
+  const animatedReorder = useCallback<AnimatedReorder>(
+    async (from, to) => {
+      if (from === to) return;
+      if (!prefersReducedMotion()) {
+        // Settle any in-flight slide so the pre-move measurement reads true
+        // layout positions, not transformed ones.
+        settleActive();
+        pendingRef.current = { beforeTops: measureTops(), from, to };
+      }
+      const before = useJobStore.getState().draft;
+      const name = basename(before.items[from]?.path ?? "");
+      await useJobStore.getState().reorder(from, to);
+      if (useJobStore.getState().draft === before) {
+        // Failed/no-op reorder: drop the capture, leave no feedback.
+        pendingRef.current = null;
+        return;
+      }
+      // The moved item now sits at `to`; flag it for the settle highlight and
+      // announce the move (1-based position) to assistive tech.
+      setJustMovedIndex(to);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = setTimeout(
+        () => setJustMovedIndex(null),
+        HIGHLIGHT_CLEAR_MS,
+      );
+      announceSeqRef.current += 1;
+      const pad = "\u200B".repeat(announceSeqRef.current % 2);
+      setLiveMessage(`Moved ${name} to position ${to + 1}${pad}`);
+    },
+    [measureTops, settleActive],
+  );
+
+  return { animatedReorder, justMovedIndex, liveMessage };
+}
+
+export function ReorderAnimationProvider({
+  animatedReorder,
+  justMovedIndex,
+  children,
+}: {
+  animatedReorder: AnimatedReorder;
+  justMovedIndex: number | null;
+  children: ReactNode;
+}) {
+  const value = useMemo<ReorderAnimationContextValue>(
+    () => ({ animatedReorder, justMovedIndex }),
+    [animatedReorder, justMovedIndex],
+  );
+  return (
+    <ReorderAnimationContext.Provider value={value}>
+      {children}
+    </ReorderAnimationContext.Provider>
+  );
+}
+
+/** The animated reorder for the current context, or a plain fallback. */
+export function useAnimatedReorder(): AnimatedReorder {
+  const ctx = useContext(ReorderAnimationContext);
+  return ctx?.animatedReorder ?? plainReorder;
+}
+
+/**
+ * Per-row reorder state: the animated reorder plus whether this row is the one
+ * just moved (drives the settle highlight). Falls back to a plain reorder and
+ * no highlight outside the provider.
+ */
+export function useReorderAnimationRow(index: number): {
+  animatedReorder: AnimatedReorder;
+  justMoved: boolean;
+} {
+  const ctx = useContext(ReorderAnimationContext);
+  return {
+    animatedReorder: ctx?.animatedReorder ?? plainReorder,
+    justMoved: ctx?.justMovedIndex === index,
+  };
+}

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { useAnimatedReorder } from "@/components/reorder-animation";
 import { useJobStore } from "@/store/jobStore";
 
 type RowPointerEvent = ReactPointerEvent<HTMLElement>;
@@ -50,7 +51,7 @@ const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
  */
 export function ReorderDndProvider({ children }: { children: ReactNode }) {
   const running = useJobStore((s) => s.running);
-  const reorder = useJobStore((s) => s.reorder);
+  const animatedReorder = useAnimatedReorder();
   const count = useJobStore((s) => s.draft.items.length);
 
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
@@ -135,10 +136,10 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
       // The store's reorder is remove-then-insert: removing `from` shifts every
       // gap after it left by one, so a gap past `from` maps to `gap - 1`.
       const to = gap <= from ? gap : gap - 1;
-      if (to !== from) void reorder(from, to);
+      if (to !== from) void animatedReorder(from, to);
     }
     reset();
-  }, [enabled, reorder, reset]);
+  }, [enabled, animatedReorder, reset]);
 
   // End the gesture on any release/cancel anywhere so a drag never gets stuck.
   // A still-pending (un-armed) press needs no window backstop: the row's own


### PR DESCRIPTION
## Summary

After moving a queue row — especially via the ▲▼ buttons — there was no motion and no confirmation, so users could not tell **which** row moved, **where** it landed, or **whether** the move happened at all (▲▼ swapped instantly; a pointer-drag had during-drag feedback but no "landed" cue). This adds a visible affordance to **both** reorder paths: rows **slide** to their new position (FLIP), the moved row gets a one-shot **settle highlight**, and the move is **announced** to screen readers.

## Background / Motivation

- The ▲▼ buttons called `reorder()` only — two rows swapped with zero animation. The drag had during-drag cues (dimmed row + 2px insertion line) but the drop snapped into place with no settle confirmation.
- A reorder needs to answer three questions: **which** row, **where** it went, and **did it move**. The slide answers "where", the settle highlight answers "which / did it move", and a live region serves assistive tech — three separate perceptual channels.
- Rows are index-keyed and `DraftItemDto` has no stable id (source paths may legitimately duplicate), and `draft` is a backend DTO — so adding an id would mean a Rust + ts-rs + every-`DraftSnapshot`-literal change. Instead this uses **position-based FLIP**: a pure `reorderPermutation(from, to, count)` reproduces the post-move order and each row's `top` is measured before/after to invert the slide. Works with index keys and variable row heights, frontend-only, no new dependency.

## Changes

### Pure FLIP helpers
- `src/components/flip.ts` (new): `reorderPermutation(from, to, count)` (a splice on an index array) and `computeFlipDeltas(perm, beforeTops, afterTops)` (`delta[newIndex] = beforeTops[perm[newIndex]] − afterTops[newIndex]`, missing measurement ⇒ 0).

### Animation orchestration
- `src/components/reorder-animation.tsx` (new): `useReorderAnimation(tableRef)` captures row tops before the commit, plays the FLIP slide (Web Animations API, ~200ms ease-out) after the `draft.items` reference changes, holds `justMovedIndex` (settle highlight) + the live message, detects `prefers-reduced-motion`, and cancels in-flight slides before re-measuring (rapid moves). Exposes `animatedReorder(from, to)`; both reorder paths route through it, with a plain-`reorder` fallback outside the provider.

### Wiring
- `src/components/TaskRow.tsx`: `data-row-index`; ▲▼ buttons call `animatedReorder`; `data-just-moved` + `.row-settle` on the just-moved row.
- `src/components/reorder-dnd.tsx`: the drag `drop()` routes through `animatedReorder` (same slide + highlight as the buttons).
- `src/components/TaskList.tsx`: table ref + hook, `ReorderAnimationProvider` nesting, and a visually-hidden polite `<output>` live region.
- `src/App.css`: `@keyframes row-settle` (accent → transparent, 700ms).

## Constraints honored

- **No new library** — the FLIP is hand-rolled with the Web Animations API, consistent with the project's hand-rolled pointer DnD.
- **Frontend-only** — no Rust / `src/bindings` / `DraftSnapshot` changes, and no stable row id added.
- `prefers-reduced-motion: reduce` **skips the slide** but keeps the settle highlight + announcement.
- Existing ▲▼ and pointer-drag behavior preserved; the `reorder(from, to)` store action is unchanged; per-row render isolation in `TaskRow` is preserved.
- The live region re-announces even an identical consecutive message (zero-width parity pad) — React bails on an identical string and AT will not re-read unchanged content.

## Testing

- `pnpm test` — **499 passing** (new: FLIP permutation/delta geometry; slide invoked with `translateY` and **skipped** under reduced motion; settle highlight appears then clears; live-region announcement text).
- `pnpm lint:ci`, `pnpm fmt:check`, `pnpm build`, `pnpm knip` — all green (oxfmt 0.55.0 / oxlint 1.70.0, matching the lockfile).
- ⚠️ The motion itself cannot be verified in jsdom — a manual smoke test (including the OS "Reduce motion" setting) is recommended before merge.
