### PR TITLE
fix(ui): make the grabbed queue row read as lifted, not ghosted

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -189,20 +189,24 @@
   animation: row-settle 700ms ease-out;
 }
 
-/* "Picked up" affordance for the row being dragged: a readable translucency plus
-   an accent tint and an elevation shadow so it visibly lifts off the list and
-   reads as grabbed (the old translucency-only cue was too subtle on the dark
-   table). `position`/`z-index` float it above its neighbours so the shadow is not
-   clipped by the next row's background. A static state, not motion, so it is kept
-   under prefers-reduced-motion. No FLIP slide runs while a row is held, so the
-   lift transform never competes with the drop animation. */
+/* "Picked up" affordance for the row being dragged: the row stays near-opaque so
+   it reads as a solid card lifted off the list — the earlier 0.6 translucency
+   ghosted the row and made the grab cue look weak on the dark table — and is
+   framed by an accent ring and floated on a deep elevation shadow so the lift is
+   unmistakable. `position`/`z-index` float it above its neighbours so neither the
+   ring nor the shadow is clipped by the next row's background. The first
+   box-shadow layer is the ring (a hard, zero-blur 2px spread in the primary
+   accent); the remaining layers are the soft drop shadow. A static state, not
+   motion, so it is kept under prefers-reduced-motion. No FLIP slide runs while a
+   row is held, so the lift transform never competes with the drop animation. */
 .row-dragging {
   position: relative;
   z-index: 1;
-  opacity: 0.6;
+  opacity: 0.95;
   background-color: var(--color-accent);
   box-shadow:
-    0 6px 16px -4px rgb(0 0 0 / 0.5),
-    0 2px 4px -2px rgb(0 0 0 / 0.4);
-  transform: translateY(-2px) scale(1.01);
+    0 0 0 2px var(--color-primary),
+    0 10px 24px -6px rgb(0 0 0 / 0.6),
+    0 3px 6px -3px rgb(0 0 0 / 0.5);
+  transform: translateY(-3px) scale(1.02);
 }


### PR DESCRIPTION
## Summary

The dragged queue row's "picked up" cue was a 0.6-opacity translucency that, on the dark table, read as ghosted/disabled rather than grabbed. This swaps it for a near-opaque solid card, framed by an accent ring and floated on a deeper elevation shadow with a slightly larger lift, so the held row is unmistakably lifted off the list.

## Background / Motivation

- The `row-dragging` grab cue added in #145 dimmed the held row to `opacity: 0.6`; on the dark queue table that translucency-only treatment looked like the row was fading out / disabled instead of being grabbed.
- A picked-up element should read as *more* prominent than its neighbours, not less — ghosting the source row fights that, and there is no separate floating drag clone to carry the "lifted" signal, so the row itself must.

## Changes

### Solid lift for `.row-dragging` (`src/App.css`)

- Raise `opacity` 0.6 → 0.95 so the held row stays a solid card rather than a ghost.
- Add an accent ring as the first `box-shadow` layer (a hard, zero-blur 2px spread in `--color-primary`) to frame the grabbed row; the remaining layers stay the soft drop shadow.
- Deepen the elevation drop shadow and grow the lift transform `translateY(-2px) scale(1.01)` → `translateY(-3px) scale(1.02)`.
- Class name and DOM contract are unchanged, so the existing `row-dragging` wiring in `TaskRow.tsx` and its assertions are untouched; still a static state (no motion) kept under `prefers-reduced-motion`.

## Verification

- Grab a queue row (grip, or row body past the 5px threshold): the held row stays near-opaque, gains a `--color-primary` ring, and floats on a stronger shadow with a slightly larger lift — clearly "picked up" — until drop. Look for the `row-dragging` class / `data-dragging="true"` on the dragged `<tr>`.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 516 passed (45 files); no new tests — CSS-only, and the existing `row-dragging` assertion in `TaskList.test.tsx` still holds.
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check, matching the lockfile)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings, matching the lockfile)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): drag a row and confirm the lifted ring + shadow read clearly on the dark table; confirm it still respects the OS "Reduce motion" setting (static, so unaffected).
