### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,7 +3770,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.6.0"
+version = "0.7.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release prep for **v0.7.0**: bump the version `0.6.0` → `0.7.0` across all tracked manifests.

## Changes

- `package.json`
- `src-tauri/Cargo.toml`
- `crates/core/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `Cargo.lock` (both `simple-archiver` and `simple-archiver-core` entries)

Verified with `cargo metadata --locked` (exit 0). No source changes; version-only PR.

## Release contents (since v0.6.0)

Queue-row reordering and keyboard interaction overhaul:

- Drag the whole queue row to reorder, with a dedicated grip column, precise insertion line, slide/settle animation, and a11y announcements
- Arrow-key row move and a lifted grab affordance
- Select queue rows and delete them with the keyboard
- Output rail layout: move "If exists" above the destination, move Clear to the queue toolbar, soft-fill the Clear button
- Fix: scope `opener` `open_path` so the "Open folder" button works
