### PR TITLE
feat(ui): relabel output mode toggle and emphasize it

### DIFF
--- a/src/components/LeftRail.tsx
+++ b/src/components/LeftRail.tsx
@@ -75,7 +75,10 @@ export function LeftRail() {
         className="flex min-h-full w-full flex-col gap-4 px-5 py-4"
         style={{ minWidth: `${DEFAULT_RAIL_WIDTH}px` }}
       >
-        <div className="flex items-center justify-between">
+        {/* OUTPUT header stacks the section label above the full-width mode
+          toggle. The toggle is the primary "what do you want to do?" choice, so
+          it gets its own prominent row rather than sharing the header line. */}
+        <div className="flex flex-col gap-2">
           <span className="text-xs font-medium uppercase tracking-[0.96px] text-muted-foreground">
             OUTPUT
           </span>

--- a/src/components/OutputModeToggle.test.tsx
+++ b/src/components/OutputModeToggle.test.tsx
@@ -6,15 +6,15 @@ import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 afterEach(() => resetJobStore());
 
-it("renders .zip selected by default and switches to Folder on click", () => {
+it("renders zip selected by default and switches to folder on click", () => {
   const spy = vi
     .spyOn(useJobStore.getState(), "setOutputMode")
     .mockResolvedValue();
 
   render(<OutputModeToggle />);
 
-  const zip = screen.getByRole("radio", { name: /\.zip file/i });
-  const folder = screen.getByRole("radio", { name: /folder/i });
+  const zip = screen.getByRole("radio", { name: /rebundle to zip file/i });
+  const folder = screen.getByRole("radio", { name: /unarchive to folders/i });
   expect(zip.getAttribute("aria-checked")).toBe("true");
   expect(folder.getAttribute("aria-checked")).toBe("false");
 

--- a/src/components/OutputModeToggle.tsx
+++ b/src/components/OutputModeToggle.tsx
@@ -3,8 +3,8 @@ import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
 const OPTIONS: { value: OutputMode; label: string }[] = [
-  { value: "zip", label: ".zip file" },
-  { value: "folder", label: "Folder" },
+  { value: "zip", label: "Rebundle to zip file(s)" },
+  { value: "folder", label: "Unarchive to folders" },
 ];
 
 /**
@@ -12,6 +12,11 @@ const OPTIONS: { value: OutputMode; label: string }[] = [
  * mode pushes it into the store, which drives the conditional OUTPUT fields and
  * the hero path. Two `role="radio"` buttons in a `role="radiogroup"` keep it
  * keyboard- and screen-reader-friendly.
+ *
+ * This is the primary "what do you want to do?" decision, so it is deliberately
+ * the loudest control in the rail: a full-width pair of equal segments, larger
+ * type, and a strong brand-primary fill on the selected segment — heavier than
+ * the subtler `bg-accent` segmented controls elsewhere (e.g. ConflictPolicySelect).
  */
 export function OutputModeToggle() {
   const mode = useJobStore((s) => s.draft.outputMode);
@@ -25,7 +30,7 @@ export function OutputModeToggle() {
     <div
       role="radiogroup"
       aria-label="Output as"
-      className="inline-flex overflow-hidden rounded-md border border-border"
+      className="flex w-full overflow-hidden rounded-md border border-border shadow-sm"
     >
       {OPTIONS.map((opt) => {
         const selected = opt.value === mode;
@@ -41,10 +46,10 @@ export function OutputModeToggle() {
             aria-checked={selected}
             onClick={() => choose(opt.value)}
             className={cn(
-              "px-2.5 py-1 text-xs font-medium",
+              "flex-1 px-3 py-2 text-sm font-semibold transition-colors",
               selected
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground",
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
             )}
           >
             {opt.label}


### PR DESCRIPTION
## Summary

The OUTPUT mode toggle (the segmented control at the top of the left rail) used terse, asymmetric labels — `.zip file` vs `Folder` — that named the *artifact* rather than the *action*, and it sat as a small accessory tucked to the right of the `OUTPUT` header with the same subdued `bg-accent` treatment as every other segmented control. This relabels it to action-first text and promotes it to the loudest control in the rail. Presentation-only — no `bindings/*`, domain, or IPC change.

## Background / Motivation

- **The labels named the output, not the choice.** `.zip file` / `Folder` described what comes out, not what the run does; a user scanning the rail had to infer that "Folder" meant *unarchive* and ".zip file" meant *rebundle*.
- **The toggle was visually under-weighted.** It shared the `OUTPUT` header line as a small `inline-flex` control with the subtle `bg-accent` selected fill — indistinguishable in prominence from the secondary `If exists` (`ConflictPolicySelect`) toggle below it, even though picking the mode is the primary "what do you want to do?" decision.
- **Longer, clearer labels no longer fit inline.** The new action-first labels are too wide to share the header row within the fixed 320px rail.

## Changes

### Action-first labels (`src/components/OutputModeToggle.tsx`)

- `.zip file` → **Rebundle to zip file(s)** and `Folder` → **Unarchive to folders**, so each segment names the action taken rather than the resulting artifact. The `zip` / `folder` store values and `aria-label="Output as"` radiogroup are unchanged.

### Emphasis treatment (`src/components/OutputModeToggle.tsx`)

- Container switched from `inline-flex` to a full-width `flex w-full ... shadow-sm`; each segment is `flex-1` so the pair splits the rail into two equal, prominent halves.
- Larger type and padding (`px-3 py-2 text-sm font-semibold`, up from `px-2.5 py-1 text-xs font-medium`).
- The selected segment now uses the strong brand fill `bg-primary text-primary-foreground` instead of the subtle `bg-accent text-accent-foreground`; the unselected segment gains a `hover:bg-accent/60 hover:text-foreground` affordance and a `transition-colors`. This makes it deliberately heavier than the sibling `ConflictPolicySelect`, which keeps the subdued `bg-accent` styling.

### Header relayout (`src/components/LeftRail.tsx`)

- The OUTPUT header changes from `flex items-center justify-between` (label + toggle on one line) to `flex flex-col gap-2`, stacking the `OUTPUT` label above the now full-width toggle on its own row.

### Tests (`src/components/OutputModeToggle.test.tsx`)

- Updated the radio name matchers to the new labels (`/rebundle to zip file/i`, `/unarchive to folders/i`); the default-selection and switch-on-click assertions are otherwise unchanged. `LeftRail.test.tsx` is untouched — it targets the radiogroup by its unchanged `Output as` label.

## Verification

- In the running app, the OUTPUT section shows a full-width two-segment toggle labelled **Rebundle to zip file(s)** / **Unarchive to folders**, with the active segment filled in the solid primary brand colour and standing out above the smaller `If exists` toggle.
- In the DOM, the radiogroup is `div[role="radiogroup"][aria-label="Output as"]` with `flex w-full`; the selected `button[role="radio"][aria-checked="true"]` carries `bg-primary text-primary-foreground`.

## Test plan

- [x] `pnpm exec vitest run` — 530 passed (45 files)
- [x] `pnpm exec tsc` — exit 0
- [x] `pnpm build` (tsc && vite build) — exit 0
- [x] `pnpm lint:ci` (oxlint --deny-warnings) — exit 0
- [x] `pnpm fmt:check` (oxfmt) — exit 0
- [x] `pnpm knip` — exit 0
