### PR TITLE
feat(ledger): group completion results by outcome, failures first

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -210,29 +210,3 @@
     0 3px 6px -3px rgb(0 0 0 / 0.5);
   transform: translateY(-3px) scale(1.02);
 }
-
-/* One-shot entrance for the transient "Path was copied" pill: it rises slightly
-   and fades in by the pointer. The element's resting transform (-50%, -150%)
-   comes from utility classes; the keyframe only animates the approach to it. */
-@keyframes copied-hint-in {
-  from {
-    opacity: 0;
-    transform: translate(-50%, -130%);
-  }
-  to {
-    opacity: 1;
-    transform: translate(-50%, -150%);
-  }
-}
-
-.copied-hint {
-  animation: copied-hint-in 140ms ease-out;
-}
-
-/* Motion is decorative here; honour a reduced-motion preference by snapping the
-   pill straight to its resting state. */
-@media (prefers-reduced-motion: reduce) {
-  .copied-hint {
-    animation: none;
-  }
-}

--- a/src/__tests__/summary-flow.test.tsx
+++ b/src/__tests__/summary-flow.test.tsx
@@ -76,9 +76,8 @@ describe("run → summary flow", () => {
     );
 
     render(<Ledger />);
-    // The "<label> <n>" form is unique to the header tally (row badges show only
-    // the bare label).
-    expect(screen.getByText(/Succeeded\s*1/)).toBeTruthy();
+    // The header subline summarises the projected outcomes.
+    expect(screen.getByText(/1 succeeded/i)).toBeTruthy();
     expect(screen.getByText("out_2.zip")).toBeTruthy();
     expect(screen.getByText(/unrar error: boom/)).toBeTruthy();
   });

--- a/src/components/Ledger.test.tsx
+++ b/src/components/Ledger.test.tsx
@@ -118,9 +118,8 @@ describe("Ledger", () => {
     });
     render(<Ledger />);
 
-    const rows = screen.getAllByRole("row");
-    // 3 result rows (the sticky header is not a table row).
-    expect(rows.length).toBe(3);
+    // Count data rows by their Copy action (group-heading rows have no button).
+    expect(screen.getAllByRole("button", { name: /copy/i })).toHaveLength(3);
 
     expect(screen.getByText("a.rar")).toBeTruthy();
     expect(screen.getByText("b.rar")).toBeTruthy();
@@ -137,12 +136,11 @@ describe("Ledger", () => {
     });
     render(<Ledger />);
 
-    // The sticky header insets its status tally by px-4; without a matching left
-    // pad on the first body cell the row numbers hug the card's left border and
-    // fall out of alignment with the header. The number cell must carry pl-4 so
-    // the two left edges line up.
-    const firstRow = screen.getAllByRole("row")[0];
-    const numberCell = within(firstRow).getAllByRole("cell")[0];
+    // The header insets its content by px-4; the number cell must carry pl-4 so
+    // the row numbers line up with it. Target a known data row (grouping reorders
+    // rows, so the first DOM row is a group heading, not a data row).
+    const row = screen.getByText("out_1.zip").closest("tr") as HTMLElement;
+    const numberCell = within(row).getAllByRole("cell")[0];
     expect(numberCell.className).toContain("pl-4");
   });
 
@@ -155,18 +153,94 @@ describe("Ledger", () => {
     expect(screen.getByText(/unrar error: boom/)).toBeTruthy();
   });
 
