### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,7 +3770,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.7.0"
+version = "0.8.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Release v0.8.0

Bump version `0.7.0` → `0.8.0` across the 4 manifests + both `Cargo.lock` entries (`simple-archiver`, `simple-archiver-core`).

`cargo metadata --locked` passes (exit 0); the diff is exactly the 6 version lines, no `src/bindings/` regen.

### What's landing in v0.8.0 (since v0.7.0)

**Features**
- `feat(zip)`: apply conflict policy to archive output
- `feat(ledger)`: copy-path toast affordance, drop per-row reveal
- `feat(menu)`: show only the simple-archiver app menu in the menu bar

**Fixes**
- `fix(ledger)`: align run-summary row numbers with header inset
- `fix(reorder)`: strengthen the lifted grab affordance on the dragged row
- `fix(rail)`: scroll horizontally on a narrow pane instead of clipping

**Refactors**
- Output destination SSOT via `ArchiveTask::output_destination` (core + presentation)
- `next_free_path` helper unifying collision naming across `FsPlacer` / `ZipArchiver`
- `jobStore` derived calcs extracted to pure lib helpers

### Release procedure
After merge: `gh release create v0.8.0 --target main --title "v0.8.0" --notes-file <f> --latest` — the tag fires `release.yml`, which builds + attaches the macOS (universal) `.dmg` and Windows `.msi` + NSIS `.exe`.
