### PR TITLE
refactor(core): unify per-task output-destination path (SSOT)

### DIFF
--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -109,18 +109,13 @@ impl<A: Archiver + 'static, E: Extractor + 'static, P: Placer + 'static> RunArch
         let work: Vec<WorkItem> = job
             .tasks()
             .iter()
-            .map(|t| {
-                let dest = match mode {
-                    OutputMode::Zip => out_dir.join(t.output_name().as_str()),
-                    OutputMode::Folder => out_dir.join(t.source().output_stem()),
-                };
-                WorkItem {
-                    task: t.id(),
-                    source: t.source().clone(),
-                    dest,
-                    mode,
-                    policy,
-                }
+            .map(|t| WorkItem {
+                task: t.id(),
+                source: t.source().clone(),
+                // Single source of truth for the destination formula (domain).
+                dest: t.output_destination(&out_dir, mode),
+                mode,
+                policy,
             })
             .collect();
 

--- a/crates/core/src/domain/archive_task.rs
+++ b/crates/core/src/domain/archive_task.rs
@@ -1,8 +1,10 @@
 //! The stable task identity and the archive-task entity.
 
 use crate::domain::file_name::OutputFileName;
+use crate::domain::output_mode::OutputMode;
 use crate::domain::source_item::SourceItem;
 use crate::domain::task_status::{IllegalTransition, TaskEvent, TaskStatus};
+use std::path::{Path, PathBuf};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TaskId
@@ -80,6 +82,21 @@ impl ArchiveTask {
     /// Return a reference to the current lifecycle status.
     pub fn status(&self) -> &TaskStatus {
         &self.status
+    }
+
+    /// Compute this task's output destination path under `out_dir` (pure path
+    /// math; performs no IO).
+    ///
+    /// This is the single source of truth for the per-task destination formula:
+    /// `Zip` joins the validated output filename, `Folder` joins the source's
+    /// output stem. Both the engine (`RunArchiveJob`) and the presentation layer
+    /// (`task_path_meta`) consume this so the "where the file lands" computation
+    /// can never drift between them.
+    pub fn output_destination(&self, out_dir: &Path, mode: OutputMode) -> PathBuf {
+        match mode {
+            OutputMode::Zip => out_dir.join(self.output_name().as_str()),
+            OutputMode::Folder => out_dir.join(self.source().output_stem()),
+        }
     }
 
     // ── Crate-internal mutators ───────────────────────────────────────────────
@@ -361,5 +378,26 @@ mod tests {
         task.apply_event(TaskEvent::StartExtracting).unwrap();
         task.set_output_name(make_output_name("other"));
         assert_eq!(task.status(), &TaskStatus::Extracting);
+    }
+
+    // ── output_destination (SSOT for the per-task output path) ──────────────────
+
+    #[test]
+    fn output_destination_zip_joins_output_name() {
+        // Zip mode: out_dir / <output filename> (e.g. "foo.zip").
+        let task = make_task(1); // output_name stem "foo" -> "foo.zip"
+        let out_dir = std::path::PathBuf::from("/out");
+        let dest = task.output_destination(&out_dir, OutputMode::Zip);
+        assert_eq!(dest, out_dir.join("foo.zip"));
+    }
+
+    #[test]
+    fn output_destination_folder_joins_source_output_stem() {
+        // Folder mode: out_dir / <source output stem>. A RarFile("a.rar")
+        // source has the stem "a", independent of the output filename.
+        let task = make_task(1);
+        let out_dir = std::path::PathBuf::from("/out");
+        let dest = task.output_destination(&out_dir, OutputMode::Folder);
+        assert_eq!(dest, out_dir.join("a"));
     }
 }

--- a/src-tauri/src/presentation/commands.rs
+++ b/src-tauri/src/presentation/commands.rs
@@ -187,9 +187,9 @@ pub async fn run_job_inner(
     job_summary_dto(summary, &meta)
 }
 
-/// Recompute each task's `(id, output base name, absolute output path)` from the
-/// planned job, mirroring the engine's destination formula in `run_archive_job`:
-/// Zip mode joins the output filename, Folder mode joins the source's output stem.
+/// Recompute each task's id, output base name, and absolute output path from the
+/// planned job. The absolute path is computed by the domain SSOT
+/// `ArchiveTask::output_destination`, so it cannot diverge from the engine.
 ///
 /// `PathBuf` is rendered to a lossy UTF-8 `String` at this wire boundary.
 fn task_path_meta(job: &ArchiveJob) -> Vec<TaskPathMeta> {
@@ -198,12 +198,21 @@ fn task_path_meta(job: &ArchiveJob) -> Vec<TaskPathMeta> {
     job.tasks()
         .iter()
         .map(|t| {
-            let name = match mode {
+            let output_name = match mode {
                 DomainOutputMode::Zip => t.output_name().as_str().to_string(),
                 DomainOutputMode::Folder => t.source().output_stem(),
             };
-            let path = out_dir.join(&name).to_string_lossy().into_owned();
-            (t.id(), name, path)
+            // Absolute output path comes from the domain SSOT so it can never
+            // drift from the engine's destination formula.
+            let output_path = t
+                .output_destination(out_dir, mode)
+                .to_string_lossy()
+                .into_owned();
+            TaskPathMeta {
+                id: t.id(),
+                output_name,
+                output_path,
+            }
         })
         .collect()
 }

--- a/src-tauri/src/presentation/dto_map.rs
+++ b/src-tauri/src/presentation/dto_map.rs
@@ -61,12 +61,17 @@ impl From<&JobProgress> for ProgressEvent {
 }
 
 /// Per-task output metadata the presentation layer recomputes from the planned
-/// job: `(task id, output base name, absolute output path)`, in job/task order.
+/// job: task id, output base name, and absolute output path, in job/task order.
 ///
 /// This is the bridge that lets the wire summary carry output paths without the
-/// core engine producing them — the engine returns task ids only, and the path
-/// formula is mirrored here at the IPC boundary (see `commands::run_job_inner`).
-pub type TaskPathMeta = (TaskId, String, String);
+/// core engine producing them — the engine returns task ids only. The path is
+/// computed via the domain SSOT `ArchiveTask::output_destination` (see
+/// `commands::task_path_meta`).
+pub(crate) struct TaskPathMeta {
+    pub(crate) id: TaskId,
+    pub(crate) output_name: String,
+    pub(crate) output_path: String,
+}
 
 /// Build a [`JobSummaryDto`] from the engine's [`JobSummary`] plus per-task
 /// output metadata.
@@ -95,8 +100,8 @@ pub(crate) fn job_summary_dto(summary: JobSummary, meta: &[TaskPathMeta]) -> Job
 
     let results = meta
         .iter()
-        .map(|(id, output_name, output_path)| {
-            let raw = id.get();
+        .map(|m| {
+            let raw = m.id.get();
             let (status, reason) = status_by_id.get(&raw).cloned().unwrap_or_else(|| {
                 (
                     TaskStatusDto::Failed,
@@ -105,8 +110,8 @@ pub(crate) fn job_summary_dto(summary: JobSummary, meta: &[TaskPathMeta]) -> Job
             });
             TaskResultDto {
                 task_id: raw,
-                output_name: output_name.clone(),
-                output_path: output_path.clone(),
+                output_name: m.output_name.clone(),
+                output_path: m.output_path.clone(),
                 status,
                 reason,
             }
@@ -274,16 +279,21 @@ mod tests {
         .unwrap()
     }
 
-    /// Build the `(id, name, abs path)` meta for a Zip job, mirroring the engine's
-    /// destination formula `out_dir.join(t.output_name())`.
+    /// Build the per-task meta for a Zip job, computing the path via the domain
+    /// SSOT `ArchiveTask::output_destination` so the test asserts the production
+    /// formula.
     fn zip_meta(job: &ArchiveJob) -> Vec<TaskPathMeta> {
         let out_dir = job.output_directory().path();
+        let mode = job.output_mode();
         job.tasks()
             .iter()
-            .map(|t| {
-                let name = t.output_name().as_str().to_string();
-                let path = out_dir.join(&name).to_string_lossy().into_owned();
-                (t.id(), name, path)
+            .map(|t| TaskPathMeta {
+                id: t.id(),
+                output_name: t.output_name().as_str().to_string(),
+                output_path: t
+                    .output_destination(out_dir, mode)
+                    .to_string_lossy()
+                    .into_owned(),
             })
             .collect()
     }
@@ -366,13 +376,17 @@ mod tests {
 
         // Build meta the same way the command does for Folder mode.
         let out_dir = job.output_directory().path();
+        let mode = job.output_mode();
         let meta: Vec<TaskPathMeta> = job
             .tasks()
             .iter()
-            .map(|t| {
-                let stem = t.source().output_stem();
-                let path = out_dir.join(&stem).to_string_lossy().into_owned();
-                (t.id(), stem, path)
+            .map(|t| TaskPathMeta {
+                id: t.id(),
+                output_name: t.source().output_stem(),
+                output_path: t
+                    .output_destination(out_dir, mode)
+                    .to_string_lossy()
+                    .into_owned(),
             })
             .collect();
 


### PR DESCRIPTION
## Summary

The per-task output-destination formula — `out_dir.join(Zip → output_name / Folder → source.output_stem())` — was duplicated in three places (the engine, the presentation `task_path_meta` mirror, and a test helper). If the engine formula ever changed, the presentation layer would silently return a stale path and the UI's "where the file lands" display would diverge from where the file actually lands. This introduces one pure domain method, `ArchiveTask::output_destination`, as the single source of truth every call site consumes, and replaces the swap-prone positional tuple `TaskPathMeta` with a named struct. Behavior-preserving: all existing tests stay green.

## Background / Motivation

- The destination formula lived in three independent copies; the engine (`run_archive_job`) and the presentation mirror (`task_path_meta`) could drift apart with no compile-time link, so a change to one would leave the IPC summary reporting a path the engine never wrote — a real correctness bug.
- `TaskPathMeta` was a positional tuple `(TaskId, String, String)` destructured as `(id, output_name, output_path)` at the consumer; the two `String` fields are trivially swappable with no type-level guard.
- The path math is pure domain logic but was being recomputed at the application and presentation layers rather than owned by the entity that has the data.

## Changes

### Domain SSOT method (`crates/core/src/domain/archive_task.rs`)

- Add `ArchiveTask::output_destination(&self, out_dir: &Path, mode: OutputMode) -> PathBuf` — pure path math, no IO: `Zip` joins the validated output filename, `Folder` joins the source's output stem.
- Takes `&Path` (not `&OutputDirectory`) because both real callers already hold a `&Path`, keeping the domain method free of the newtype at the join site.

### Engine consumes the SSOT (`crates/core/src/application/run_archive_job.rs`)

- Replace the inline `match mode { Zip => …, Folder => … }` in the work-list builder with `dest: t.output_destination(&out_dir, mode)`.

### `TaskPathMeta` tuple → named struct (`src-tauri/src/presentation/dto_map.rs`)

- Convert the `pub type TaskPathMeta = (TaskId, String, String)` alias into a `pub(crate) struct TaskPathMeta { id, output_name, output_path }`.
- Update the `job_summary_dto` consumer to read named fields instead of destructuring a tuple.
- Update the test helpers (`zip_meta` and the Folder-mode inline builder) to construct the struct and derive the path via `output_destination`.

### Presentation path via the SSOT (`src-tauri/src/presentation/commands.rs`)

- `task_path_meta` now builds the named struct and computes `output_path` via `ArchiveTask::output_destination`, removing the second copy of the formula; the display `output_name` branch stays (name and path differ in intent, but the path can no longer diverge from the engine).

### Tests

- New `output_destination` unit tests in `archive_task.rs` cover both branches: Zip joins `"foo.zip"`, Folder joins the source stem `"a"` (deliberately different from the output name, proving the branches diverge). Both confirmed RED (`no method named output_destination`) before implementation.
- Existing engine and presentation tests (placements at `/out/a`, `/out/b`; `out_1.zip`; Folder `"photos"`) are unchanged and pin the resulting destinations.

## Verification

- `git grep -n "out_dir.join"` in core/presentation: the per-task destination formula now appears once, inside `ArchiveTask::output_destination`; the engine and `task_path_meta` call the method rather than re-deriving it.
- Backend only — `TaskPathMeta` is an internal `pub(crate)` type, not a `#[derive(TS)]` wire DTO, so there is no ts-rs regeneration and `src/bindings/*.ts` is untouched; the frontend build is unaffected.

## Test plan

- [x] `cargo nextest run -p simple-archiver-core -p simple-archiver` — 342 passed (incl. 2 new `output_destination` tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `git status src/bindings/` — clean (no ts-rs regeneration committed)

Closes #154
