### PR TITLE
fix(rail): scroll horizontally on a narrow pane instead of clipping

### DIFF
--- a/src/components/LeftRail.test.tsx
+++ b/src/components/LeftRail.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { DEFAULT_RAIL_WIDTH } from "@/lib/rail-width";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 import { LeftRail } from "./LeftRail";
@@ -111,6 +112,27 @@ describe("LeftRail", () => {
     render(<LeftRail />);
     expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^run$/i })).toBeNull();
+  });
+
+  it("scrolls horizontally instead of clipping the controls when the pane is narrow", () => {
+    render(<LeftRail />);
+    const region = screen.getByRole("complementary", {
+      name: /output settings/i,
+    });
+    // The rail scrolls on both axes: a pane narrower than the controls' design
+    // width shows a horizontal scrollbar rather than clipping/compressing them.
+    // `overflow-y-auto` would clip horizontal overflow, so the class must be the
+    // both-axes `overflow-auto`.
+    expect(region.className.split(/\s+/)).toContain("overflow-auto");
+  });
+
+  it("keeps the controls at least the default rail width so a narrow pane scrolls", () => {
+    render(<LeftRail />);
+    // The controls live in a content wrapper that never collapses below the
+    // default rail width; when the pane is dragged narrower, that wrapper
+    // overflows and the rail scrolls horizontally instead of compressing.
+    const content = screen.getByTestId("rail-content");
+    expect(content.style.minWidth).toBe(`${DEFAULT_RAIL_WIDTH}px`);
   });
 
   it("keeps Run accessibly disabled with a describedby reason when not ready", () => {

--- a/src/components/LeftRail.tsx
+++ b/src/components/LeftRail.tsx
@@ -7,6 +7,7 @@ import { OutputModeToggle } from "@/components/OutputModeToggle";
 import { RunControls } from "@/components/RunControls";
 import { StartNumberForm } from "@/components/StartNumberForm";
 import { joinOutputPath } from "@/lib/path";
+import { DEFAULT_RAIL_WIDTH } from "@/lib/rail-width";
 import { selectFirstPreview, useJobStore } from "@/store/jobStore";
 
 /**
@@ -25,9 +26,12 @@ import { selectFirstPreview, useJobStore } from "@/store/jobStore";
  *
  * The rail fills its resizable pane (the width is owned by AppShell via the
  * pane separator); on a viewport too short to fit its natural height it scrolls
- * internally (the right canvas is the primary scroller). It is a labelled
- * complementary landmark (an <aside>) so assistive tech can jump straight to the
- * output settings.
+ * internally (the right canvas is the primary scroller). Its controls live in a
+ * content wrapper that never collapses below {@link DEFAULT_RAIL_WIDTH}, so a
+ * pane dragged narrower scrolls horizontally rather than clipping or
+ * compressing the controls (the <aside> is an `overflow-auto` scroll container
+ * on both axes). It is a labelled complementary landmark (an <aside>) so
+ * assistive tech can jump straight to the output settings.
  */
 export function LeftRail() {
   const outputDir = useJobStore((s) => s.draft.outputDir);
@@ -58,80 +62,93 @@ export function LeftRail() {
   return (
     <aside
       aria-label="Output settings"
-      className="flex min-h-0 w-full flex-col gap-4 overflow-y-auto bg-muted/40 px-5 py-4"
+      className="flex min-h-0 w-full overflow-auto bg-muted/40"
     >
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">
-          OUTPUT
-        </span>
-        <OutputModeToggle />
-      </div>
+      {/* Content wrapper: holds the controls in a vertical stack and never
+          collapses below the default rail width. The <aside> scrolls on both
+          axes, so a pane dragged narrower than this width scrolls horizontally
+          instead of clipping or compressing the controls. min-h-full keeps the
+          column at least as tall as the pane so RunControls stays pinned to the
+          bottom via mt-auto. */}
+      <div
+        data-testid="rail-content"
+        className="flex min-h-full w-full flex-col gap-4 px-5 py-4"
+        style={{ minWidth: `${DEFAULT_RAIL_WIDTH}px` }}
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">
+            OUTPUT
+          </span>
+          <OutputModeToggle />
+        </div>
 
-      {/* Folder-mode collision policy: pinned directly under the OUTPUT header,
+        {/* Folder-mode collision policy: pinned directly under the OUTPUT header,
           ahead of the destination, so the "if a folder already exists" choice is
           the first decision seen when extracting to folders. */}
-      {outputMode === "folder" ? (
-        <div className="flex flex-col gap-1.5">
-          <span className="text-xs font-medium text-muted-foreground">
-            If exists
-          </span>
-          <ConflictPolicySelect />
-        </div>
-      ) : null}
+        {outputMode === "folder" ? (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              If exists
+            </span>
+            <ConflictPolicySelect />
+          </div>
+        ) : null}
 
-      {/* Collapsed Destination: path or "(not set)" + Required, with Change. */}
-      <OutputDirPicker />
+        {/* Collapsed Destination: path or "(not set)" + Required, with Change. */}
+        <OutputDirPicker />
 
-      {/* Compact hero: the full landing path, shown only once the preview
+        {/* Compact hero: the full landing path, shown only once the preview
           filename has resolved so the destination is never shown in isolation.
           The leading arrow only appears once a destination joins the filename. */}
-      <div className="flex flex-col gap-1">
-        {heroPath !== null ? (
-          <p className="flex items-center gap-2 truncate text-sm">
-            {outputDir !== null ? (
-              <ArrowRight
-                aria-hidden="true"
-                data-testid="hero-path-arrow"
-                className="size-4 shrink-0 text-muted-foreground"
-              />
-            ) : null}
-            <span
-              className="truncate font-mono text-foreground"
-              title={heroPath}
-            >
-              {heroPath}
-            </span>
-          </p>
-        ) : null}
-        {outputDir === null ? (
-          <p className="text-xs text-muted-foreground">
-            Select a destination to preview the full path.
-          </p>
-        ) : null}
-        {outputMode === "zip" && error ? (
-          <p role="alert" className="text-sm text-destructive">
-            {error}
-          </p>
-        ) : null}
-      </div>
-
-      {/* Mode-specific editing controls: naming + start number in zip mode, the
-          extraction note in folder mode (the collision policy sits up top). */}
-      {outputMode === "zip" ? (
-        <div className="flex flex-col gap-3">
-          <NamingRuleForm />
-          <StartNumberForm />
+        <div className="flex flex-col gap-1">
+          {heroPath !== null ? (
+            <p className="flex items-center gap-2 truncate text-sm">
+              {outputDir !== null ? (
+                <ArrowRight
+                  aria-hidden="true"
+                  data-testid="hero-path-arrow"
+                  className="size-4 shrink-0 text-muted-foreground"
+                />
+              ) : null}
+              <span
+                className="truncate font-mono text-foreground"
+                title={heroPath}
+              >
+                {heroPath}
+              </span>
+            </p>
+          ) : null}
+          {outputDir === null ? (
+            <p className="text-xs text-muted-foreground">
+              Select a destination to preview the full path.
+            </p>
+          ) : null}
+          {outputMode === "zip" && error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
         </div>
-      ) : (
-        <p className="text-xs text-muted-foreground">
-          Each archive is extracted into its own folder named after the archive.
-        </p>
-      )}
 
-      {/* The run action lives at the foot of the rail, pushed to the bottom so it
+        {/* Mode-specific editing controls: naming + start number in zip mode, the
+          extraction note in folder mode (the collision policy sits up top). */}
+        {outputMode === "zip" ? (
+          <div className="flex flex-col gap-3">
+            <NamingRuleForm />
+            <StartNumberForm />
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Each archive is extracted into its own folder named after the
+            archive.
+          </p>
+        )}
+
+        {/* The run action lives at the foot of the rail, pushed to the bottom so it
           stays anchored below the settings. */}
-      <div className="mt-auto border-t border-border pt-4">
-        <RunControls />
+        <div className="mt-auto border-t border-border pt-4">
+          <RunControls />
+        </div>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

When the left OUTPUT rail is dragged narrower than its controls' design width, the panel clipped and compressed its contents — long destination/landing paths truncated, the DESTINATION/NAME/START # rows squeezed — with no way to reach the hidden content. The rail now scrolls **horizontally** instead: its controls keep their default-width layout and a pane narrower than that reveals a horizontal scrollbar, so every control stays reachable. Vertical scroll, the bottom-anchored Run control, and all store wiring are unchanged.

## Background / Motivation

- The rail (`LeftRail`) is user-resizable down to `MIN_RAIL_WIDTH` (240px) via the pane separator, but its `<aside>` only carried `overflow-y-auto`; horizontal overflow was clipped by the body's `overflow-hidden`.
- Inside the column the controls are `w-full` and the paths use `truncate`, so a narrow pane compressed/ellipsized them in place rather than overflowing — the cut-off text was simply unreachable.
- The controls are designed around `DEFAULT_RAIL_WIDTH` (320px); below that they should keep their shape and scroll, not collapse.

## Changes

### Horizontally scrollable rail (`src/components/LeftRail.tsx`)

- The rail `<aside>` becomes an `overflow-auto` scroll container (both axes) instead of `overflow-y-auto`, so horizontal overflow scrolls rather than being clipped.
- The controls move into a `data-testid="rail-content"` wrapper with `min-width` pinned to `DEFAULT_RAIL_WIDTH` (imported from `@/lib/rail-width`): at or above the default width it fills the pane (`w-full`); narrower, it holds 320px and the `<aside>` scrolls horizontally.
- The wrapper carries `min-h-full` so it stays at least as tall as the pane, preserving the `mt-auto` bottom-anchor for `RunControls`. The vertical stack (`flex-col gap-4 px-5 py-4`) and every sub-control are otherwise untouched.

### Tests (`src/components/LeftRail.test.tsx`)

- `scrolls horizontally instead of clipping the controls when the pane is narrow` — asserts the rail region carries the both-axes `overflow-auto` class (not `overflow-y-auto`).
- `keeps the controls at least the default rail width so a narrow pane scrolls` — asserts the `rail-content` wrapper's `min-width` equals `DEFAULT_RAIL_WIDTH`.
- Both were confirmed RED before the implementation landed.

## Verification

- Drag the pane separator to shrink the OUTPUT rail below ~320px: a horizontal scrollbar appears and the DESTINATION / NAME / START # controls keep their full width and stay reachable by scrolling, instead of compressing or truncating.
- At the default width (or wider) the rail looks unchanged — no horizontal scrollbar, Run still pinned to the bottom, vertical scroll still works on a short viewport.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 518 passed (45 files; +2 new, each confirmed RED first)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): drag the rail narrow and confirm horizontal scroll reaches every control; confirm the default width is visually unchanged
