### PR TITLE
feat(ledger): copy-path toast affordance, drop per-row reveal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -206,3 +206,29 @@
     0 2px 4px -2px rgb(0 0 0 / 0.4);
   transform: translateY(-2px) scale(1.01);
 }
+
+/* One-shot entrance for the transient "Path was copied" pill: it rises slightly
+   and fades in by the pointer. The element's resting transform (-50%, -150%)
+   comes from utility classes; the keyframe only animates the approach to it. */
+@keyframes copied-hint-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -130%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -150%);
+  }
+}
+
+.copied-hint {
+  animation: copied-hint-in 140ms ease-out;
+}
+
+/* Motion is decorative here; honour a reduced-motion preference by snapping the
+   pill straight to its resting state. */
+@media (prefers-reduced-motion: reduce) {
+  .copied-hint {
+    animation: none;
+  }
+}

--- a/src/__tests__/summary-flow.test.tsx
+++ b/src/__tests__/summary-flow.test.tsx
@@ -22,7 +22,6 @@ vi.mock("@/lib/archive", () => ({
 // reaches the real Tauri backend.
 vi.mock("@/lib/reveal", () => ({
   openPath: vi.fn(),
-  revealItem: vi.fn(),
   copyText: vi.fn(),
 }));
 

--- a/src/components/LastBatchChip.test.tsx
+++ b/src/components/LastBatchChip.test.tsx
@@ -26,7 +26,6 @@ vi.mock("@/lib/archive", () => ({
 // Mock the opener wrapper so the chip's Open action never reaches Tauri.
 vi.mock("@/lib/reveal", () => ({
   openPath: vi.fn(),
-  revealItem: vi.fn(),
   copyText: vi.fn(),
 }));
 

--- a/src/components/Ledger.test.tsx
+++ b/src/components/Ledger.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,7 +6,7 @@ import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 import * as archive from "@/lib/archive";
-import { copyText, openPath, revealItem } from "@/lib/reveal";
+import { copyText, openPath } from "@/lib/reveal";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 import { Ledger } from "./Ledger";
@@ -29,14 +29,12 @@ vi.mock("@/lib/archive", () => ({
 // Mock the opener/clipboard wrapper so the row actions never reach Tauri.
 vi.mock("@/lib/reveal", () => ({
   openPath: vi.fn(),
-  revealItem: vi.fn(),
   copyText: vi.fn(),
 }));
 
 beforeEach(() => {
   resetJobStore();
   vi.mocked(openPath).mockReset();
-  vi.mocked(revealItem).mockReset();
   vi.mocked(copyText).mockReset();
 });
 
@@ -218,20 +216,17 @@ describe("Ledger", () => {
       });
     });
 
-    it("Reveal on a succeeded row reveals that row's output path", async () => {
-      vi.mocked(revealItem).mockResolvedValue(undefined);
+    it("offers no Reveal action on any row (the column was removed)", () => {
       render(<Ledger />);
-
-      const succeededRow = screen.getByText("out_1.zip").closest("tr");
-      expect(succeededRow).not.toBeNull();
-      await userEvent.click(
-        within(succeededRow as HTMLElement).getByRole("button", {
-          name: /reveal/i,
-        }),
+      expect(screen.queryAllByRole("button", { name: /reveal/i })).toHaveLength(
+        0,
       );
-
-      expect(vi.mocked(revealItem)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(revealItem)).toHaveBeenCalledWith("/out/out_1.zip");
+      // Every result row keeps exactly its single Copy action.
+      for (const name of ["out_1.zip", "out_2.zip", "out_3.zip"]) {
+        const row = screen.getByText(name).closest("tr") as HTMLElement;
+        expect(within(row).getAllByRole("button")).toHaveLength(1);
+        expect(within(row).getByRole("button", { name: /copy/i })).toBeTruthy();
+      }
     });
 
     it("Copy on a row copies that row's output path", async () => {
@@ -247,29 +242,88 @@ describe("Ledger", () => {
 
       expect(vi.mocked(copyText)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(copyText)).toHaveBeenCalledWith("/out/out_1.zip");
+      // The success affordance appears (and we await it to settle the state
+      // update so the assertions above run inside act()).
+      await screen.findByText(/path was copied/i);
     });
 
-    it("disables Reveal on a failed row (no on-disk output exists)", () => {
+    it("Copy is available even on a failed row (the path can still be pasted)", async () => {
+      vi.mocked(copyText).mockResolvedValue(undefined);
       render(<Ledger />);
+
       const failedRow = screen.getByText("out_3.zip").closest("tr");
-      const reveal = within(failedRow as HTMLElement).getByRole("button", {
-        name: /reveal/i,
-      });
-      expect((reveal as HTMLButtonElement).disabled).toBe(true);
+      await userEvent.click(
+        within(failedRow as HTMLElement).getByRole("button", {
+          name: /copy/i,
+        }),
+      );
+
+      expect(vi.mocked(copyText)).toHaveBeenCalledWith("/out/out_3.zip");
+      await screen.findByText(/path was copied/i);
     });
 
-    it("surfaces an error when revealing fails", async () => {
-      vi.mocked(revealItem).mockRejectedValue(new Error("no such file"));
+    it("shows a 'Path was copied' affordance near the pointer after copying", async () => {
+      vi.mocked(copyText).mockResolvedValue(undefined);
+      render(<Ledger />);
+
+      const succeededRow = screen.getByText("out_1.zip").closest("tr");
+      // fireEvent (not userEvent) so we can supply pointer coordinates; the
+      // affordance is positioned at the click point.
+      fireEvent.click(
+        within(succeededRow as HTMLElement).getByRole("button", {
+          name: /copy/i,
+        }),
+        { clientX: 123, clientY: 456 },
+      );
+
+      const hint = await screen.findByText(/path was copied/i);
+      // Fixed-position pill anchored at the pointer's viewport coordinates.
+      expect(hint.style.left).toBe("123px");
+      expect(hint.style.top).toBe("456px");
+    });
+
+    it("dismisses the copied affordance after a few seconds", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(copyText).mockResolvedValue(undefined);
+        render(<Ledger />);
+
+        const succeededRow = screen.getByText("out_1.zip").closest("tr");
+        fireEvent.click(
+          within(succeededRow as HTMLElement).getByRole("button", {
+            name: /copy/i,
+          }),
+          { clientX: 10, clientY: 20 },
+        );
+        // Flush the async copy → state update that mounts the affordance.
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(screen.getByText(/path was copied/i)).toBeTruthy();
+
+        // After the timeout elapses, the affordance is gone.
+        act(() => {
+          vi.advanceTimersByTime(5000);
+        });
+        expect(screen.queryByText(/path was copied/i)).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("surfaces an error when copying fails (and shows no affordance)", async () => {
+      vi.mocked(copyText).mockRejectedValue(new Error("clipboard denied"));
       render(<Ledger />);
 
       const succeededRow = screen.getByText("out_1.zip").closest("tr");
       await userEvent.click(
         within(succeededRow as HTMLElement).getByRole("button", {
-          name: /reveal/i,
+          name: /copy/i,
         }),
       );
 
-      expect(useJobStore.getState().error).toBe("no such file");
+      expect(useJobStore.getState().error).toBe("clipboard denied");
+      expect(screen.queryByText(/path was copied/i)).toBeNull();
     });
   });
 
@@ -362,8 +416,7 @@ describe("Ledger", () => {
       render(<Ledger />);
 
       expect(screen.getByRole("status", { name: /run summary/i })).toBeTruthy();
-      // Icon buttons carry accessible names.
-      expect(screen.getByRole("button", { name: /reveal/i })).toBeTruthy();
+      // The per-row Copy icon button carries an accessible name.
       expect(screen.getByRole("button", { name: /copy/i })).toBeTruthy();
     });
   });

--- a/src/components/Ledger.tsx
+++ b/src/components/Ledger.tsx
@@ -1,4 +1,5 @@
-import { ArrowUpRight, Copy, Eraser, FolderOpen } from "lucide-react";
+import { Copy, Eraser, FolderOpen } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 import type { TaskResultDto } from "@/bindings/TaskResultDto";
@@ -6,9 +7,13 @@ import { Button } from "@/components/ui/button";
 import { messageFromReason } from "@/lib/errors";
 import { formatBytes } from "@/lib/format";
 import { basename } from "@/lib/path";
-import { copyText, openPath, revealItem } from "@/lib/reveal";
+import { copyText, openPath } from "@/lib/reveal";
 import { statusVisual } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
+
+// How long the transient "Path was copied" affordance lingers near the pointer
+// after a successful per-row Copy before it fades away on its own.
+const COPIED_HINT_MS = 2000;
 
 // Run an IPC-touching action and surface a failure through the shared store
 // error path rather than swallowing it, mirroring the other event handlers
@@ -44,20 +49,22 @@ interface LedgerRowProps {
   source: string;
   /** Best-effort produced size, or null when unknown. */
   size: string | null;
+  /**
+   * Raise the transient "Path was copied" affordance at the given viewport
+   * coordinates after this row's path is successfully copied.
+   */
+  onCopied: (x: number, y: number) => void;
 }
 
 /**
- * One ledger row: `# | source → output name | size | status | Reveal | Copy`.
+ * One ledger row: `# | source → output name | size | status | Copy`.
  *
- * Reveal targets the row's own absolute output path. A failed task produced no
- * on-disk output, so Reveal is disabled there (the header's "Open folder" is the
- * obvious fallback to reach the destination directory). Copy always copies the
- * intended output path so the user can paste it even for a failed row.
+ * Copy writes the row's intended absolute output path to the clipboard; even a
+ * failed row exposes it so the path can still be pasted. On success it raises a
+ * transient "Path was copied" affordance at the pointer via `onCopied`.
  */
-function LedgerRow({ index, result, source, size }: LedgerRowProps) {
+function LedgerRow({ index, result, source, size, onCopied }: LedgerRowProps) {
   const visual = statusVisual(result.status);
-  // A failed task wrote nothing to disk, so there is no item to reveal.
-  const canReveal = result.status !== "failed";
 
   return (
     <tr className="border-b border-border/50 hover:bg-muted/30 transition-colors">
@@ -99,19 +106,16 @@ function LedgerRow({ index, result, source, size }: LedgerRowProps) {
           <Button
             variant="ghost"
             size="icon"
-            aria-label={`Reveal ${result.outputName} in file explorer`}
-            disabled={!canReveal}
-            onClick={() =>
-              runOrReportError(() => revealItem(result.outputPath))
-            }
-          >
-            <ArrowUpRight aria-hidden="true" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
             aria-label={`Copy path of ${result.outputName}`}
-            onClick={() => runOrReportError(() => copyText(result.outputPath))}
+            onClick={(event) => {
+              // Capture the pointer position now; the synthetic event is not
+              // available once the async copy resolves.
+              const { clientX, clientY } = event;
+              runOrReportError(async () => {
+                await copyText(result.outputPath);
+                onCopied(clientX, clientY);
+              });
+            }}
           >
             <Copy aria-hidden="true" />
           </Button>
@@ -125,7 +129,7 @@ function LedgerRow({ index, result, source, size }: LedgerRowProps) {
  * The Inline Ledger is the completion view shown in the right canvas after a job
  * finishes. It replaces the old RunSummary panel: a sticky header with the
  * status tally + an "Open folder" affordance, then one row per task carrying its
- * source → output name, produced size, status, and per-row Reveal/Copy actions.
+ * source → output name, produced size, status, and a per-row Copy action.
  *
  * Pure projection of the backend JobSummaryDto: the header counts are tallied
  * from `summary.results[].status` (never recomputed independently) and failure
@@ -137,6 +141,21 @@ export function Ledger() {
   const items = useJobStore((s) => s.draft.items);
   const outputDir = useJobStore((s) => s.draft.outputDir);
   const clearResults = useJobStore((s) => s.clearResults);
+
+  // Transient per-row "Path was copied" affordance, anchored at the pointer.
+  // `nonce` changes the object identity on every copy so a repeat copy re-arms
+  // the dismiss timer and repositions the pill even when the text is unchanged.
+  const [copiedHint, setCopiedHint] = useState<{
+    x: number;
+    y: number;
+    nonce: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (copiedHint === null) return;
+    const timer = setTimeout(() => setCopiedHint(null), COPIED_HINT_MS);
+    return () => clearTimeout(timer);
+  }, [copiedHint]);
 
   if (summary === null) return null;
 
@@ -151,72 +170,93 @@ export function Ledger() {
     { visual: statusVisual("failed"), n: failed },
   ];
 
+  const showCopiedHint = (x: number, y: number) =>
+    setCopiedHint((prev) => ({ x, y, nonce: (prev?.nonce ?? 0) + 1 }));
+
   // <output> carries an implicit ARIA role of "status" (and implicit aria-live),
   // so the ledger is announced to assistive tech and tests resolve it via
   // getByRole("status"); keep this an <output> when refactoring.
   return (
-    <output
-      aria-live="polite"
-      aria-label="Run summary"
-      className="flex flex-col rounded-md border border-border bg-card text-sm"
-    >
-      {/* Sticky header: status tally + the whole-job "find my files" action. */}
-      <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3 rounded-t-md border-b border-border bg-card px-4 py-3">
-        <div className="flex flex-wrap items-center gap-2">
-          {counts.map(({ visual, n }) => (
-            <span
-              key={visual.label}
-              className={`inline-flex items-center gap-1.5 rounded px-2 py-1 font-medium ${visual.className}`}
-            >
-              <span aria-hidden="true">{visual.icon}</span>
-              {visual.label} {n}
-            </span>
-          ))}
-        </div>
+    <>
+      <output
+        aria-live="polite"
+        aria-label="Run summary"
+        className="flex flex-col rounded-md border border-border bg-card text-sm"
+      >
+        {/* Sticky header: status tally + the whole-job "find my files" action. */}
+        <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3 rounded-t-md border-b border-border bg-card px-4 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {counts.map(({ visual, n }) => (
+              <span
+                key={visual.label}
+                className={`inline-flex items-center gap-1.5 rounded px-2 py-1 font-medium ${visual.className}`}
+              >
+                <span aria-hidden="true">{visual.icon}</span>
+                {visual.label} {n}
+              </span>
+            ))}
+          </div>
 
-        <div className="flex items-center gap-2">
-          {/* Guarded on outputDir so it never opens a null path. */}
-          {outputDir !== null && (
+          <div className="flex items-center gap-2">
+            {/* Guarded on outputDir so it never opens a null path. */}
+            {outputDir !== null && (
+              <Button
+                variant="outline"
+                size="sm"
+                aria-label="Open folder"
+                onClick={() => runOrReportError(() => openPath(outputDir))}
+              >
+                <FolderOpen aria-hidden="true" />
+                Open folder
+              </Button>
+            )}
+
+            {/* Clear folds the Ledger back to the drop zone and pins the residual
+              chip; it never deletes files on disk. The chip's Undo is the undo
+              affordance, so there is no confirm dialog. */}
             <Button
               variant="outline"
               size="sm"
-              aria-label="Open folder"
-              onClick={() => runOrReportError(() => openPath(outputDir))}
+              aria-label="Clear results"
+              onClick={() => runOrReportError(() => clearResults())}
             >
-              <FolderOpen aria-hidden="true" />
-              Open folder
+              <Eraser aria-hidden="true" />
+              Clear
             </Button>
-          )}
-
-          {/* Clear folds the Ledger back to the drop zone and pins the residual
-              chip; it never deletes files on disk. The chip's Undo is the undo
-              affordance, so there is no confirm dialog. */}
-          <Button
-            variant="outline"
-            size="sm"
-            aria-label="Clear results"
-            onClick={() => runOrReportError(() => clearResults())}
-          >
-            <Eraser aria-hidden="true" />
-            Clear
-          </Button>
+          </div>
         </div>
-      </div>
 
-      {/* One row per task, in job order. */}
-      <table className="w-full text-left">
-        <tbody>
-          {results.map((result, index) => (
-            <LedgerRow
-              key={result.taskId}
-              index={index}
-              result={result}
-              source={basename(items[index]?.path ?? "")}
-              size={sizeForTask(result.taskId, progress)}
-            />
-          ))}
-        </tbody>
-      </table>
-    </output>
+        {/* One row per task, in job order. */}
+        <table className="w-full text-left">
+          <tbody>
+            {results.map((result, index) => (
+              <LedgerRow
+                key={result.taskId}
+                index={index}
+                result={result}
+                source={basename(items[index]?.path ?? "")}
+                size={sizeForTask(result.taskId, progress)}
+                onCopied={showCopiedHint}
+              />
+            ))}
+          </tbody>
+        </table>
+      </output>
+
+      {/* Transient confirmation that floats in near the pointer after a Copy
+          and fades on its own. Pointer-events-none so it never intercepts a
+          follow-up click; its own <output> announces the copy to assistive
+          tech without disturbing the run-summary region above. */}
+      {copiedHint !== null && (
+        <output
+          key={copiedHint.nonce}
+          aria-live="polite"
+          className="copied-hint pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-[150%] rounded-md border border-border bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-md"
+          style={{ left: copiedHint.x, top: copiedHint.y }}
+        >
+          Path was copied
+        </output>
+      )}
+    </>
   );
 }

--- a/src/components/RightCanvas.tsx
+++ b/src/components/RightCanvas.tsx
@@ -16,7 +16,7 @@ import { useJobStore } from "@/store/jobStore";
  *   queued  → the waiting TaskList,
  *   running → OverallProgress pinned to the top of the canvas + the TaskList
  *             (each row keeps its own live progress),
- *   results → the Inline Ledger (per-row Reveal/Copy + status tally header).
+ *   results → the Inline Ledger (per-row Copy + status tally header).
  *
  * After a finished run is cleared, the canvas returns to the drop zone with the
  * residual {@link LastBatchChip} pinned above it (whenever a last batch exists).

--- a/src/lib/reveal.test.ts
+++ b/src/lib/reveal.test.ts
@@ -1,23 +1,18 @@
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import {
-  openPath as openWith,
-  revealItemInDir,
-} from "@tauri-apps/plugin-opener";
+import { openPath as openWith } from "@tauri-apps/plugin-opener";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openPath: vi.fn(),
-  revealItemInDir: vi.fn(),
 }));
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({ writeText: vi.fn() }));
 
 // Import after the mocks are registered.
-import { copyText, openPath, revealItem } from "./reveal";
+import { copyText, openPath } from "./reveal";
 
 describe("reveal client", () => {
   beforeEach(() => {
     vi.mocked(openWith).mockReset();
-    vi.mocked(revealItemInDir).mockReset();
     vi.mocked(writeText).mockReset();
   });
 
@@ -35,25 +30,6 @@ describe("reveal client", () => {
       vi.mocked(openWith).mockRejectedValue(new Error("no such path"));
 
       await expect(openPath("/missing")).rejects.toThrow("no such path");
-    });
-  });
-
-  describe("revealItem", () => {
-    it("reveals the given path via revealItemInDir exactly once", async () => {
-      vi.mocked(revealItemInDir).mockResolvedValue(undefined);
-
-      await revealItem("/out/photo_001.zip");
-
-      expect(vi.mocked(revealItemInDir)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(revealItemInDir)).toHaveBeenCalledWith(
-        "/out/photo_001.zip",
-      );
-    });
-
-    it("propagates a reveal failure rather than swallowing it", async () => {
-      vi.mocked(revealItemInDir).mockRejectedValue(new Error("not found"));
-
-      await expect(revealItem("/missing")).rejects.toThrow("not found");
     });
   });
 

--- a/src/lib/reveal.ts
+++ b/src/lib/reveal.ts
@@ -1,13 +1,11 @@
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import {
-  openPath as openWith,
-  revealItemInDir,
-} from "@tauri-apps/plugin-opener";
+import { openPath as openWith } from "@tauri-apps/plugin-opener";
 
 // Thin wrapper around the Tauri opener + clipboard plugins, mirroring how
 // lib/dialog.ts centralizes the dialog plugin. Keeping every opener/clipboard
 // call here gives the app a single, typed surface (and a single mock point in
-// tests). The Inline Ledger's per-row Reveal/Copy actions go through here.
+// tests). The Inline Ledger's "Open folder" + per-row Copy actions go through
+// here.
 //
 // Each function rejects on a real plugin/IPC failure; callers are responsible
 // for surfacing the error rather than swallowing it.
@@ -17,14 +15,6 @@ import {
  */
 export async function openPath(path: string): Promise<void> {
   await openWith(path);
-}
-
-/**
- * Reveal a file/folder in the OS file explorer (Finder/Explorer) with the item
- * selected, rather than opening it. Used by the Ledger's per-row Reveal action.
- */
-export async function revealItem(path: string): Promise<void> {
-  await revealItemInDir(path);
 }
 
 /**


### PR DESCRIPTION
## Summary

The Inline Ledger's per-row actions were an open-in-explorer Reveal arrow plus a Copy button, and Copy fired silently — nothing told the user the path had actually landed on the clipboard. This drops the Reveal action entirely and makes Copy raise a transient "Path was copied" pill at the pointer that fades on its own, so a successful copy is confirmed right where the click happened.

## Background / Motivation

- Clicking a row's Copy button wrote the output path to the clipboard with zero feedback; on a fast, silent action users had no confirmation it worked.
- The per-row Reveal (open-in-file-explorer arrow) duplicated the header's "Open folder" affordance for reaching the destination directory, so the extra per-row column carried little weight.
- Removing the Reveal button left `revealItem` (the `revealItemInDir` wrapper in `lib/reveal.ts`) used only by its own test — dead production code that `knip`/hygiene would flag.

## Changes

### Drop the per-row Reveal action (`src/components/Ledger.tsx`, `src/lib/reveal.ts`)

- Remove the `ArrowUpRight` Reveal `<Button>` and the `canReveal` (failed-row disable) logic from `LedgerRow`; each row now carries a single Copy action.
- Delete the now-unused `revealItem` wrapper and its `revealItemInDir` import from `lib/reveal.ts`; `openPath` (header "Open folder") and `copyText` stay.
- Tidy the stale `revealItem: vi.fn()` mock keys in `LastBatchChip.test.tsx` and `summary-flow.test.tsx`, and refresh the Reveal/Copy doc comments in `RightCanvas.tsx`.

### "Path was copied" affordance (`src/components/Ledger.tsx`, `src/App.css`)

- The Copy `onClick` captures the pointer's `clientX/clientY` up front (the synthetic event is gone once the async copy resolves), copies, then on success calls `onCopied(x, y)` to raise the hint; a failure still routes through the shared `runOrReportError` error path and shows no hint.
- `Ledger` holds a `copiedHint` state `{ x, y, nonce }` and renders a `position: fixed` pill anchored at those viewport coordinates as a sibling `<output>` (its own polite live region, separate from the run-summary region) so assistive tech announces the copy without disturbing the ledger.
- A `useEffect` auto-dismisses the pill after `COPIED_HINT_MS` (2s); `nonce` changes the state object identity on every copy so a repeat copy re-arms the timer and repositions the pill even when the text is unchanged.
- New CSS keyframe `copied-hint-in` (a short rise + fade) follows the existing `row-settle` pattern and is disabled under `prefers-reduced-motion`.

### Tests

- `Ledger.test.tsx`: replace the Reveal tests with — no Reveal button on any row (each row keeps exactly one Copy action); Copy still copies that row's `outputPath`; Copy works on a failed row; the affordance appears near the pointer (asserts the fixed pill's inline `left`/`top` match the click coordinates); it auto-dismisses after the timeout (fake timers); a copy failure surfaces the error and shows no affordance.
- `reveal.test.ts`: drop the `revealItem` describe block and its `revealItemInDir` mock.
- Each new/changed test was confirmed RED before implementation.

## Verification

- Run a job to the results Ledger: each row shows a single Copy icon button (no arrow/Reveal button). Click Copy — a "Path was copied" pill appears at the cursor for ~2s, then fades; the row's absolute output path is on the clipboard.
- Inspect the pill: a `position: fixed` `<output class="copied-hint ...">` whose inline `left`/`top` equal the click's viewport coordinates; it carries `pointer-events-none` so it never intercepts a follow-up click.
- Copy on a failed row still works (path can be pasted); a clipboard failure shows the shared error banner and no pill.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 516 passed (45 files)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check, matching the lockfile)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings, matching the lockfile)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): click Copy and confirm the pill appears near the cursor and fades after a couple seconds; confirm it respects the OS "Reduce motion" setting (snaps in, no animation)
