### PR TITLE
feat(zip): apply conflict policy to archive output

### DIFF
--- a/crates/core/src/application/ports.rs
+++ b/crates/core/src/application/ports.rs
@@ -36,12 +36,21 @@ pub trait Archiver: Send + Sync {
     /// Compress every regular file under `src_dir` into the zip at `dest_zip`,
     /// reporting cumulative byte progress through `ctx`. Each file is recorded
     /// under its `/`-separated path relative to `src_dir`; empty directories are
-    /// dropped; the output zip is never included in itself. Implementations must
-    /// **not** overwrite an existing `dest_zip`.
+    /// dropped; the output zip is never included in itself.
+    ///
+    /// When `dest_zip` already exists, the collision is resolved by `policy`
+    /// (mirroring [`Placer::place`] for Folder mode):
+    /// - [`ConflictPolicy::AutoRename`]: write a sibling `name (2).zip`,
+    ///   `name (3).zip`, … (the ` (n)` is inserted before the extension), leaving
+    ///   the existing file untouched.
+    /// - [`ConflictPolicy::Skip`]: leave the existing file untouched and write
+    ///   nothing — reported as a successful no-op (`Ok(())`).
+    /// - [`ConflictPolicy::Overwrite`]: remove the existing file, then write.
     fn compress(
         &self,
         src_dir: &Path,
         dest_zip: &Path,
+        policy: ConflictPolicy,
         ctx: &CompressContext,
     ) -> impl Future<Output = Result<(), ArchiveError>> + Send;
 }

