### PR TITLE
refactor(infra): extract shared next_free_path collision helper

### DIFF
--- a/crates/core/src/infrastructure/fs_placer.rs
+++ b/crates/core/src/infrastructure/fs_placer.rs
@@ -5,6 +5,7 @@
 
 use crate::application::ports::{PlaceError, Placer};
 use crate::domain::conflict_policy::ConflictPolicy;
+use crate::infrastructure::path_utils::next_free_path;
 use std::path::{Path, PathBuf};
 
 /// Copies extracted trees into the output directory without overwriting.
@@ -71,23 +72,13 @@ fn place_blocking(
 /// Return `desired` if it does not exist, else `desired (2)`, `desired (3)`, …
 /// on the final component until a free path is found.
 fn non_colliding(desired: &Path) -> PathBuf {
-    if !desired.exists() {
-        return desired.to_path_buf();
-    }
     let parent = desired.parent().unwrap_or_else(|| Path::new("."));
     let base = desired
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "archive".to_string());
-    // Counter starts at 2 so the first alternative reads "name (2)".
-    for n in 2..=u32::MAX {
-        let candidate = parent.join(format!("{base} ({n})"));
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    // Astronomically unreachable; fall back to the desired path.
-    desired.to_path_buf()
+    // Folder mode: append ` (n)` to the whole final component.
+    next_free_path(desired, |n| parent.join(format!("{base} ({n})")))
 }
 
 /// Recursively copy the directory tree at `src` into a fresh directory `dest`.

--- a/crates/core/src/infrastructure/path_utils.rs
+++ b/crates/core/src/infrastructure/path_utils.rs
@@ -8,7 +8,7 @@
 //! iteration primitive; each caller keeps its own policy.
 
 use std::ffi::OsStr;
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 
 /// Classification of a single path `Component` into the buckets the zip adapters
 /// care about. The borrowed `OsStr` in `Normal` ties the lifetime to the path.
@@ -42,6 +42,32 @@ pub(crate) fn classify(component: Component<'_>) -> PathPart<'_> {
 /// through [`classify`]. Callers decide what to do with each `PathPart`.
 pub(crate) fn classified_components(path: &Path) -> impl Iterator<Item = PathPart<'_>> {
     path.components().map(classify)
+}
+
+/// Return `desired` unchanged when it is free, otherwise the first candidate
+/// produced by `candidate(n)` (starting at `n = 2`) whose path does not yet
+/// exist. The counter starts at 2 so the first alternative reads "… (2)".
+///
+/// `candidate` lets each caller decide HOW to fold the counter into the name
+/// (the Folder placer appends ` (n)` to the whole final component; the Zip
+/// archiver inserts ` (n)` before the file extension), while this helper owns
+/// the shared loop, the `u32::MAX` bound, and the unreachable fallback.
+///
+/// This is a pure path-string helper: the only IO is the same `Path::exists()`
+/// probe the two adapters already performed.
+pub(crate) fn next_free_path(desired: &Path, candidate: impl Fn(u32) -> PathBuf) -> PathBuf {
+    if !desired.exists() {
+        return desired.to_path_buf();
+    }
+    // Counter starts at 2 so the first alternative reads "… (2)".
+    for n in 2..=u32::MAX {
+        let path = candidate(n);
+        if !path.exists() {
+            return path;
+        }
+    }
+    // Astronomically unreachable; fall back to the desired path.
+    desired.to_path_buf()
 }
 
 #[cfg(test)]
@@ -85,5 +111,60 @@ mod tests {
                 PathPart::Normal(OsStr::new("file.txt")),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod next_free_path_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Build the n-th Folder-mode candidate: append ` (n)` to the whole final
+    /// component (mirrors `FsPlacer`).
+    fn append_to_name(parent: &Path, base: &str, n: u32) -> PathBuf {
+        parent.join(format!("{base} ({n})"))
+    }
+
+    /// Build the n-th Zip-mode candidate: insert ` (n)` before the extension
+    /// (mirrors `ZipArchiver`).
+    fn before_extension(parent: &Path, stem: &str, ext: &str, n: u32) -> PathBuf {
+        parent.join(format!("{stem} ({n}).{ext}"))
+    }
+
+    #[test]
+    fn returns_desired_unchanged_when_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let desired = dir.path().join("foo");
+        let got = next_free_path(&desired, |n| append_to_name(dir.path(), "foo", n));
+        assert_eq!(got, desired);
+    }
+
+    #[test]
+    fn append_to_name_picks_first_free_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let desired = dir.path().join("foo");
+        std::fs::create_dir(&desired).unwrap();
+        let got = next_free_path(&desired, |n| append_to_name(dir.path(), "foo", n));
+        assert_eq!(got, dir.path().join("foo (2)"));
+    }
+
+    #[test]
+    fn before_extension_preserves_the_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let desired = dir.path().join("o.zip");
+        std::fs::write(&desired, b"x").unwrap();
+        let got = next_free_path(&desired, |n| before_extension(dir.path(), "o", "zip", n));
+        assert_eq!(got, dir.path().join("o (2).zip"));
+    }
+
+    #[test]
+    fn advances_past_multiple_collisions() {
+        // Both `foo` and `foo (2)` already exist, so the counter must reach 3.
+        let dir = tempfile::tempdir().unwrap();
+        let desired = dir.path().join("foo");
+        std::fs::create_dir(&desired).unwrap();
+        std::fs::create_dir(dir.path().join("foo (2)")).unwrap();
+        let got = next_free_path(&desired, |n| append_to_name(dir.path(), "foo", n));
+        assert_eq!(got, dir.path().join("foo (3)"));
     }
 }

