### PR TITLE
refactor(jobStore): extract derived calcs to pure lib helpers

### DIFF
--- a/src/lib/naming.test.ts
+++ b/src/lib/naming.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_START,
   DEFAULT_TEMPLATE,
   MAX_START,
+  nextStartAfterBatch,
   sanitizeStartNumber,
 } from "./naming";
 
@@ -40,5 +41,18 @@ describe("sanitizeStartNumber", () => {
 
   it("exposes a default of 1", () => {
     expect(DEFAULT_START).toBe(1);
+  });
+});
+
+describe("nextStartAfterBatch", () => {
+  it("advances the start by the batch count", () => {
+    expect(nextStartAfterBatch(1, 3)).toBe(4);
+    expect(nextStartAfterBatch(0, 0)).toBe(0);
+    expect(nextStartAfterBatch(10, 5)).toBe(15);
+  });
+
+  it("clamps the advanced start to MAX_START", () => {
+    expect(nextStartAfterBatch(MAX_START, 1)).toBe(MAX_START);
+    expect(nextStartAfterBatch(MAX_START - 2, 5)).toBe(MAX_START);
   });
 });

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -17,6 +17,15 @@ export const DEFAULT_START = 1;
 export const MAX_START = 4_294_967_295; // u32::MAX
 
 /**
+ * The start number for the next batch after one of `count` tasks ran with the
+ * given `start`: advance by the batch count, clamped to `MAX_START` so the
+ * auto-continue never exceeds the backend's `u32` start field. Pure: no IPC.
+ */
+export function nextStartAfterBatch(start: number, count: number): number {
+  return Math.min(start + count, MAX_START);
+}
+
+/**
  * Parse a start-number input string into a valid start value, or `null` when the
  * input is not a usable integer (empty / non-numeric / fractional). Negative
  * values clamp to 0; values above `MAX_START` clamp to the maximum. Callers treat

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import type { JobSummaryDto } from "@/bindings/JobSummaryDto";
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
 
-import { computeStatus, statusVisual, taskOutcomeFor } from "./status";
+import {
+  computeStatus,
+  statusVisual,
+  taskIdsFromProgress,
+  taskOutcomeFor,
+} from "./status";
 
 describe("statusVisual", () => {
   it("maps succeeded to the unified 'Succeeded' label and the success tokens", () => {
@@ -137,5 +142,30 @@ describe("computeStatus", () => {
 
   it("returns 'Waiting' when not running and no summary yet", () => {
     expect(computeStatus(0, false, null, null, [10])).toBe("Waiting");
+  });
+});
+
+describe("taskIdsFromProgress", () => {
+  it("returns an empty list for an empty perTask array", () => {
+    const progress: ProgressEvent = {
+      overall: { bytesDone: 0, bytesTotal: 0 },
+      overallEtaMs: null,
+      perTask: [],
+      elapsedMs: 0,
+    };
+    expect(taskIdsFromProgress(progress)).toEqual([]);
+  });
+
+  it("projects perTask entries to their task ids in order", () => {
+    const progress: ProgressEvent = {
+      overall: { bytesDone: 30, bytesTotal: 60 },
+      overallEtaMs: 1000,
+      perTask: [
+        { taskId: 7, bytesDone: 10, bytesTotal: 20, etaMs: null },
+        { taskId: 3, bytesDone: 20, bytesTotal: 40, etaMs: 500 },
+      ],
+      elapsedMs: 250,
+    };
+    expect(taskIdsFromProgress(progress)).toEqual([7, 3]);
   });
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -57,6 +57,15 @@ export function statusVisual(outcome: TaskOutcome): StatusVisual {
 }
 
 /**
+ * Project a progress event to the per-task ids in the job's task order. The
+ * store keeps this index-aligned with `draft.items` as `taskIdByIndex`. Pure:
+ * no React/Tauri — the single owner of the ProgressEvent → task-id projection.
+ */
+export function taskIdsFromProgress(progress: ProgressEvent): number[] {
+  return progress.perTask.map((t) => t.taskId);
+}
+
+/**
  * The resolved outcome of a single task once a job has finished.
  *
  * It widens the three terminal `TaskOutcome` buckets with two non-bucket

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -9,8 +9,13 @@ import type { ProgressEvent } from "@/bindings/ProgressEvent";
 // which share names (addItems, reorder, setNamingRule, ...).
 import * as archive from "@/lib/archive";
 import { messageFromReason } from "@/lib/errors";
-import { DEFAULT_START, DEFAULT_TEMPLATE, MAX_START } from "@/lib/naming";
+import {
+  DEFAULT_START,
+  DEFAULT_TEMPLATE,
+  nextStartAfterBatch,
+} from "@/lib/naming";
 import { persistOutputDir } from "@/lib/output-dir-default";
+import { taskIdsFromProgress } from "@/lib/status";
 
 // Monotonic counter tagging each recomputePreviews run. A run only commits its
 // result if it is still the latest; otherwise a slower batch could overwrite a
@@ -330,7 +335,7 @@ export const useJobStore = create<JobState>()((set, get) => ({
       // Derive task ids from the latest progress if a job emitted any.
       const progress = get().progress;
       const taskIdByIndex = progress
-        ? progress.perTask.map((t) => t.taskId)
+        ? taskIdsFromProgress(progress)
         : get().taskIdByIndex;
       set({ summary, running: false, taskIdByIndex });
     } catch (reason) {
@@ -349,7 +354,7 @@ export const useJobStore = create<JobState>()((set, get) => ({
   },
 
   applyProgress: (event) => {
-    set({ progress: event, taskIdByIndex: event.perTask.map((t) => t.taskId) });
+    set({ progress: event, taskIdByIndex: taskIdsFromProgress(event) });
   },
 
   recomputePreviews: async () => {
@@ -441,9 +446,9 @@ export const useJobStore = create<JobState>()((set, get) => ({
     // No finished run means nothing to clear; Clear is a no-op there.
     if (summary === null) return;
     const count = summary.results.length;
-    // Auto-continue: the next batch picks up where this one ended. Clamp to the
-    // field's max so a near-overflow start never exceeds the backend's u32.
-    const nextStart = Math.min(draft.startNumber + count, MAX_START);
+    // Auto-continue: the next batch picks up where this one ended (clamped to
+    // the backend's u32 max). The clamp itself lives in lib/naming, unit-tested.
+    const nextStart = nextStartAfterBatch(draft.startNumber, count);
     // Stash the finished run BEFORE mutating, so the residual chip and Undo can
     // summarize/restore it. setStartNumber recomputes previews against the new
     // (empty) queue; clearItems empties the backend draft.


### PR DESCRIPTION
Closes #155

## Summary

Two derived calculations were inlined inside Zustand store actions in `src/store/jobStore.ts`, mixing fiddly pure logic with IPC orchestration so the pure parts could not be unit-tested in isolation. This extracts them into pure, unit-tested `lib/` functions and points the store's three call sites at them. Behavior is unchanged; the win is isolated boundary coverage for the user-visible start-number auto-continue clamp.

## Background / Motivation

- The start-number auto-continue clamp (`Math.min(start + count, MAX_START)`) lived inline in `clearResults`, so its `MAX_START` boundary — a user-visible numbering behavior near the backend's `u32` ceiling — had no isolated unit test.
- The `ProgressEvent` -> task-id projection (`progress.perTask.map((t) => t.taskId)`) was duplicated inline across three store sites (`runJob`, `applyProgress`, `clearResults`), with the position-alignment invariant (`taskIdByIndex` index-aligned with `draft.items`) implied but never centralized.
- `lib/status.ts` already owns the position/status pure logic and `lib/naming.ts` already owns `MAX_START`, so the natural home for each calc already existed.

## Changes

### `nextStartAfterBatch` pure helper (`src/lib/naming.ts`)

- New `nextStartAfterBatch(start, count)` returns `Math.min(start + count, MAX_START)`, placed next to `MAX_START`; pure, no IPC.
- `clearResults` now delegates to it and drops the now-unused `MAX_START` import.

### `taskIdsFromProgress` pure projection (`src/lib/status.ts`)

- New `taskIdsFromProgress(progress)` returns `progress.perTask.map((t) => t.taskId)` (`number[]` — there is no `TaskId` alias in the codebase), documented as the single owner of the projection.
- `runJob` and `applyProgress` now call it instead of inlining the map.

### Tests

- `naming.test.ts`: `nextStartAfterBatch` advances by the batch count and clamps at the `MAX_START` boundary (both confirmed RED before implementing).
- `status.test.ts`: `taskIdsFromProgress` returns `[]` for an empty `perTask` and projects ids in task order (confirmed RED first).
- Existing `jobStore.test.ts` (69 cases) stays green unchanged — the swaps are behavior-preserving.

## Verification

- Frontend only — no backend / DTO change, so no `src/bindings/*.ts` regeneration.
- Run a batch, then Clear: the next start advances by the cleared count (clamped at `u32::MAX`); per-row statuses still resolve correctly via `taskIdByIndex`, confirming the projection swap changed nothing observable.

## Test plan

- [x] `pnpm test` — 522 passed (45 files)
- [x] `pnpm lint:ci` (oxlint) — clean
- [x] `pnpm fmt:check` (oxfmt) — clean
- [x] `pnpm build` (tsc && vite build) — clean
- [x] `pnpm knip` — clean
- [ ] Manual (packaged app): run a batch, Clear, confirm the next start advances by the batch count and per-row statuses still render