--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -236,7 +236,11 @@ async fn run_one<A: Archiver, E: Extractor, P: Placer>(
         OutputMode::Zip => {
             let reporter = Arc::new(ChannelReporter { tx: tx.clone() });
             let ctx = CompressContext::new(item.task, reporter, cancellation_token);
-            map_archive_result(archiver.compress(prepared.dir(), &item.dest, &ctx).await)
+            map_archive_result(
+                archiver
+                    .compress(prepared.dir(), &item.dest, item.policy, &ctx)
+                    .await,
+            )
         }
         OutputMode::Folder => {
             // A folder source has no archive to extract in Folder mode, so there
@@ -359,6 +363,9 @@ mod tests {
         calls: Arc<AtomicUsize>,
         live: Arc<AtomicUsize>,
         max_live: Arc<AtomicUsize>,
+        // Records the conflict policy handed to each `compress` call, so a test
+        // can prove the job's policy threads all the way through to the archiver.
+        seen_policies: Arc<Mutex<Vec<ConflictPolicy>>>,
     }
     impl FakeArchiver {
         fn new() -> Self {
@@ -369,11 +376,16 @@ mod tests {
                 calls: Arc::new(AtomicUsize::new(0)),
                 live: Arc::new(AtomicUsize::new(0)),
                 max_live: Arc::new(AtomicUsize::new(0)),
+                seen_policies: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         fn call_count(&self) -> Arc<AtomicUsize> {
             self.calls.clone()
+        }
+
+        fn seen_policies(&self) -> Arc<Mutex<Vec<ConflictPolicy>>> {
+            self.seen_policies.clone()
         }
     }
     impl Archiver for FakeArchiver {
@@ -381,8 +393,10 @@ mod tests {
             &self,
             _src: &Path,
             dest: &Path,
+            policy: ConflictPolicy,
             ctx: &CompressContext,
         ) -> Result<(), ArchiveError> {
+            self.seen_policies.lock().unwrap().push(policy);
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.live.fetch_add(1, Ordering::SeqCst);
             ctx.report(5, 10);
@@ -527,6 +541,46 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
+    /// A Zip-mode job's conflict policy threads all the way to the archiver:
+    /// every `compress` call receives the job's policy. The Zip path previously
+    /// dropped the policy, so an existing-output collision always failed instead
+    /// of honoring AutoRename/Skip/Overwrite.
+    #[tokio::test]
+    async fn zip_job_threads_conflict_policy_through_to_the_archiver() {
+        let items = vec![
+            SourceItem::RarFile(PathBuf::from("a.rar")),
+            SourceItem::RarFile(PathBuf::from("b.rar")),
+        ];
+        let job = ArchiveJob::plan_with_start(
+            items,
+            NamingRule::parse("f{n}").unwrap(),
+            OutputDirectory::new(PathBuf::from("/out")),
+            1,
+            ConflictPolicy::Overwrite,
+        )
+        .unwrap();
+        let fake = Arc::new(FakeArchiver::new());
+        let seen = fake.seen_policies();
+        let engine = RunArchiveJob::new(
+            fake,
+            Arc::new(FakeExtractor::new()),
+            Arc::new(FakePlacer::new()),
+            nz(2),
+        );
+        let sink = RecordingSink::default();
+        let clock = FixedClock(Instant::now());
+
+        let summary = engine.execute(job, &clock, &sink).await;
+
+        assert_eq!(summary.succeeded.len(), 2, "both tasks compress");
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2, "one compress call per task");
+        assert!(
+            seen.iter().all(|p| *p == ConflictPolicy::Overwrite),
+            "every compress call must receive the job's policy, got {seen:?}"
+        );
+    }
+
     #[tokio::test]
     async fn rar_task_cancelled_before_start_emits_cancel_and_does_not_extract() {
         let job = ArchiveJob::plan(
@@ -656,6 +710,7 @@ mod tests {
             &self,
             _src: &Path,
             dest: &Path,
+            _policy: ConflictPolicy,
             ctx: &CompressContext,
         ) -> Result<(), ArchiveError> {
             let name = dest.file_name().unwrap().to_string_lossy().to_string();

--- a/crates/core/src/domain/archive_job.rs
+++ b/crates/core/src/domain/archive_job.rs
@@ -143,10 +143,11 @@ pub struct ArchiveJob {
 }
 
 impl ArchiveJob {
-    /// Plan a new job numbering items from 1.
+    /// Plan a new job numbering items from 1, using the default
+    /// [`ConflictPolicy::AutoRename`].
     ///
-    /// Equivalent to [`plan_with_start`] with `start = 1`: item at index `i` gets
-    /// `TaskId(i + 1)` and output name `rule.resolve(i + 1)`.
+    /// Equivalent to [`plan_with_start`] with `start = 1` and the default policy:
+    /// item at index `i` gets `TaskId(i + 1)` and output name `rule.resolve(i + 1)`.
     ///
     /// [`plan_with_start`]: ArchiveJob::plan_with_start
     pub fn plan(
@@ -154,7 +155,7 @@ impl ArchiveJob {
         rule: NamingRule,
         out_dir: OutputDirectory,
     ) -> Result<Self, PlanError> {
-        Self::plan_with_start(items, rule, out_dir, 1)
+        Self::plan_with_start(items, rule, out_dir, 1, ConflictPolicy::default())
     }
 
     /// Plan a new job numbering items from `start`, deriving each task's output
@@ -164,6 +165,10 @@ impl ArchiveJob {
     /// 1-based `TaskId(i + 1)` as its stable identity (independent of `start`).
     /// The `SequenceNumber` is a transient argument to name resolution — it is
     /// derived from position and is NOT stored on the task. `start` may be `0`.
+    ///
+    /// `policy` is the [`ConflictPolicy`] applied when an output zip already
+    /// exists at run time (Zip mode resolves collisions through the archiver,
+    /// symmetrically to how Folder mode resolves them through the placer).
     ///
     /// Returns [`PlanError::Empty`] when `items` is empty,
     /// [`PlanError::SequenceOverflow`] when the numbering range
@@ -176,6 +181,7 @@ impl ArchiveJob {
         rule: NamingRule,
         out_dir: OutputDirectory,
         start: u32,
+        policy: ConflictPolicy,
     ) -> Result<Self, PlanError> {
         if items.is_empty() {
             return Err(PlanError::Empty);
@@ -221,8 +227,8 @@ impl ArchiveJob {
             rule,
             out_dir,
             mode: OutputMode::Zip,
-            // Zip mode never collides via the placer; default to the safe policy.
-            policy: ConflictPolicy::default(),
+            // Zip mode resolves collisions through the archiver at run time.
+            policy,
         })
     }
 
@@ -471,6 +477,12 @@ mod tests {
             .collect()
     }
 
+    /// The default conflict policy, for `plan_with_start` call sites whose
+    /// assertions are independent of the policy.
+    fn policy() -> ConflictPolicy {
+        ConflictPolicy::default()
+    }
+
     /// Build an `OutputFileName` from a plain stem (test convenience).
     fn name(stem: &str) -> OutputFileName {
         OutputFileName::from_stem(FileStem::new(stem).unwrap())
@@ -525,7 +537,8 @@ mod tests {
 
     #[test]
     fn plan_with_start_numbers_names_from_start_but_keeps_one_based_ids() {
-        let job = ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 5).unwrap();
+        let job = ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 5, policy())
+            .unwrap();
         assert_eq!(
             id_name_pairs(&job),
             vec![
@@ -538,7 +551,8 @@ mod tests {
 
     #[test]
     fn plan_with_start_allows_zero() {
-        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 0).unwrap();
+        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 0, policy())
+            .unwrap();
         assert_eq!(
             id_name_pairs(&job),
             vec![
@@ -552,7 +566,8 @@ mod tests {
     #[test]
     fn plan_with_start_grows_digits_past_the_pad_width() {
         // printf semantics: {n:02} is a minimum width, so 100 renders as "100".
-        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 99).unwrap();
+        let job = ArchiveJob::plan_with_start(sources(3), rule("{n:02}"), out_dir(), 99, policy())
+            .unwrap();
         assert_eq!(
             id_name_pairs(&job),
             vec![
@@ -566,7 +581,8 @@ mod tests {
     #[test]
     fn plan_with_start_rejects_u32_overflow() {
         // Numbering 2 items from u32::MAX would need u32::MAX + 1.
-        let result = ArchiveJob::plan_with_start(sources(2), rule("file{n}"), out_dir(), u32::MAX);
+        let result =
+            ArchiveJob::plan_with_start(sources(2), rule("file{n}"), out_dir(), u32::MAX, policy());
         assert_eq!(
             result,
             Err(PlanError::SequenceOverflow {
@@ -580,8 +596,31 @@ mod tests {
     fn plan_numbers_from_one_by_default() {
         let default = ArchiveJob::plan(sources(3), rule("file{n}"), out_dir()).unwrap();
         let explicit =
-            ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 1).unwrap();
+            ArchiveJob::plan_with_start(sources(3), rule("file{n}"), out_dir(), 1, policy())
+                .unwrap();
         assert_eq!(id_name_pairs(&default), id_name_pairs(&explicit));
+    }
+
+    #[test]
+    fn plan_defaults_zip_conflict_policy_to_auto_rename() {
+        let job = ArchiveJob::plan(sources(1), rule("file{n}"), out_dir()).unwrap();
+        assert_eq!(job.conflict_policy(), ConflictPolicy::AutoRename);
+    }
+
+    #[test]
+    fn plan_with_start_stores_the_given_conflict_policy() {
+        // A Zip-mode job must carry the caller's chosen policy (not a hardcoded
+        // default), so the engine can resolve output collisions accordingly.
+        let job = ArchiveJob::plan_with_start(
+            sources(1),
+            rule("file{n}"),
+            out_dir(),
+            1,
+            ConflictPolicy::Overwrite,
+        )
+        .unwrap();
+        assert_eq!(job.output_mode(), OutputMode::Zip);
+        assert_eq!(job.conflict_policy(), ConflictPolicy::Overwrite);
     }
 
     // ── plan: empty ───────────────────────────────────────────────────────────

--- a/crates/core/src/domain/conflict_policy.rs
+++ b/crates/core/src/domain/conflict_policy.rs
@@ -1,14 +1,15 @@
-//! How a Folder-mode extraction resolves a name collision at the destination.
+//! How an output collision is resolved at the destination, for both Zip-mode
+//! (`Destination/<name>.zip`) and Folder-mode (`Destination/<name>/`) runs.
 
-/// What to do when `Destination/<name>/` already exists.
+/// What to do when the destination output already exists.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ConflictPolicy {
     /// Write to `name (2)`, `name (3)`, … — never destroy existing data (default).
     #[default]
     AutoRename,
-    /// Leave the existing folder; do not extract this item.
+    /// Leave the existing output; do not write this item.
     Skip,
-    /// Remove the existing folder, then extract.
+    /// Remove the existing output, then write.
     Overwrite,
 }
 

--- a/crates/core/src/infrastructure/zip_archiver.rs
+++ b/crates/core/src/infrastructure/zip_archiver.rs
@@ -2,6 +2,7 @@
 
 use crate::application::compress_context::CompressContext;
 use crate::application::ports::{ArchiveError, Archiver};
+use crate::domain::conflict_policy::ConflictPolicy;
 use crate::infrastructure::path_utils::{classified_components, PathPart};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
@@ -28,6 +29,7 @@ impl Archiver for ZipArchiver {
         &self,
         src_dir: &Path,
         dest_zip: &Path,
+        policy: ConflictPolicy,
         ctx: &CompressContext,
     ) -> Result<(), ArchiveError> {
         // Collect the file list from the walk BEFORE creating the output file.
@@ -48,19 +50,30 @@ impl Archiver for ZipArchiver {
             return Err(ArchiveError::Cancelled);
         }
 
-        // Refuse to overwrite an existing destination: a collision fails the task
-        // (AlreadyExists surfaces as ArchiveError::Io) rather than clobbering it.
+        // Resolve the output path according to the conflict policy, symmetric to
+        // `FsPlacer` for Folder mode. `Skip` short-circuits with no write when the
+        // destination already exists; `Overwrite` has removed the old file here;
+        // `AutoRename` has chosen a free `name (n).zip`. Resolved after the cancel
+        // checkpoint so a cancelled `Overwrite` never deletes the existing file.
+        let dest = match resolve_destination(dest_zip, policy).await? {
+            Some(path) => path,
+            None => return Ok(()),
+        };
+
+        // `create_new` still guarantees we never clobber: the policy resolution
+        // above has already freed the path (renamed or removed), so the only
+        // collision left is a concurrent writer, which should fail the task.
         let file = tokio::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(dest_zip)
+            .open(&dest)
             .await?;
         let mut writer = ZipFileWriter::with_tokio(file);
 
         let mut bytes_done: u64 = 0;
         for path in &files {
             if ctx.is_cancelled() {
-                close_and_remove(writer, dest_zip).await;
+                close_and_remove(writer, &dest).await;
                 return Err(ArchiveError::Cancelled);
             }
 
@@ -75,7 +88,7 @@ impl Archiver for ZipArchiver {
             ctx.report(bytes_done, bytes_total);
 
             if ctx.is_cancelled() {
-                close_and_remove(writer, dest_zip).await;
+                close_and_remove(writer, &dest).await;
                 return Err(ArchiveError::Cancelled);
             }
         }
@@ -152,6 +165,73 @@ async fn remove_partial_output(dest_zip: &Path) {
         // future logging-infrastructure PR (no logging crate is wired up yet).
         Err(_) => {}
     }
+}
+
+/// Resolve `dest_zip` into the path to actually write, applying `policy`:
+///
+/// - [`ConflictPolicy::AutoRename`]: never clobber — return the first free
+///   `name (2).zip`, `name (3).zip`, … (or `dest_zip` itself if free).
+/// - [`ConflictPolicy::Skip`]: return `None` (a successful no-op) when `dest_zip`
+///   already exists, leaving it untouched; otherwise write at `dest_zip`.
+/// - [`ConflictPolicy::Overwrite`]: remove an existing `dest_zip`, then write at
+///   the same path. A missing file is not an error.
+///
+/// Mirrors `FsPlacer`'s collision handling for Folder mode. Returns `Some(path)`
+/// to write at `path`, or `None` to skip writing entirely.
+async fn resolve_destination(
+    dest_zip: &Path,
+    policy: ConflictPolicy,
+) -> Result<Option<PathBuf>, ArchiveError> {
+    match policy {
+        ConflictPolicy::AutoRename => Ok(Some(non_colliding_zip(dest_zip))),
+        ConflictPolicy::Skip => {
+            if dest_zip.exists() {
+                Ok(None)
+            } else {
+                Ok(Some(dest_zip.to_path_buf()))
+            }
+        }
+        ConflictPolicy::Overwrite => {
+            match tokio::fs::remove_file(dest_zip).await {
+                Ok(()) => {}
+                // Nothing to overwrite — proceed to write at the desired path.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(ArchiveError::Io(e)),
+            }
+            Ok(Some(dest_zip.to_path_buf()))
+        }
+    }
+}
+
+/// Return `desired` if free, else `stem (2).ext`, `stem (3).ext`, … inserting the
+/// ` (n)` BEFORE the extension so the `.zip` suffix is preserved (e.g.
+/// `photo_01.zip` → `photo_01 (2).zip`). The Folder placer appends ` (n)` to the
+/// whole final component; a file keeps its extension, so the suffix goes before it.
+fn non_colliding_zip(desired: &Path) -> PathBuf {
+    if !desired.exists() {
+        return desired.to_path_buf();
+    }
+    let parent = desired.parent().unwrap_or_else(|| Path::new("."));
+    let stem = desired
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "archive".to_string());
+    let ext = desired
+        .extension()
+        .map(|e| e.to_string_lossy().into_owned());
+    // Counter starts at 2 so the first alternative reads "stem (2).ext".
+    for n in 2..=u32::MAX {
+        let file_name = match &ext {
+            Some(ext) => format!("{stem} ({n}).{ext}"),
+            None => format!("{stem} ({n})"),
+        };
+        let candidate = parent.join(file_name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    // Astronomically unreachable; fall back to the desired path.
+    desired.to_path_buf()
 }
 
 /// Walk `root` and return the paths of every regular file it contains.
@@ -255,7 +335,7 @@ mod tests {
         let capture = Arc::new(Capture(Mutex::new(Vec::new())));
         let ctx = CompressContext::new(TaskId::new(1), capture.clone(), CancellationToken::new());
         ZipArchiver::new()
-            .compress(src.path(), &dest, &ctx)
+            .compress(src.path(), &dest, ConflictPolicy::AutoRename, &ctx)
             .await
             .unwrap();
 
@@ -272,22 +352,124 @@ mod tests {
         assert_eq!(reports.last().unwrap().bytes_done(), total, "ends at total");
     }
 
+    /// Read and sort every entry name in a zip archive, draining each entry so a
+    /// truncated/corrupt body surfaces as a panic. Proves a real archive (not
+    /// arbitrary bytes) was written at `path`.
+    fn zip_entry_names(path: &Path) -> Vec<String> {
+        use std::io::Read as _;
+        let file = std::fs::File::open(path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut names = Vec::new();
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).unwrap();
+            let mut body = Vec::new();
+            entry.read_to_end(&mut body).unwrap();
+            names.push(entry.name().to_string());
+        }
+        names.sort();
+        names
+    }
+
     #[tokio::test]
-    async fn refuses_to_overwrite_existing_output() {
+    async fn auto_rename_writes_a_sibling_and_leaves_the_existing_zip_untouched() {
+        // AutoRename must never clobber: an existing o.zip is left byte-for-byte
+        // intact and the new archive lands in the extension-aware sibling
+        // "o (2).zip" (the ` (2)` is inserted before the .zip extension).
         let src = tempfile::tempdir().unwrap();
         std::fs::write(src.path().join("a.txt"), b"hi").unwrap();
         let out = tempfile::tempdir().unwrap();
         let dest = out.path().join("o.zip");
         std::fs::write(&dest, b"pre-existing").unwrap();
 
-        let err = ZipArchiver::new()
-            .compress(src.path(), &dest, &CompressContext::detached())
+        ZipArchiver::new()
+            .compress(
+                src.path(),
+                &dest,
+                ConflictPolicy::AutoRename,
+                &CompressContext::detached(),
+            )
             .await
-            .unwrap_err();
-        assert!(
-            matches!(err, ArchiveError::Io(_)),
-            "expected Io(AlreadyExists), got {err:?}"
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            b"pre-existing",
+            "the pre-existing zip must be left untouched"
         );
+        let sibling = out.path().join("o (2).zip");
+        assert!(sibling.exists(), "auto-rename must write o (2).zip");
+        assert_eq!(zip_entry_names(&sibling), vec!["a.txt".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn auto_rename_without_a_collision_writes_the_desired_name() {
+        // With no existing output, AutoRename writes the desired path unchanged
+        // (and creates no sibling) — i.e. the default policy is a no-op here.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"hi").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let dest = out.path().join("o.zip");
+
+        ZipArchiver::new()
+            .compress(
+                src.path(),
+                &dest,
+                ConflictPolicy::AutoRename,
+                &CompressContext::detached(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(zip_entry_names(&dest), vec!["a.txt".to_string()]);
+        assert!(!out.path().join("o (2).zip").exists());
+    }
+
+    #[tokio::test]
+    async fn skip_leaves_the_existing_zip_untouched_and_writes_no_sibling() {
+        // Skip is a successful no-op when the destination exists: the existing
+        // file is untouched and no auto-rename sibling is created.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"hi").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let dest = out.path().join("o.zip");
+        std::fs::write(&dest, b"pre-existing").unwrap();
+
+        ZipArchiver::new()
+            .compress(
+                src.path(),
+                &dest,
+                ConflictPolicy::Skip,
+                &CompressContext::detached(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"pre-existing");
+        assert!(!out.path().join("o (2).zip").exists());
+    }
+
+    #[tokio::test]
+    async fn overwrite_replaces_the_existing_zip_in_place() {
+        // Overwrite removes the existing file then writes the archive at the same
+        // path — the original bytes are gone and no sibling is created.
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"hi").unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let dest = out.path().join("o.zip");
+        std::fs::write(&dest, b"pre-existing").unwrap();
+
+        ZipArchiver::new()
+            .compress(
+                src.path(),
+                &dest,
+                ConflictPolicy::Overwrite,
+                &CompressContext::detached(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(zip_entry_names(&dest), vec!["a.txt".to_string()]);
+        assert!(!out.path().join("o (2).zip").exists());
     }
 
     #[tokio::test]
@@ -306,7 +488,7 @@ mod tests {
         let ctx = CompressContext::new(TaskId::new(1), reporter.clone(), token);
 
         let err = ZipArchiver::new()
-            .compress(src.path(), &dest, &ctx)
+            .compress(src.path(), &dest, ConflictPolicy::AutoRename, &ctx)
             .await
             .unwrap_err();
         assert!(matches!(err, ArchiveError::Cancelled), "got {err:?}");
@@ -335,7 +517,7 @@ mod tests {
         let ctx = CompressContext::new(TaskId::new(1), reporter.clone(), token);
 
         let err = ZipArchiver::new()
-            .compress(src.path(), &dest, &ctx)
+            .compress(src.path(), &dest, ConflictPolicy::AutoRename, &ctx)
             .await
             .unwrap_err();
         assert!(matches!(err, ArchiveError::Cancelled), "got {err:?}");

--- a/crates/core/tests/zip_archiver_smoke.rs
+++ b/crates/core/tests/zip_archiver_smoke.rs
@@ -7,6 +7,7 @@
 
 use simple_archiver_core::application::compress_context::CompressContext;
 use simple_archiver_core::application::ports::Archiver;
+use simple_archiver_core::domain::conflict_policy::ConflictPolicy;
 use simple_archiver_core::infrastructure::zip_archiver::ZipArchiver;
 use std::collections::BTreeMap;
 use std::io::Read;
@@ -45,7 +46,12 @@ async fn compress_folder_produces_a_readable_zip() {
     let out_path = out_dir.path().join("out.zip");
 
     ZipArchiver::new()
-        .compress(src.path(), &out_path, &CompressContext::detached())
+        .compress(
+            src.path(),
+            &out_path,
+            ConflictPolicy::AutoRename,
+            &CompressContext::detached(),
+        )
         .await
         .unwrap();
 
@@ -62,7 +68,12 @@ async fn output_inside_source_is_not_self_included() {
     let out_path = src.path().join("out.zip");
 
     ZipArchiver::new()
-        .compress(src.path(), &out_path, &CompressContext::detached())
+        .compress(
+            src.path(),
+            &out_path,
+            ConflictPolicy::AutoRename,
+            &CompressContext::detached(),
+        )
         .await
         .unwrap();
 

--- a/src-tauri/src/presentation/state.rs
+++ b/src-tauri/src/presentation/state.rs
@@ -183,7 +183,7 @@ impl JobDraft {
     /// Branches on [`output_mode`]:
     /// - [`OutputMode::Zip`]: requires both a naming template and an output
     ///   directory, then calls [`ArchiveJob::plan_with_start`] with the draft's
-    ///   start number.
+    ///   start number and conflict policy.
     /// - [`OutputMode::Folder`]: requires only an output directory (no template),
     ///   then calls [`ArchiveJob::plan_extract`].
     ///
@@ -205,12 +205,14 @@ impl JobDraft {
                     .ok_or_else(|| "naming rule not set".to_string())?;
                 // Reuse the rule parsed in `set_template`; the template is
                 // never re-parsed here. Numbering starts at the draft's
-                // start_number (default 1).
+                // start_number (default 1). The conflict policy is threaded in so
+                // Zip output resolves collisions just like Folder mode does.
                 ArchiveJob::plan_with_start(
                     self.items.clone(),
                     template.rule.clone(),
                     OutputDirectory::new(out_dir.clone()),
                     self.start_number,
+                    self.conflict_policy,
                 )
                 .map_err(|e| e.to_string())
             }
@@ -758,6 +760,27 @@ mod tests {
         draft.set_conflict_policy(ConflictPolicy::Overwrite);
         let job = draft.build().expect("folder draft should build");
         assert_eq!(job.conflict_policy(), ConflictPolicy::Overwrite);
+    }
+
+    /// In Zip mode the chosen conflict policy also threads into the planned job,
+    /// so the archiver can resolve an existing-output collision (it previously
+    /// hardcoded AutoRename and ignored the user's choice).
+    #[test]
+    fn set_conflict_policy_threads_into_zip_job() {
+        let mut draft = JobDraft::new(); // defaults to Zip mode
+        draft.add_items(vec![SourceItem::ZipFile(PathBuf::from("/in/a.zip"))]);
+        draft.set_template("file{n}".to_string()).unwrap();
+        draft.set_out_dir(PathBuf::from("/out"));
+
+        // Default is AutoRename.
+        let job = draft.build().expect("zip draft should build");
+        assert_eq!(job.output_mode(), OutputMode::Zip);
+        assert_eq!(job.conflict_policy(), ConflictPolicy::AutoRename);
+
+        // Setting Skip carries through to the built Zip job.
+        draft.set_conflict_policy(ConflictPolicy::Skip);
+        let job = draft.build().expect("zip draft should build");
+        assert_eq!(job.conflict_policy(), ConflictPolicy::Skip);
     }
 
     // ── RunState ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The OUTPUT "If exists" policy (Auto-rename / Skip / Overwrite) only took effect in `Folder` mode. In `.zip file` mode the archiver ignored it and every collision with an existing output failed with `I/O error: File exists (os error 17)`, so a re-run into a destination that already held the target names left every row Failed. This threads the chosen policy through to the zip archiver and implements all three behaviors there, so `.zip file` output now auto-renames, skips, or overwrites just like `Folder` mode.

## Background / Motivation

- `ZipArchiver::compress` opened the destination with `create_new(true)`, and the run engine never passed the draft's `ConflictPolicy` on the Zip branch, so an existing-output collision always surfaced as `File exists (os error 17)` and Failed the task — regardless of the selected Auto-rename / Skip / Overwrite.
- `ArchiveJob::plan_with_start` hardcoded the Zip-mode policy to `ConflictPolicy::default()`, discarding the user's choice; the `Placer`-backed `Folder` path already honored it via `plan_extract`.
- The two output modes were asymmetric: `Folder` collisions were resolved by the `Placer` port (`FsPlacer`), but the `Archiver` port carried no policy parameter at all.

## Changes

### Carry the policy to the Zip path (`ports.rs`, `run_archive_job.rs`, `archive_job.rs`)

- Add a `ConflictPolicy` parameter to the `Archiver::compress` port, symmetric to `Placer::place`; the doc now spells out the three collision behaviors.
- `run_archive_job` passes each `WorkItem`'s `policy` into `archiver.compress(...)` — the Zip branch previously dropped it.
- `ArchiveJob::plan_with_start` takes and stores the `policy`; `plan` keeps the `ConflictPolicy::default()` (AutoRename) convenience, so the ~40 existing `plan` call sites are unchanged.

### Three policies in `ZipArchiver::compress` (`zip_archiver.rs`)

- New `resolve_destination` resolves the output path per policy, run *after* the cancel checkpoint so a cancelled Overwrite never deletes the existing file:
  - **Auto-rename**: `non_colliding_zip` returns the first free `name (2).zip`, `name (3).zip`, … inserting ` (n)` *before* the `.zip` extension (a file keeps its extension, unlike the placer's whole-component suffix).
  - **Skip**: returns `None` when the destination exists, so `compress` is a successful no-op that leaves the file untouched.
  - **Overwrite**: removes the existing file (a missing file is not an error), then writes at the same path.
- The actual open keeps `create_new(true)`, so an unexpected concurrent collision still fails the task instead of clobbering.

### Thread the draft's policy in the presentation layer (`state.rs`)

- `JobDraft::build()`'s Zip branch passes `self.conflict_policy` into `plan_with_start`, so the chosen policy reaches the engine (the Folder branch already did this via `plan_extract`).

### Tests

- `zip_archiver`: Auto-rename writes `o (2).zip` and leaves the original byte-for-byte; Auto-rename with no collision writes the desired name; Skip leaves the existing file untouched with no sibling; Overwrite replaces in place. A `zip` reader proves a real archive (not arbitrary bytes) was written. Each new case was confirmed RED (the same `File exists (os error 17)`) before the fix.
- `archive_job`: `plan_with_start` stores the chosen policy; `plan` defaults to AutoRename.
- `run_archive_job`: a Zip job threads its policy through to every `compress` call.
- `state`: a Zip-mode draft threads the policy into the planned job.

## Verification

- Reproduce pre-fix: in `.zip file` mode, run into a folder that already holds the target names — every row Fails with `I/O error: File exists (os error 17)`. After this change, Auto-rename writes `… (2).zip` siblings (originals untouched), Skip leaves the existing files and reports success, and Overwrite replaces them.
- Backend only — no DTO / ts-rs change, so no `src/bindings/*.ts` regeneration and the frontend is unaffected.

## Test plan

- [x] `cargo nextest run` — 340/340 pass
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --all --check` — clean
- [x] loom: `RUSTFLAGS="--cfg loom" cargo clippy/nextest -p simple-archiver-core --features loom` — clean, 172/172 pass
- [ ] Manual (packaged app): in `.zip file` mode, drop archives whose target names already exist in the destination and confirm Auto-rename / Skip / Overwrite each behave as labeled