--- a/crates/core/src/infrastructure/zip_archiver.rs
+++ b/crates/core/src/infrastructure/zip_archiver.rs
@@ -3,7 +3,7 @@
 use crate::application::compress_context::CompressContext;
 use crate::application::ports::{ArchiveError, Archiver};
 use crate::domain::conflict_policy::ConflictPolicy;
-use crate::infrastructure::path_utils::{classified_components, PathPart};
+use crate::infrastructure::path_utils::{classified_components, next_free_path, PathPart};
 use async_zip::base::write::ZipFileWriter;
 use async_zip::{Compression, ZipEntryBuilder};
 use std::path::{Path, PathBuf};
@@ -208,9 +208,6 @@ async fn resolve_destination(
 /// `photo_01.zip` → `photo_01 (2).zip`). The Folder placer appends ` (n)` to the
 /// whole final component; a file keeps its extension, so the suffix goes before it.
 fn non_colliding_zip(desired: &Path) -> PathBuf {
-    if !desired.exists() {
-        return desired.to_path_buf();
-    }
     let parent = desired.parent().unwrap_or_else(|| Path::new("."));
     let stem = desired
         .file_stem()
@@ -219,19 +216,14 @@ fn non_colliding_zip(desired: &Path) -> PathBuf {
     let ext = desired
         .extension()
         .map(|e| e.to_string_lossy().into_owned());
-    // Counter starts at 2 so the first alternative reads "stem (2).ext".
-    for n in 2..=u32::MAX {
+    // Zip mode: insert ` (n)` before the extension so the suffix is preserved.
+    next_free_path(desired, |n| {
         let file_name = match &ext {
             Some(ext) => format!("{stem} ({n}).{ext}"),
             None => format!("{stem} ({n})"),
         };
-        let candidate = parent.join(file_name);
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    // Astronomically unreachable; fall back to the desired path.
-    desired.to_path_buf()
+        parent.join(file_name)
+    })
 }
 
 /// Walk `root` and return the paths of every regular file it contains.


### PR DESCRIPTION
## Summary

The "append ` (2)`, ` (3)`, … until a free path is found" collision-avoidance loop was duplicated in two infrastructure adapters — `FsPlacer::non_colliding` (Folder mode) and `ZipArchiver::non_colliding_zip` (Zip mode) — differing only in WHERE the counter is folded into the name. This extracts a single shared `next_free_path` helper in `path_utils.rs` that both adapters call, so a future tweak to the numbering scheme can no longer land in one copy and silently diverge the Zip-mode vs. Folder-mode collision names. Behavior-preserving: same starting counter, same format, same existence check, same fallback.

Closes #153

## Background / Motivation

- Both `FsPlacer::non_colliding` and `ZipArchiver::non_colliding_zip` carried their own `for n in 2..=u32::MAX` loop, `u32::MAX` upper bound, `Path::exists()` probe, unreachable fallback, and near-identical comments — the only real difference was Folder mode appending ` (n)` to the whole final component vs. Zip mode inserting ` (n)` before the extension.
- Duplicated collision logic means a numbering change (e.g. ` (2)` → `-2`) has to be made in two places; missing one silently diverges Folder-mode and Zip-mode output names.

## Changes

### Shared `next_free_path` helper (`crates/core/src/infrastructure/path_utils.rs`)

- Add `pub(crate) fn next_free_path(desired: &Path, candidate: impl Fn(u32) -> PathBuf) -> PathBuf`, placed alongside `classify` / `classified_components`. It owns the shared loop (counter starting at 2), the `u32::MAX` bound, the `Path::exists()` check, and the unreachable fallback; the caller supplies a `candidate(n)` closure deciding HOW to fold the counter into the name. Stays a pure path-string helper — the only IO is the same `Path::exists()` probe the two adapters already performed.

### Route the Folder placer through the helper (`crates/core/src/infrastructure/fs_placer.rs`)

- `non_colliding` keeps its parent/base derivation and now delegates to `next_free_path`, passing a closure that appends ` (n)` to the whole final component. Its own collision loop is gone; the `fn` signature and `place_blocking` caller are unchanged.

### Route the Zip archiver through the helper (`crates/core/src/infrastructure/zip_archiver.rs`)

- `non_colliding_zip` keeps its stem/extension derivation and the `Some(ext)` / `None` branch, and now delegates to `next_free_path`, passing a closure that inserts ` (n)` before the extension so the `.zip` suffix is preserved. Its own collision loop is gone; the `fn` signature and `resolve_destination` caller are unchanged.

### Tests (`path_utils.rs`)

- New `next_free_path_tests` module drives both insertion modes against a real temp dir: returns the desired path unchanged when free; Folder-mode append picks the first free sibling (`foo` → `foo (2)`); Zip-mode insertion preserves the suffix (`o.zip` → `o (2).zip`); and a multi-collision case where both `foo` and `foo (2)` exist advances the counter to `foo (3)`.
- The existing `FsPlacer` policy tests and `ZipArchiver` auto-rename / skip / overwrite tests are unmodified and serve as the behavior-preserving regression guard.

## Verification

- Confirm neither adapter still contains its own `2..=u32::MAX` loop — `grep -rn "2..=u32::MAX" crates/core/src/infrastructure` now matches only `path_utils.rs`.
- Core-crate / infra refactor only — no domain change, no DTO / ts-rs change, so no `src/bindings/*.ts` regeneration and the frontend is unaffected.

## Test plan

- [x] `cargo nextest run -p simple-archiver-core` — 242 passed, 0 skipped
- [x] `cargo clippy --all-targets -- -D warnings` — no issues
- [x] `cargo fmt --all -- --check` — no diff
- [ ] Manual (packaged app): run into a destination that already holds the target names in both Folder and `.zip file` mode and confirm Auto-rename still produces `… (2)` / `… (3)` siblings exactly as before.
