### PR TITLE
feat(menu): show only the simple-archiver app menu in the menu bar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,42 @@
 pub mod presentation;
 
+use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
+use tauri::{AppHandle, Runtime};
+
+/// Build the application menu so the macOS menu bar shows only the app-name
+/// menu ("simple-archiver") and none of Tauri's default File/Edit/View/Window/
+/// Help entries. On macOS the first (and here only) submenu always renders as
+/// the application menu, taking its title from the bundle name.
+///
+/// The Cut/Copy/Paste/Select All predefined items are nested inside this single
+/// submenu on purpose: AppKit registers their `Cmd+X/C/V/A` key equivalents for
+/// every item in the menu tree regardless of nesting, so the text inputs
+/// (naming rule, start number) keep working without exposing a separate "Edit"
+/// menu in the bar.
+fn make_menu<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let app_menu = Submenu::with_items(
+        handle,
+        "simple-archiver",
+        true,
+        &[
+            &PredefinedMenuItem::about(handle, None, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::cut(handle, None)?,
+            &PredefinedMenuItem::copy(handle, None)?,
+            &PredefinedMenuItem::paste(handle, None)?,
+            &PredefinedMenuItem::select_all(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::hide(handle, None)?,
+            &PredefinedMenuItem::quit(handle, None)?,
+        ],
+    )?;
+    Menu::with_items(handle, &[&app_menu])
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .menu(make_menu)
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())


### PR DESCRIPTION
## Summary

Restrict the macOS menu bar to the `simple-archiver` app-name menu only, dropping Tauri's default `File / Edit / View / Window / Help` entries. To avoid breaking copy/paste in the naming-rule and start-number text inputs once `Edit` is gone, the `Cut / Copy / Paste / Select All` shortcuts are preserved.

## Background / Motivation

- No menu was configured, so `tauri::Builder::default()` fell back to `Menu::default()` and macOS auto-generated the full `simple-archiver / File / Edit / View / Window / Help` bar.
- We want a minimal menu bar that shows only the app name.
- Simply removing the `Edit` menu breaks `Cmd+X/C/V/A` (Cut/Copy/Paste/Select All) inside WKWebView text inputs — a known macOS behavior — which would degrade the `NamingRuleForm` / `StartNumberForm` fields.

## Changes

### App-name-only menu (`src-tauri/src/lib.rs`)

- Add `make_menu<R: Runtime>(handle)` and wire it via `Builder::menu(make_menu)`, replacing the implicit `Builder::default()` menu.
- The menu has a single top-level submenu. On macOS the first submenu is always rendered as the application menu and takes its title from the bundle name (`simple-archiver`), so only `simple-archiver` remains in the bar.

### Preserve copy/paste shortcuts

- The `Cut / Copy / Paste / Select All` `PredefinedMenuItem`s live inside that single submenu. AppKit registers key equivalents for the whole menu tree regardless of nesting, so `Cmd+X/C/V/A` stay wired without exposing an `Edit` menu in the bar.
- `About` / `Hide` / `Quit` are included in the same submenu to keep standard actions such as `Cmd+Q`.

## Verification

- Launch the packaged macOS app and confirm the menu bar shows only `simple-archiver` — no `File / Edit / View / Window / Help`.
- Open the `simple-archiver` menu and confirm `About / Cut / Copy / Paste / Select All / Hide / Quit` are present.
- Confirm `Cmd+C` / `Cmd+V` / `Cmd+X` / `Cmd+A` still work in the naming-rule and start-number inputs.
- No backend DTO change, so no `src/bindings/*.ts` regeneration is needed.

## Test plan

- [x] `cargo build --lib`
- [x] `cargo clippy --lib --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo nextest run` — 101 passed
- [ ] Manual (packaged macOS app): confirm the bar shows only `simple-archiver` and that copy/paste works in the inputs

> Native menu construction cannot be unit-tested in a headless CI without a display (muda requires a real runtime/display), so the menu wiring is covered by green build/clippy/fmt/nextest plus manual on-device verification.