-  it("tallies the header counts from the results status, not recomputed", () => {
+  it("orders groups failures-first, successes-last", () => {
     useJobStore.setState({
       draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
       summary: MIXED_SUMMARY,
     });
     render(<Ledger />);
-    // 1 succeeded, 1 cancelled, 1 failed. The counts (with their number) live in
-    // the sticky header; the per-row status badges render only the bare label, so
-    // matching "<label> <n>" uniquely resolves the header tally.
-    expect(screen.getByText(/Succeeded\s*1/)).toBeTruthy();
-    expect(screen.getByText(/Cancelled\s*1/)).toBeTruthy();
-    expect(screen.getByText(/Failed\s*1/)).toBeTruthy();
+    // out_3.zip is the failed row, out_1.zip the succeeded row: failures first.
+    const failed = screen.getByText("out_3.zip");
+    const succeeded = screen.getByText("out_1.zip");
+    expect(
+      failed.compareDocumentPosition(succeeded) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders a group heading with the count for each non-empty outcome", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+      summary: MIXED_SUMMARY,
+    });
+    render(<Ledger />);
+    expect(screen.getByText(/Failed\s*·\s*1/)).toBeTruthy();
+    expect(screen.getByText(/Cancelled\s*·\s*1/)).toBeTruthy();
+    expect(screen.getByText(/Succeeded\s*·\s*1/)).toBeTruthy();
+  });
+
+  it("omits a group heading for an outcome with no results", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar"]),
+      summary: {
+        succeeded: [10],
+        cancelled: [],
+        failed: [],
+        results: [
+          {
+            taskId: 10,
+            outputName: "out_1.zip",
+            outputPath: "/out/out_1.zip",
+            status: "succeeded",
+            reason: null,
+          },
+        ],
+      },
+    });
+    render(<Ledger />);
+    expect(screen.queryByText(/Failed\s*·/)).toBeNull();
+    expect(screen.queryByText(/Cancelled\s*·/)).toBeNull();
+    expect(screen.getByText(/Succeeded\s*·\s*1/)).toBeTruthy();
+  });
+
+  it("numbers rows by original job order after grouping reorders them", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+      summary: MIXED_SUMMARY,
+    });
+    render(<Ledger />);
+    // Failed (out_3.zip) is index 2 in results → number 3, even though it leads.
+    const failedRow = screen
+      .getByText("out_3.zip")
+      .closest("tr") as HTMLElement;
+    expect(within(failedRow).getAllByRole("cell")[0].textContent).toBe("3");
+  });
+
+  it("summarises the batch in the header with per-outcome counts", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+      summary: MIXED_SUMMARY,
+    });
+    render(<Ledger />);
+    // Total + a subline that omits zero categories.
+    expect(screen.getByText(/3 archives/i)).toBeTruthy();
+    expect(screen.getByText(/1 succeeded/i)).toBeTruthy();
+    expect(screen.getByText(/1 cancelled/i)).toBeTruthy();
+    expect(screen.getByText(/1 failed/i)).toBeTruthy();
+  });
+
+  it("gives Open folder primary emphasis and Clear an outline treatment", () => {
+    useJobStore.setState({
+      draft: draftWith(["/in/a.rar"], "/out"),
+      summary: MIXED_SUMMARY,
+    });
+    render(<Ledger />);
+    expect(
+      screen.getByRole("button", { name: /open folder/i }).className,
+    ).toContain("bg-primary");
+    expect(
+      screen.getByRole("button", { name: /clear results/i }).className,
+    ).toContain("border");
   });
 
   it("shows the per-row size from the last progress event keyed by task id", () => {
@@ -278,53 +352,50 @@ describe("Ledger", () => {
       await screen.findByText(/path was copied/i);
     });
 
-    it("shows a 'Path was copied' affordance near the pointer after copying", async () => {
-      vi.mocked(copyText).mockResolvedValue(undefined);
-      render(<Ledger />);
-
-      const succeededRow = screen.getByText("out_1.zip").closest("tr");
-      // fireEvent (not userEvent) so we can supply pointer coordinates; the
-      // affordance is positioned at the click point.
-      fireEvent.click(
-        within(succeededRow as HTMLElement).getByRole("button", {
-          name: /copy/i,
-        }),
-        { clientX: 123, clientY: 456 },
-      );
-
-      const hint = await screen.findByText(/path was copied/i);
-      // Fixed-position pill anchored at the pointer's viewport coordinates.
-      expect(hint.style.left).toBe("123px");
-      expect(hint.style.top).toBe("456px");
-    });
-
-    it("dismisses the copied affordance after a few seconds", async () => {
+    it("marks the clicked row as Copied and reverts after the timeout", async () => {
       vi.useFakeTimers();
       try {
         vi.mocked(copyText).mockResolvedValue(undefined);
         render(<Ledger />);
 
-        const succeededRow = screen.getByText("out_1.zip").closest("tr");
+        const succeededRow = screen
+          .getByText("out_1.zip")
+          .closest("tr") as HTMLElement;
         fireEvent.click(
-          within(succeededRow as HTMLElement).getByRole("button", {
-            name: /copy/i,
-          }),
-          { clientX: 10, clientY: 20 },
+          within(succeededRow).getByRole("button", { name: /copy/i }),
         );
-        // Flush the async copy → state update that mounts the affordance.
+        // Flush the async copy → state update that flips the row into Copied.
         await act(async () => {
           await Promise.resolve();
         });
-        expect(screen.getByText(/path was copied/i)).toBeTruthy();
+        expect(within(succeededRow).getByText(/copied/i)).toBeTruthy();
 
-        // After the timeout elapses, the affordance is gone.
+        // After the timeout elapses, the row reverts to the bare Copy action.
         act(() => {
-          vi.advanceTimersByTime(5000);
+          vi.advanceTimersByTime(2000);
         });
-        expect(screen.queryByText(/path was copied/i)).toBeNull();
+        expect(within(succeededRow).queryByText(/copied/i)).toBeNull();
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("only marks the row that was clicked as Copied", async () => {
+      vi.mocked(copyText).mockResolvedValue(undefined);
+      render(<Ledger />);
+
+      const succeededRow = screen
+        .getByText("out_1.zip")
+        .closest("tr") as HTMLElement;
+      const cancelledRow = screen
+        .getByText("out_2.zip")
+        .closest("tr") as HTMLElement;
+      await userEvent.click(
+        within(succeededRow).getByRole("button", { name: /copy/i }),
+      );
+
+      expect(within(succeededRow).getByText(/copied/i)).toBeTruthy();
+      expect(within(cancelledRow).queryByText(/copied/i)).toBeNull();
     });
 
     it("surfaces an error when copying fails (and shows no affordance)", async () => {
@@ -434,6 +505,42 @@ describe("Ledger", () => {
       expect(screen.getByRole("status", { name: /run summary/i })).toBeTruthy();
       // The per-row Copy icon button carries an accessible name.
       expect(screen.getByRole("button", { name: /copy/i })).toBeTruthy();
+    });
+  });
+
+  describe("proportion bar", () => {
+    it("renders one segment per non-empty outcome", () => {
+      useJobStore.setState({
+        draft: draftWith(["/in/a.rar", "/in/b.rar", "/in/c.rar"]),
+        summary: MIXED_SUMMARY,
+      });
+      const { container } = render(<Ledger />);
+      const bar = container.querySelector(".ledger-segment-bar");
+      expect(bar).not.toBeNull();
+      expect((bar as HTMLElement).children).toHaveLength(3);
+    });
+
+    it("renders a single segment when every task shares one outcome", () => {
+      useJobStore.setState({
+        draft: draftWith(["/in/a.rar"]),
+        summary: {
+          succeeded: [10],
+          cancelled: [],
+          failed: [],
+          results: [
+            {
+              taskId: 10,
+              outputName: "out_1.zip",
+              outputPath: "/out/out_1.zip",
+              status: "succeeded",
+              reason: null,
+            },
+          ],
+        },
+      });
+      const { container } = render(<Ledger />);
+      const bar = container.querySelector(".ledger-segment-bar");
+      expect((bar as HTMLElement).children).toHaveLength(1);
     });
   });
 });

--- a/src/components/Ledger.tsx
+++ b/src/components/Ledger.tsx
@@ -1,4 +1,4 @@
-import { Copy, Eraser, FolderOpen } from "lucide-react";
+import { Check, Copy, Delete, FolderOpen } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import type { ProgressEvent } from "@/bindings/ProgressEvent";
@@ -8,12 +8,15 @@ import { messageFromReason } from "@/lib/errors";
 import { formatBytes } from "@/lib/format";
 import { basename } from "@/lib/path";
 import { copyText, openPath } from "@/lib/reveal";
-import { statusVisual } from "@/lib/status";
+import { statusVisual, type TaskOutcome } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
 
-// How long the transient "Path was copied" affordance lingers near the pointer
-// after a successful per-row Copy before it fades away on its own.
+// How long a row's "Copied" affordance lingers before it reverts to the Copy icon.
 const COPIED_HINT_MS = 2000;
+
+// Outcome groups render in action-first order: failures first so the rows a user
+// must act on lead; successes last.
+const GROUP_ORDER: TaskOutcome[] = ["failed", "cancelled", "succeeded"];
 
 // Run an IPC-touching action and surface a failure through the shared store
 // error path rather than swallowing it, mirroring the other event handlers
@@ -42,34 +45,40 @@ function sizeForTask(
 }
 
 interface LedgerRowProps {
-  /** Position in the results list, used for the source-basename lookup. */
+  /** Original job-order position (preserved across grouping) for the number cell. */
   index: number;
   result: TaskResultDto;
   /** Source basename, resolved by the parent from draft.items[index]. */
   source: string;
   /** Best-effort produced size, or null when unknown. */
   size: string | null;
-  /**
-   * Raise the transient "Path was copied" affordance at the given viewport
-   * coordinates after this row's path is successfully copied.
-   */
-  onCopied: (x: number, y: number) => void;
+  /** Whether this row is currently showing its transient "Copied" affordance. */
+  copied: boolean;
+  /** Copy the row's output path and raise the in-row confirmation. */
+  onCopy: (taskId: number, outputPath: string) => void;
 }
 
 /**
- * One ledger row: `# | source → output name | size | status | Copy`.
+ * One ledger row: `# | source → output name | size-or-reason | Copy`.
  *
+ * The per-row status is conveyed by the enclosing outcome group, so the row
+ * carries no status chip. Failed rows render their reason in place of the size.
  * Copy writes the row's intended absolute output path to the clipboard; even a
- * failed row exposes it so the path can still be pasted. On success it raises a
- * transient "Path was copied" affordance at the pointer via `onCopied`.
+ * failed row exposes it so the path can still be pasted. On success the button
+ * morphs to "Copied" in place.
  */
-function LedgerRow({ index, result, source, size, onCopied }: LedgerRowProps) {
-  const visual = statusVisual(result.status);
-
+function LedgerRow({
+  index,
+  result,
+  source,
+  size,
+  copied,
+  onCopy,
+}: LedgerRowProps) {
   return (
     <tr className="border-b border-border/50 hover:bg-muted/30 transition-colors">
-      {/* Sequence number. pl-4 matches the sticky header's px-4 inset so the row
-          numbers line up with the status tally instead of hugging the card edge. */}
+      {/* Sequence number. pl-4 matches the header's px-4 inset so the row numbers
+          line up with the header instead of hugging the card edge. */}
       <td className="py-2 pl-4 pr-3 font-mono text-muted-foreground">
         {index + 1}
       </td>
@@ -83,44 +92,32 @@ function LedgerRow({ index, result, source, size, onCopied }: LedgerRowProps) {
         <span>{result.outputName}</span>
       </td>
 
-      {/* Size (omitted when unknown) */}
-      <td className="py-2 pr-3 font-mono text-muted-foreground">
-        {size ?? ""}
-      </td>
-
-      {/* Status glyph + label; failed rows carry the reason inline */}
-      <td className="py-2 pr-3">
-        <span
-          className={`inline-flex items-center gap-1.5 rounded px-2 py-1 font-medium ${visual.className}`}
-        >
-          <span aria-hidden="true">{visual.icon}</span>
-          {visual.label}
-        </span>
-        {result.status === "failed" && result.reason !== null && (
-          <span className="ml-2 font-mono text-status-danger-foreground">
-            {result.reason}
-          </span>
+      {/* size for non-failed rows; the failure reason (emphasised) for failed rows */}
+      <td className="py-2 pr-3 font-mono text-xs">
+        {result.status === "failed" ? (
+          <span className="text-status-danger-foreground">{result.reason}</span>
+        ) : (
+          <span className="text-muted-foreground">{size ?? ""}</span>
         )}
       </td>
 
-      {/* Per-row actions */}
-      <td className="py-2">
-        <div className="flex gap-1">
+      {/* Per-row Copy action with an in-place "Copied" confirmation. */}
+      <td className="py-2 pr-4">
+        <div className="flex justify-end">
           <Button
             variant="ghost"
-            size="icon"
+            size="sm"
             aria-label={`Copy path of ${result.outputName}`}
-            onClick={(event) => {
-              // Capture the pointer position now; the synthetic event is not
-              // available once the async copy resolves.
-              const { clientX, clientY } = event;
-              runOrReportError(async () => {
-                await copyText(result.outputPath);
-                onCopied(clientX, clientY);
-              });
-            }}
+            onClick={() => onCopy(result.taskId, result.outputPath)}
           >
-            <Copy aria-hidden="true" />
+            {copied ? (
+              <>
+                <Check aria-hidden="true" />
+                Copied
+              </>
+            ) : (
+              <Copy aria-hidden="true" />
+            )}
           </Button>
         </div>
       </td>
@@ -130,12 +127,11 @@ function LedgerRow({ index, result, source, size, onCopied }: LedgerRowProps) {
 
 /**
  * The Inline Ledger is the completion view shown in the right canvas after a job
- * finishes. It replaces the old RunSummary panel: a sticky header with the
- * status tally + an "Open folder" affordance, then one row per task carrying its
- * source → output name, produced size, status, and a per-row Copy action.
+ * finishes. Results are grouped by outcome (failures first), each group labelled
+ * with its count, and every row carries a per-row Copy action.
  *
- * Pure projection of the backend JobSummaryDto: the header counts are tallied
- * from `summary.results[].status` (never recomputed independently) and failure
+ * Pure projection of the backend JobSummaryDto: the counts are tallied from
+ * `summary.results[].status` (never recomputed independently) and failure
  * reasons come verbatim from each result. Renders nothing until a summary exists.
  */
 export function Ledger() {
@@ -145,20 +141,18 @@ export function Ledger() {
   const outputDir = useJobStore((s) => s.draft.outputDir);
   const clearResults = useJobStore((s) => s.clearResults);
 
-  // Transient per-row "Path was copied" affordance, anchored at the pointer.
-  // `nonce` changes the object identity on every copy so a repeat copy re-arms
-  // the dismiss timer and repositions the pill even when the text is unchanged.
-  const [copiedHint, setCopiedHint] = useState<{
-    x: number;
-    y: number;
+  // The task id whose row currently shows "Copied". `nonce` re-arms the dismiss
+  // timer and re-announces on a repeat copy even when the same row is copied.
+  const [copied, setCopied] = useState<{
+    taskId: number;
     nonce: number;
   } | null>(null);
 
   useEffect(() => {
-    if (copiedHint === null) return;
-    const timer = setTimeout(() => setCopiedHint(null), COPIED_HINT_MS);
+    if (copied === null) return;
+    const timer = setTimeout(() => setCopied(null), COPIED_HINT_MS);
     return () => clearTimeout(timer);
-  }, [copiedHint]);
+  }, [copied]);
 
   if (summary === null) return null;
 
@@ -167,14 +161,34 @@ export function Ledger() {
   const cancelled = results.filter((r) => r.status === "cancelled").length;
   const failed = results.filter((r) => r.status === "failed").length;
 
-  const counts = [
-    { visual: statusVisual("succeeded"), n: succeeded },
-    { visual: statusVisual("cancelled"), n: cancelled },
-    { visual: statusVisual("failed"), n: failed },
-  ];
+  // Header subline: per-outcome counts, omitting zero categories.
+  const sublineParts: string[] = [];
+  if (succeeded) sublineParts.push(`${succeeded} succeeded`);
+  if (cancelled) sublineParts.push(`${cancelled} cancelled`);
+  if (failed) sublineParts.push(`${failed} failed`);
+  const subline = sublineParts.join(" · ");
 
-  const showCopiedHint = (x: number, y: number) =>
-    setCopiedHint((prev) => ({ x, y, nonce: (prev?.nonce ?? 0) + 1 }));
+  // Proportion bar segments in a stable visual order, omitting empty ones. The
+  // status-*-foreground tokens are already registered (used as text colors), so
+  // the bg-* variants resolve.
+  const segments = [
+    { key: "succeeded", n: succeeded, bg: "bg-status-success-foreground" },
+    { key: "cancelled", n: cancelled, bg: "bg-status-warning-foreground" },
+    { key: "failed", n: failed, bg: "bg-status-danger-foreground" },
+  ].filter((s) => s.n > 0);
+
+  // Preserve each row's original job-order number before grouping reorders them.
+  const entries = results.map((result, index) => ({ result, index }));
+  const groups = GROUP_ORDER.map((outcome) => ({
+    outcome,
+    items: entries.filter((e) => e.result.status === outcome),
+  })).filter((g) => g.items.length > 0);
+
+  const handleCopy = (taskId: number, outputPath: string) =>
+    runOrReportError(async () => {
+      await copyText(outputPath);
+      setCopied((prev) => ({ taskId, nonce: (prev?.nonce ?? 0) + 1 }));
+    });
 
   // <output> carries an implicit ARIA role of "status" (and implicit aria-live),
   // so the ledger is announced to assistive tech and tests resolve it via
@@ -186,25 +200,23 @@ export function Ledger() {
         aria-label="Run summary"
         className="flex flex-col rounded-md border border-border bg-card text-sm"
       >
-        {/* Sticky header: status tally + the whole-job "find my files" action. */}
+        {/* Sticky header: batch summary + the whole-job actions. Open folder is
+            the primary next action; Clear is the quieter outline dismiss. */}
         <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3 rounded-t-md border-b border-border bg-card px-4 py-3">
-          <div className="flex flex-wrap items-center gap-2">
-            {counts.map(({ visual, n }) => (
-              <span
-                key={visual.label}
-                className={`inline-flex items-center gap-1.5 rounded px-2 py-1 font-medium ${visual.className}`}
-              >
-                <span aria-hidden="true">{visual.icon}</span>
-                {visual.label} {n}
-              </span>
-            ))}
+          <div>
+            <div className="font-semibold text-foreground">
+              {results.length} archives
+            </div>
+            {subline !== "" && (
+              <div className="text-xs text-muted-foreground">{subline}</div>
+            )}
           </div>
 
           <div className="flex items-center gap-2">
             {/* Guarded on outputDir so it never opens a null path. */}
             {outputDir !== null && (
               <Button
-                variant="outline"
+                variant="default"
                 size="sm"
                 aria-label="Open folder"
                 onClick={() => runOrReportError(() => openPath(outputDir))}
@@ -223,40 +235,59 @@ export function Ledger() {
               aria-label="Clear results"
               onClick={() => runOrReportError(() => clearResults())}
             >
-              <Eraser aria-hidden="true" />
+              <Delete aria-hidden="true" />
               Clear
             </Button>
           </div>
         </div>
 
-        {/* One row per task, in job order. */}
+        {/* Proportion bar (decorative; counts are read out via the subline). */}
+        <div
+          aria-hidden="true"
+          className="ledger-segment-bar flex h-1.5 overflow-hidden"
+        >
+          {segments.map((s) => (
+            <div key={s.key} className={s.bg} style={{ flexGrow: s.n }} />
+          ))}
+        </div>
+
+        {/* Grouped rows: one tbody per non-empty outcome, failures first. */}
         <table className="w-full text-left">
-          <tbody>
-            {results.map((result, index) => (
-              <LedgerRow
-                key={result.taskId}
-                index={index}
-                result={result}
-                source={basename(items[index]?.path ?? "")}
-                size={sizeForTask(result.taskId, progress)}
-                onCopied={showCopiedHint}
-              />
-            ))}
-          </tbody>
+          {groups.map((group) => {
+            const visual = statusVisual(group.outcome);
+            return (
+              <tbody key={group.outcome}>
+                <tr>
+                  <th
+                    colSpan={4}
+                    scope="rowgroup"
+                    className={`px-4 py-1.5 text-left text-xs font-semibold ${visual.className}`}
+                  >
+                    <span aria-hidden="true">{visual.icon}</span> {visual.label}{" "}
+                    · {group.items.length}
+                  </th>
+                </tr>
+                {group.items.map(({ result, index }) => (
+                  <LedgerRow
+                    key={result.taskId}
+                    index={index}
+                    result={result}
+                    source={basename(items[index]?.path ?? "")}
+                    size={sizeForTask(result.taskId, progress)}
+                    copied={copied?.taskId === result.taskId}
+                    onCopy={handleCopy}
+                  />
+                ))}
+              </tbody>
+            );
+          })}
         </table>
       </output>
 
-      {/* Transient confirmation that floats in near the pointer after a Copy
-          and fades on its own. Pointer-events-none so it never intercepts a
-          follow-up click; its own <output> announces the copy to assistive
-          tech without disturbing the run-summary region above. */}
-      {copiedHint !== null && (
-        <output
-          key={copiedHint.nonce}
-          aria-live="polite"
-          className="copied-hint pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-[150%] rounded-md border border-border bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-md"
-          style={{ left: copiedHint.x, top: copiedHint.y }}
-        >
+      {/* Visually-hidden, polite announcement of a successful copy. Keyed by nonce
+          so a repeat copy re-announces even though the text is unchanged. */}
+      {copied !== null && (
+        <output key={copied.nonce} aria-live="polite" className="sr-only">
           Path was copied
         </output>
       )}


### PR DESCRIPTION
## Summary

The completion view (`Ledger`, shown in the right canvas after a batch job finishes) was a flat, monospace-dense table: one tally chip row in the header, a per-row status chip, two equal-weight outline actions, and a "Path was copied" pill that **followed the pointer** with `position: fixed`. Near the canvas edge that pill wrapped onto three lines and clipped, and failures sat buried among successes. This redesigns the view as a **status-grouped, action-first** completion screen reviewed against a principal UI/UX panel: results are grouped by outcome with failures first, the header gains a real summary + a primary `Open folder` action, a proportion bar previews the mix at a glance, and copy confirmation moves in-row so it can never mis-position again. Presentation-only — no `bindings/*`, domain, or IPC change.

## Background / Motivation

- **The copy pill was fragile.** It was anchored at the click's viewport `clientX/clientY` via `position: fixed` with no `white-space: nowrap`, so a copy near the right edge wrapped "Path was copied" across three lines and clipped (the reported visual bug).
- **Flat hierarchy.** `Open folder` (the next action) and `Clear` (dismiss) were both `variant="outline"` — equal weight. The header was a row of status tally chips, duplicated by a per-row status chip on every line.
- **Failures were buried.** Rows rendered in job order, so the one failed archive a user must act on sat below the successes.

## Changes

### Outcome grouping, failures-first (`src/components/Ledger.tsx`)

- Group `summary.results` by outcome in a fixed action-first order `GROUP_ORDER = ["failed", "cancelled", "succeeded"]`, rendering one `<tbody>` per **non-empty** outcome with a `<th colSpan={4} scope="rowgroup">` heading carrying `icon + label · count` (reuses `statusVisual()`, so meaning is never color-only). Empty outcomes are omitted entirely.
- Row numbers preserve the **original job order**: the index is captured (`results.map((result, index) => …)`) before grouping reorders the rows.
- Removed the per-row status chip (the group conveys the outcome). Failed rows now show their `reason` (emphasised) in the meta column; non-failed rows show the produced size.

### Header: summary + action hierarchy (`src/components/Ledger.tsx`)

- Replaced the tally-chip header with a `N archives` summary line plus an omit-zeros subline (`X succeeded · Y cancelled · Z failed`).
- `Open folder` promoted to `variant="default"` (solid primary); `Clear` stays `variant="outline"` and swaps its icon `Eraser → Delete` (backspace glyph). The `outputDir === null` guard on `Open folder` is unchanged.

### Decorative proportion bar (`src/components/Ledger.tsx`)

- A thin `aria-hidden` `.ledger-segment-bar` under the header, one flex segment per non-empty outcome sized by count, coloured with the registered `bg-status-{success,warning,danger}-foreground` tokens. Counts are already announced via the subline, so the bar carries no AT semantics.

### Copy confirmation moves in-row (`src/components/Ledger.tsx`, `src/App.css`)

- Removed the pointer-following floating pill and its `onCopied(x, y)` plumbing. The clicked row's Copy button now morphs in place to `✓ Copied` for 2 s (state `{ taskId, nonce }`; the nonce re-arms the timer on a repeat copy), and a visually-hidden `sr-only` `aria-live="polite"` `<output>` (keyed by nonce) still announces **"Path was copied"** to assistive tech.
- Deleted the now-unused `@keyframes copied-hint-in`, `.copied-hint`, and its `prefers-reduced-motion` rule from `App.css`.

### Tests (`src/components/Ledger.test.tsx`, `src/__tests__/summary-flow.test.tsx`)

- Rewrote the Ledger suite for the new structure: count data rows via their Copy button (group-heading rows have none), target rows by output name (grouping reorders the DOM), and added tests for failures-first ordering, per-group heading + count, zero-outcome omission, original-order numbering, the in-row `Copied` morph + revert, single-row scoping, the header summary/subline, the primary/outline action treatment, and the proportion-bar segment count.
- Updated the `summary-flow` integration assertion from the old tally `/Succeeded\s*1/` to the new header subline `/1 succeeded/i`.

## Verification

- Accessibility preserved: root stays `<output role=status aria-label="Run summary">`; outcome is conveyed by heading text + glyph, not colour alone; copy confirmation works for keyboard/AT via the live region (not hover/pointer only).
- Confirmed `bg-status-*-foreground` resolve — `--color-status-*-foreground` are registered in `@theme inline` (`src/App.css`), so Tailwind v4 emits the `bg-*` variants.
- Independent code review (subagent) found no high-confidence issues; its one note (`scope="colgroup"` → `scope="rowgroup"`) is applied.

## Test plan

- [x] `pnpm exec vitest run` — 530 passed, 0 failed (45 files)
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm lint:ci` (oxlint --deny-warnings) — exit 0
- [x] `pnpm fmt:check` (oxfmt) — exit 0
- [x] `pnpm knip` — exit 0
- [x] `pnpm build` (tsc && vite build) — exit 0
