### PR TITLE
feat(ledger): show the per-row Copied confirmation as a fading popup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -189,6 +189,32 @@
   animation: row-settle 700ms ease-out;
 }
 
+/* Per-row "Copied" confirmation: a small popup that pops in over the Copy button,
+   holds for a beat, then fades out on its own. The lifetime matches
+   COPIED_HINT_MS in Ledger.tsx, which removes the node as the fade completes. */
+@keyframes copied-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(4px) scale(0.96);
+  }
+  12% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-2px) scale(0.98);
+  }
+}
+
+.copied-popup {
+  animation: copied-pop 1500ms ease-out forwards;
+}
+
 /* "Picked up" affordance for the row being dragged: the row stays near-opaque so
    it reads as a solid card lifted off the list — the earlier 0.6 translucency
    ghosted the row and made the grab cue look weak on the dark table — and is

--- a/src/components/Ledger.test.tsx
+++ b/src/components/Ledger.test.tsx
@@ -398,6 +398,26 @@ describe("Ledger", () => {
       expect(within(cancelledRow).queryByText(/copied/i)).toBeNull();
     });
 
+    it("shows the Copied confirmation as a small popup anchored in the row, not morphed into the button", async () => {
+      vi.mocked(copyText).mockResolvedValue(undefined);
+      const { container } = render(<Ledger />);
+
+      const row = screen.getByText("out_1.zip").closest("tr") as HTMLElement;
+      const button = within(row).getByRole("button", { name: /copy/i });
+      await userEvent.click(button);
+      // Settle the async copy → state update before asserting on the popup.
+      await screen.findByText(/path was copied/i);
+
+      // The confirmation renders as a dedicated, absolutely-positioned popup that
+      // lives in the clicked row — not as text morphed into the Copy button.
+      const popup = container.querySelector(".copied-popup");
+      expect(popup).not.toBeNull();
+      expect(popup?.textContent).toMatch(/copied/i);
+      expect(popup?.className).toContain("absolute");
+      expect(row.contains(popup)).toBe(true);
+      expect(button.textContent ?? "").not.toMatch(/copied/i);
+    });
+
     it("surfaces an error when copying fails (and shows no affordance)", async () => {
       vi.mocked(copyText).mockRejectedValue(new Error("clipboard denied"));
       render(<Ledger />);

--- a/src/components/Ledger.tsx
+++ b/src/components/Ledger.tsx
@@ -11,8 +11,10 @@ import { copyText, openPath } from "@/lib/reveal";
 import { statusVisual, type TaskOutcome } from "@/lib/status";
 import { useJobStore } from "@/store/jobStore";
 
-// How long a row's "Copied" affordance lingers before it reverts to the Copy icon.
-const COPIED_HINT_MS = 2000;
+// How long the "Copied" popup stays before it fades out and is removed. Mirrors
+// the copied-pop animation duration in App.css so the node is dropped just as the
+// fade completes.
+const COPIED_HINT_MS = 1500;
 
 // Outcome groups render in action-first order: failures first so the rows a user
 // must act on lead; successes last.
@@ -52,8 +54,9 @@ interface LedgerRowProps {
   source: string;
   /** Best-effort produced size, or null when unknown. */
   size: string | null;
-  /** Whether this row is currently showing its transient "Copied" affordance. */
-  copied: boolean;
+  /** When non-null, this row shows its transient "Copied" popup. The nonce keys
+   *  the popup so a repeat copy on the same row replays the pop-in animation. */
+  copiedNonce: number | null;
   /** Copy the row's output path and raise the in-row confirmation. */
   onCopy: (taskId: number, outputPath: string) => void;
 }
