### PR TITLE
feat(ui): move the selected queue row with arrow keys + drag lift cue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -188,3 +188,21 @@
 .row-settle {
   animation: row-settle 700ms ease-out;
 }
+
+/* "Picked up" affordance for the row being dragged: a readable translucency plus
+   an accent tint and an elevation shadow so it visibly lifts off the list and
+   reads as grabbed (the old translucency-only cue was too subtle on the dark
+   table). `position`/`z-index` float it above its neighbours so the shadow is not
+   clipped by the next row's background. A static state, not motion, so it is kept
+   under prefers-reduced-motion. No FLIP slide runs while a row is held, so the
+   lift transform never competes with the drop animation. */
+.row-dragging {
+  position: relative;
+  z-index: 1;
+  opacity: 0.6;
+  background-color: var(--color-accent);
+  box-shadow:
+    0 6px 16px -4px rgb(0 0 0 / 0.5),
+    0 2px 4px -2px rgb(0 0 0 / 0.4);
+  transform: translateY(-2px) scale(1.01);
+}

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -225,6 +225,72 @@ describe("TaskList reorder buttons", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Arrow-key reorder
+// ---------------------------------------------------------------------------
+
+describe("TaskList keyboard reorder", () => {
+  function seed(
+    reorder: (from: number, to: number) => Promise<void>,
+    selectedIndices: number[],
+  ) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(3),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      selectedIndices,
+      selectionAnchor: selectedIndices.length === 1 ? selectedIndices[0] : null,
+      reorder,
+    });
+  }
+
+  it("moves the single selected row down on ArrowDown", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    seed(reorder, [0]);
+
+    render(<TaskList />);
+    fireEvent.keyDown(screen.getByTestId("queue-region"), { key: "ArrowDown" });
+
+    expect(reorder).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("moves the single selected row up on ArrowUp", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    seed(reorder, [2]);
+
+    render(<TaskList />);
+    fireEvent.keyDown(screen.getByTestId("queue-region"), { key: "ArrowUp" });
+
+    expect(reorder).toHaveBeenCalledWith(2, 1);
+  });
+
+  it("does not reorder when no row is selected", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    seed(reorder, []);
+
+    render(<TaskList />);
+    fireEvent.keyDown(screen.getByTestId("queue-region"), { key: "ArrowDown" });
+
+    expect(reorder).not.toHaveBeenCalled();
+  });
+
+  it("does not reorder the bottom selected row past the edge", () => {
+    const reorder = vi.fn().mockResolvedValue(undefined);
+    seed(reorder, [2]);
+
+    render(<TaskList />);
+    fireEvent.keyDown(screen.getByTestId("queue-region"), { key: "ArrowDown" });
+
+    expect(reorder).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Status column
 // ---------------------------------------------------------------------------
 
@@ -602,6 +668,18 @@ describe("TaskList pointer reorder", () => {
     // Non-target rows must carry no insertion line.
     expect(rows[0].getAttribute("data-drop-edge")).toBeNull();
     expect(rows[1].getAttribute("data-drop-edge")).toBeNull();
+  });
+
+  it("applies the lifted grab class to the row being dragged", () => {
+    setItems(3);
+    render(<TaskList />);
+
+    const rows = bodyRows();
+    // Pressing the grip arms the drag immediately, so the row is "picked up".
+    fireEvent.pointerDown(handle(0));
+
+    expect(rows[0].className).toContain("row-dragging");
+    expect(rows[1].className).not.toContain("row-dragging");
   });
 
   it("shows a top drop-line on an interior row hovered at its upper half", () => {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useRef, type KeyboardEvent } from "react";
 
 import { ColumnResizeHandle } from "@/components/ColumnResizeHandle";
 import {
@@ -9,6 +9,7 @@ import { ReorderDndProvider } from "@/components/reorder-dnd";
 import { TASK_COLUMNS } from "@/components/task-columns";
 import { TaskRow } from "@/components/TaskRow";
 import { useColumnResize } from "@/hooks/useColumnResize";
+import { useQueueReorderKeys } from "@/hooks/useQueueReorderKeys";
 import { useQueueSelectionKeys } from "@/hooks/useQueueSelectionKeys";
 import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
@@ -32,12 +33,24 @@ export function TaskList() {
   const { widths, draggingKey, getSeparatorProps } = useColumnResize();
   // Queue-scoped keyboard shortcuts (select all / delete / clear). Stable across
   // renders, so it is safe to call before the early return below.
-  const onKeyDown = useQueueSelectionKeys();
+  const onSelectionKeys = useQueueSelectionKeys();
   // The table ref lets the reorder animation measure rows; the hook owns the
   // FLIP slide and exposes the animated reorder both reorder paths route through.
   const tableRef = useRef<HTMLTableElement>(null);
   const { animatedReorder, justMovedIndex, liveMessage } =
     useReorderAnimation(tableRef);
+  // Arrow keys move the single selected row, routing through the same animated
+  // reorder so the slide/settle/announce match drag and the buttons.
+  const onReorderKeys = useQueueReorderKeys(animatedReorder);
+  // One handler for the grid: the two hooks own disjoint keys (arrows vs
+  // select-all/delete/clear), so the order is immaterial.
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      onReorderKeys(event);
+      onSelectionKeys(event);
+    },
+    [onReorderKeys, onSelectionKeys],
+  );
 
   if (items.length === 0) {
     return (

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -131,16 +131,18 @@ function TaskRowImpl({ index }: TaskRowProps) {
     });
   };
 
-  // Drag affordances: dim the row being dragged; draw a 2px insertion line on the
-  // edge where the row would land (a box-shadow, not a real element, avoids table
-  // layout shift). A non-dragged selected row carries the accent highlight. The
-  // whole row is a drag surface, so the grab cursor lives on the row itself.
+  // Drag affordances: lift the row being dragged so it reads as "picked up"
+  // (translucent + accent tint + elevation, via the `row-dragging` class); draw a
+  // 2px insertion line on the edge where the row would land (a box-shadow, not a
+  // real element, avoids table layout shift). A non-dragged selected row carries
+  // the accent highlight. The whole row is a drag surface, so the grab cursor
+  // lives on the row itself.
   const rowClassName = [
     "border-b border-border/50 transition-colors",
     // The whole row is a drag surface; show grab at rest, grabbing mid-drag.
     dnd.enabled && (dnd.isDraggingAny ? "cursor-grabbing" : "cursor-grab"),
     dnd.isDragging
-      ? "opacity-40"
+      ? "row-dragging"
       : row.isSelected
         ? "bg-accent"
         : "hover:bg-muted/30",

--- a/src/hooks/useQueueReorderKeys.test.ts
+++ b/src/hooks/useQueueReorderKeys.test.ts
@@ -1,0 +1,142 @@
+import { renderHook } from "@testing-library/react";
+import type { KeyboardEvent } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { useQueueReorderKeys } from "./useQueueReorderKeys";
+
+// Seed the store with `itemCount` rows and a single (or no) selection so the
+// arrow handler has a queue to act on without a Tauri backend.
+function seedQueue(itemCount: number, selectedIndices: number[]): void {
+  const draft: DraftSnapshot = {
+    items: Array.from({ length: itemCount }, (_, i) => ({
+      path: `/tmp/item-${i}.rar`,
+      kind: "rar" as const,
+    })),
+    namingTemplate: null,
+    startNumber: 1,
+    outputDir: null,
+    outputMode: "zip",
+    conflictPolicy: "autoRename",
+  };
+  useJobStore.setState({
+    draft,
+    selectedIndices,
+    selectionAnchor: selectedIndices.length === 1 ? selectedIndices[0] : null,
+  });
+}
+
+// A minimal keydown event exposing only what the handler reads, with a spy on
+// preventDefault so "consumes the key" can be asserted.
+function keyEvent(key: string): KeyboardEvent<HTMLElement> {
+  return {
+    key,
+    preventDefault: vi.fn(),
+  } as unknown as KeyboardEvent<HTMLElement>;
+}
+
+beforeEach(() => {
+  resetJobStore();
+  vi.clearAllMocks();
+});
+
+describe("useQueueReorderKeys", () => {
+  it("moves the sole selected row down on ArrowDown", () => {
+    seedQueue(3, [0]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowDown");
+    result.current(event);
+
+    expect(animatedReorder).toHaveBeenCalledWith(0, 1);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("moves the sole selected row up on ArrowUp", () => {
+    seedQueue(3, [2]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowUp");
+    result.current(event);
+
+    expect(animatedReorder).toHaveBeenCalledWith(2, 1);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("does not move past the top edge but still consumes the key", () => {
+    seedQueue(3, [0]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowUp");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("does not move past the bottom edge but still consumes the key", () => {
+    seedQueue(3, [2]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowDown");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ignores arrows when no row is selected and leaves the key for scrolling", () => {
+    seedQueue(3, []);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowDown");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores arrows when more than one row is selected", () => {
+    seedQueue(3, [0, 1]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowDown");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores arrows while a job is running", () => {
+    seedQueue(3, [0]);
+    useJobStore.setState({ running: true });
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("ArrowDown");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys other than the vertical arrows", () => {
+    seedQueue(3, [0]);
+    const animatedReorder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useQueueReorderKeys(animatedReorder));
+
+    const event = keyEvent("a");
+    result.current(event);
+
+    expect(animatedReorder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useQueueReorderKeys.ts
+++ b/src/hooks/useQueueReorderKeys.ts
@@ -1,0 +1,46 @@
+import { type KeyboardEvent, useCallback } from "react";
+
+import { useJobStore } from "@/store/jobStore";
+
+type AnimatedReorder = (from: number, to: number) => Promise<void>;
+
+/**
+ * Returns a keydown handler that moves the single selected queue row with the
+ * vertical arrow keys: ArrowUp moves it up one slot, ArrowDown down one. The move
+ * routes through the supplied `animatedReorder` so the FLIP slide, settle
+ * highlight, and live-region announce fire identically to a drag or button
+ * reorder, and the store keeps the row selected at its new index so presses chain.
+ *
+ * The handler is inert — and leaves the arrow key for native scrolling — unless
+ * exactly one row is selected and no job is running. At a list edge the key is
+ * consumed (preventDefault) but nothing moves. It reads the store via
+ * `getState()` so it stays referentially stable, and is attached to the focusable
+ * queue container, not the document, so it only fires when the queue is focused.
+ */
+export function useQueueReorderKeys(
+  animatedReorder: AnimatedReorder,
+): (event: KeyboardEvent<HTMLElement>) => void {
+  return useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+
+      const state = useJobStore.getState();
+      // The queue is read-only while a job runs; leave the key for scrolling.
+      if (state.running) return;
+      // Only a single selected row can be moved with the arrows; otherwise leave
+      // the key alone so the queue can scroll.
+      if (state.selectedIndices.length !== 1) return;
+
+      const from = state.selectedIndices[0];
+      const count = state.draft.items.length;
+      const to = event.key === "ArrowUp" ? from - 1 : from + 1;
+
+      // Consume the key either way so the focused queue does not also scroll; only
+      // a move within bounds reorders.
+      event.preventDefault();
+      if (to < 0 || to >= count) return;
+      void animatedReorder(from, to);
+    },
+    [animatedReorder],
+  );
+}

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -229,6 +229,48 @@ describe("reorder", () => {
     expect(useJobStore.getState().error).toBe("bad index");
     expect(useJobStore.getState().draft).toEqual(INITIAL_DRAFT);
   });
+
+  it("keeps the moved row selected at its new index when it was the sole selection", async () => {
+    // Keyboard reorder relies on this: the dragged/moved row stays selected so the
+    // arrows can chain and the eye keeps track of the row across the move.
+    useJobStore.setState({ selectedIndices: [2], selectionAnchor: 2 });
+    mockArchive.reorder.mockResolvedValue(makeDraft(3));
+
+    await useJobStore.getState().reorder(2, 0);
+
+    expect(useJobStore.getState().selectedIndices).toEqual([0]);
+    expect(useJobStore.getState().selectionAnchor).toBe(0);
+  });
+
+  it("clears the selection when the moved row was not the sole selection", async () => {
+    // Multi-selection (or moving a row other than the single selected one) has no
+    // single row to follow, so the re-indexing drops the selection as before.
+    useJobStore.setState({ selectedIndices: [0, 1], selectionAnchor: 0 });
+    mockArchive.reorder.mockResolvedValue(makeDraft(3));
+
+    await useJobStore.getState().reorder(2, 0);
+
+    expect(useJobStore.getState().selectedIndices).toEqual([]);
+    expect(useJobStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("clears the selection when the sole selected row is not the one moved", async () => {
+    useJobStore.setState({ selectedIndices: [1], selectionAnchor: 1 });
+    mockArchive.reorder.mockResolvedValue(makeDraft(3));
+
+    await useJobStore.getState().reorder(2, 0);
+
+    expect(useJobStore.getState().selectedIndices).toEqual([]);
+  });
+
+  it("leaves the selection untouched on a failed reorder", async () => {
+    useJobStore.setState({ selectedIndices: [1], selectionAnchor: 1 });
+    mockArchive.reorder.mockRejectedValue(new Error("bad index"));
+
+    await useJobStore.getState().reorder(1, 0);
+
+    expect(useJobStore.getState().selectedIndices).toEqual([1]);
+  });
 });
 
 describe("removeItem", () => {

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -224,8 +224,15 @@ export const useJobStore = create<JobState>()((set, get) => ({
 
   reorder: async (from, to) => {
     try {
+      // A structural edit clears the selection (draftEdit), but if the moved row
+      // was the only selected one, follow it to its new index so keyboard reorder
+      // can chain and the eye keeps track of the row. Drag/button paths get the
+      // same harmless follow when their row happens to be the sole selection.
+      const sel = get().selectedIndices;
+      const followsMovedRow = sel.length === 1 && sel[0] === from;
       const draft = await archive.reorder(from, to);
       set(draftEdit(draft));
+      if (followsMovedRow) set({ selectedIndices: [to], selectionAnchor: to });
       await get().recomputePreviews();
     } catch (reason) {
       set({ error: messageFromReason(reason) });


### PR DESCRIPTION
## Summary

Adds a keyboard path to reorder the queue and makes a grabbed row read as picked up. With the queue focused and **exactly one** row selected, **ArrowUp** / **ArrowDown** moves that row one slot and keeps it selected so presses chain — routed through the same animated reorder as the ▲▼ buttons and the pointer-drag (#144), so the slide, settle highlight, and screen-reader announce fire identically. While dragging, the held row now visibly lifts off the list instead of only dimming.

## Background / Motivation

- Reordering required either the ▲▼ buttons or a pointer-drag; there was no way to move a row purely with the arrow keys, even though the queue already had keyboard selection and focus (#141).
- A pointer-drag dimmed the held row to `opacity-40` only — on the dark table that translucency-only cue was too subtle to read as "this row is grabbed", so the picked-up state was easy to miss.
- `reorder()` clears the selection on every structural edit (`draftEdit`), so a naive arrow-key move would deselect the row after one step and break chaining.

## Changes

### Arrow-key reorder (`hooks/useQueueReorderKeys.ts`, new)

- New hook mirroring `useQueueSelectionKeys`: an `onKeyDown` that, when exactly one row is selected and no job is running, moves it on ArrowUp/ArrowDown via the supplied `animatedReorder(from, to)` — so the FLIP slide, settle highlight, and live-region announce all reuse the #144 path.
- Reads the store via `getState()` so the handler stays referentially stable. Inert (key left for native scrolling) unless exactly one row is selected; at a list edge the key is consumed (`preventDefault`) but nothing moves.

### Selection follow (`store/jobStore.ts`)

- `reorder(from, to)` now keeps the moved row selected at its new index **only when it was the sole selection** (`selectedIndices === [from]`), set atomically right after the draft commits — so arrow presses chain and the eye tracks the row.
- Multi-selection or a different selected row still drop the selection as before; the error path never reaches the remap, so a failed reorder leaves the selection untouched. Drag and ▲▼ get the same harmless follow when their row happens to be the sole selection.

### Grab affordance (`components/TaskRow.tsx`, `App.css`)

- The dragged row swaps `opacity-40` for a `row-dragging` class: readable translucency (0.6) + accent tint + elevation `box-shadow` + a slight `translateY`/`scale` lift, with `position:relative; z-index` so it floats above its neighbours.
- Static state (no motion), kept under `prefers-reduced-motion`; no FLIP runs mid-drag, so the lift never competes with the drop slide.

### Wiring (`components/TaskList.tsx`)

- `useQueueReorderKeys(animatedReorder)` is composed with the existing `useQueueSelectionKeys` onto the grid's single `onKeyDown`; the two own disjoint keys, so order is immaterial.

### Tests

- `useQueueReorderKeys.test.ts` (new, +8): up/down move the sole selected row through `animatedReorder(from,to)`; an edge press still consumes the key without moving; none / multi / running leave the key for scrolling; non-arrow keys ignored.
- `jobStore.test.ts` (+5): the sole-selected moved row follows to `[to]`; multi-selection and a non-moved sole selection still clear; a failed reorder leaves the selection unchanged.
- `TaskList.test.tsx` (+5): ArrowDown/ArrowUp on the focused queue reorder the selected row; no-selection and bottom-edge are no-ops; the dragged row carries `row-dragging`.
- Each new test was confirmed RED before implementation.

## Verification

- Click a single queue row (`aria-selected="true"`, `bg-accent`), then with the queue focused press ArrowUp/ArrowDown — the row slides one slot and stays selected, so repeated presses keep moving it.
- ArrowUp on the top row / ArrowDown on the bottom row does nothing and does not scroll. With no row or multiple rows selected, the arrows scroll the queue as before; arrows are inert while a job runs.
- Grab a row (grip, or row body past the 5px threshold): the held row dims to 0.6, takes an accent tint, and lifts with a shadow (the `row-dragging` class) — visibly "picked up" — until drop.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 516 passed (45 files; +17 new, each confirmed RED first)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): select a row + ArrowUp/ArrowDown to move it and confirm it stays selected; confirm the lifted grab cue while dragging; confirm arrows scroll when nothing is selected and are inert while running
