### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,7 +3770,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async_zip",
  "lalrpop",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.8.0"
+version = "0.9.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Bump version `0.8.0` → `0.9.0` across all version-tracked files ahead of the v0.9.0 release.

- `package.json`
- `src-tauri/Cargo.toml`
- `crates/core/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `Cargo.lock` (`simple-archiver` + `simple-archiver-core`)

`cargo metadata --locked` exits 0. Diff is exactly the six version lines.

## Release contents (v0.8.0..main)

OUTPUT panel result-led redesign and Ledger completion polish:
- Group completion results by outcome, failures first (#160)
- Per-row "Copied" confirmation as a fading popup (#160)
- Output mode toggle relabeled and turned into a sliding pill with icons (#162)
- ResultPreview card + shared choose-output-dir hook; output rail re-laid around it (#163)
- Condense Name and Start number into one Naming row; folder-kind preview names match the backend `output_stem` (#163)