@@ -64,15 +67,15 @@ interface LedgerRowProps {
  * The per-row status is conveyed by the enclosing outcome group, so the row
  * carries no status chip. Failed rows render their reason in place of the size.
  * Copy writes the row's intended absolute output path to the clipboard; even a
- * failed row exposes it so the path can still be pasted. On success the button
- * morphs to "Copied" in place.
+ * failed row exposes it so the path can still be pasted. On success a small
+ * "Copied" popup pops in over the button and fades out on its own.
  */
 function LedgerRow({
   index,
   result,
   source,
   size,
-  copied,
+  copiedNonce,
   onCopy,
 }: LedgerRowProps) {
   return (
@@ -101,24 +104,34 @@ function LedgerRow({
         )}
       </td>
 
-      {/* Per-row Copy action with an in-place "Copied" confirmation. */}
+      {/* Per-row Copy action with a transient "Copied" popup confirmation. */}
       <td className="py-2 pr-4">
-        <div className="flex justify-end">
+        <div className="relative flex justify-end">
           <Button
             variant="ghost"
             size="sm"
             aria-label={`Copy path of ${result.outputName}`}
             onClick={() => onCopy(result.taskId, result.outputPath)}
           >
-            {copied ? (
-              <>
-                <Check aria-hidden="true" />
-                Copied
-              </>
-            ) : (
-              <Copy aria-hidden="true" />
-            )}
+            <Copy aria-hidden="true" />
           </Button>
+
+          {/* Decorative pop-in confirmation anchored above the button; the polite
+              announcement for assistive tech is the sr-only <output> in Ledger.
+              Keyed by nonce so a repeat copy replays the fade animation. */}
+          {copiedNonce !== null && (
+            <span
+              key={copiedNonce}
+              aria-hidden="true"
+              className="copied-popup pointer-events-none absolute bottom-full right-0 z-20 mb-1 flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-md"
+            >
+              <Check
+                aria-hidden="true"
+                className="size-3.5 text-status-success-foreground"
+              />
+              Copied
+            </span>
+          )}
         </div>
       </td>
     </tr>
@@ -274,7 +287,9 @@ export function Ledger() {
                     result={result}
                     source={basename(items[index]?.path ?? "")}
                     size={sizeForTask(result.taskId, progress)}
-                    copied={copied?.taskId === result.taskId}
+                    copiedNonce={
+                      copied?.taskId === result.taskId ? copied.nonce : null
+                    }
                     onCopy={handleCopy}
                   />
                 ))}


### PR DESCRIPTION
## Summary

After a batch finishes, each Ledger row's Copy action confirmed the copy by morphing the button itself into `✓ Copied` for 2 s. This replaces that in-place morph with a small popup that pops in over the button, holds for a beat, and fades out on its own — the Copy button keeps its icon throughout. Presentation-only — no `bindings/*`, domain, or IPC change.

## Background / Motivation

- **The confirmation hijacked the button.** Clicking Copy swapped the icon for a `✓ Copied` label for 2 s, so the action's own affordance vanished while the hint was showing.
- **A persistent in-button label reads as a state change**, not a transient acknowledgement; the desired feel is a brief popup that appears and then disappears.

## Changes

### Anchored, fading "Copied" popup (`src/components/Ledger.tsx`)

- The Copy button now always renders the `Copy` icon. On success a decorative `aria-hidden` `<span class="copied-popup">` is rendered, absolutely positioned above the button (`bottom-full right-0 z-20`), styled as a small `bg-popover` chip with `✓` (`Check`, `text-status-success-foreground`) + "Copied".
- The `LedgerRow` prop changed from `copied: boolean` to `copiedNonce: number | null`; the popup is keyed by the nonce so a repeat copy on the same row replays the pop-in animation.
- `COPIED_HINT_MS` shortened `2000 → 1500` ms to match the fade and read as a brief acknowledgement; the `{ taskId, nonce }` state + dismiss timeout still drive removal.
- The polite assistive-tech announcement is unchanged: the `sr-only` `aria-live="polite"` `<output>` keyed by nonce still announces **"Path was copied"**.

### Pop-in / fade-out animation (`src/App.css`)

- New `@keyframes copied-pop` (fade + rise in over `0–12%`, hold to `70%`, fade + rise out to `100%`) and a `.copied-popup` rule running it for `1500ms ... forwards`, mirroring `COPIED_HINT_MS` so the node is dropped as the fade completes.

### Tests (`src/components/Ledger.test.tsx`)

- Added a test asserting the confirmation renders as a dedicated `.copied-popup` element anchored in the clicked row (absolutely positioned), with the Copy button itself no longer morphed into the "Copied" label. The existing copy tests (revert-after-timeout, single-row scoping, error path, `sr-only` announcement) stay green.

## Verification

- After a batch finishes, click a row's Copy button: a small `✓ Copied` chip appears just above the button and fades out within ~1.5 s while the button keeps its Copy icon. In the DOM, look for `span.copied-popup` inside the clicked `<tr>`.
- Screen readers still hear "Path was copied" via the `sr-only` `output[aria-live="polite"]`.

## Test plan

- [x] `pnpm test` (vitest) — 531 passed (45 files)
- [x] `pnpm lint:ci` (oxlint --deny-warnings) — exit 0
- [x] `pnpm fmt:check` (oxfmt) — exit 0
- [x] `pnpm knip` — exit 0
- [x] `pnpm build` (tsc && vite build) — exit 0
