### PR TITLE
fix(ledger): align run-summary row numbers with header inset

### DIFF
--- a/src/components/Ledger.test.tsx
+++ b/src/components/Ledger.test.tsx
@@ -130,6 +130,22 @@ describe("Ledger", () => {
     expect(screen.getByText("out_3.zip")).toBeTruthy();
   });
 
+  it("insets the sequence-number cell so the row numbers align with the sticky header", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+      summary: MIXED_SUMMARY,
+    });
+    render(<Ledger />);
+
+    // The sticky header insets its status tally by px-4; without a matching left
+    // pad on the first body cell the row numbers hug the card's left border and
+    // fall out of alignment with the header. The number cell must carry pl-4 so
+    // the two left edges line up.
+    const firstRow = screen.getAllByRole("row")[0];
+    const numberCell = within(firstRow).getAllByRole("cell")[0];
+    expect(numberCell.className).toContain("pl-4");
+  });
+
   it("shows the failure reason inline on a failed row", () => {
     useJobStore.setState({
       draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),

--- a/src/components/Ledger.tsx
+++ b/src/components/Ledger.tsx
@@ -68,8 +68,11 @@ function LedgerRow({ index, result, source, size, onCopied }: LedgerRowProps) {
 
   return (
     <tr className="border-b border-border/50 hover:bg-muted/30 transition-colors">
-      {/* Sequence number */}
-      <td className="py-2 pr-3 font-mono text-muted-foreground">{index + 1}</td>
+      {/* Sequence number. pl-4 matches the sticky header's px-4 inset so the row
+          numbers line up with the status tally instead of hugging the card edge. */}
+      <td className="py-2 pl-4 pr-3 font-mono text-muted-foreground">
+        {index + 1}
+      </td>
 
       {/* source → output name */}
       <td className="py-2 pr-3 font-mono text-foreground">


### PR DESCRIPTION
## Summary

The run-summary (Inline Ledger) sequence-number column had no left padding, so the row numbers hugged the card's left border while the sticky header inset its status tally by `px-4`. This adds a matching `pl-4` to the number cell so the row numbers line up with the header instead of sitting flush against the edge.

## Background / Motivation

- The Ledger's sticky header pads its content with `px-4` (16px), but the body `<table>` rows carried no horizontal inset, so the first cell's `{index + 1}` rendered flush against the card's left border.
- The result was a visible left-edge misalignment: the row numbers (1, 2, …) did not line up with the "Succeeded / Cancelled / Failed" tally directly above them.

## Changes

### Inset the sequence-number cell (`src/components/Ledger.tsx`)

- Add `pl-4` to the `LedgerRow` sequence-number `<td>` so its left edge matches the sticky header's `px-4` inset; the existing `py-2 pr-3 font-mono text-muted-foreground` styling is unchanged.

### Tests (`src/components/Ledger.test.tsx`)

- New test asserts the first body cell of a Ledger row carries `pl-4`, locking in the alignment with the header inset. Confirmed RED before the fix.

## Verification

- Run a job to the results Ledger: the row numbers (1, 2, …) now align with the left edge of the status tally in the sticky header instead of hugging the card border. Look for `class="... pl-4 ..."` on the first `<td>` of each Ledger `<tr>`.
- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.

## Test plan

- [x] `pnpm test` — 519 passed (45 files)
- [x] `pnpm fmt:check` (oxfmt 0.55.0 --check, matching the lockfile)
- [x] `pnpm lint:ci` (oxlint 1.70.0 --deny-warnings, matching the lockfile)
- [x] `pnpm build` (tsc && vite build)
- [x] `pnpm knip`
- [ ] Manual (packaged app): finish a job and confirm the Ledger row numbers line up with the header's status tally.
