### PR TITLE
feat(site): publish landing page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy site to GitHub Pages
+
+# Publishes the static landing page under site/ to GitHub Pages.
+# Pages' "deploy from a branch" source only allows / or /docs, so the
+# site/ folder is published via the GitHub Actions Pages pipeline instead.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; cancel in-progress runs for new pushes.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What

Adds a static landing page under `site/` and a GitHub Actions workflow that publishes it to GitHub Pages.

- `site/index.html` — self-contained landing page (the Starshield-reviewed Simple Archiver page). All images/video are embedded as `data:` URIs; no external local asset references.
- `.github/workflows/deploy-pages.yml` — deploys the `site/` folder to GitHub Pages on push to `main`.

## Why a workflow instead of branch/folder source

GitHub Pages' "deploy from a branch" source only allows `/` (root) or `/docs`. To honor the requested `site/` folder verbatim, the page is published through the GitHub Actions Pages pipeline (`configure-pages` + `upload-pages-artifact` + `deploy-pages`).

## After merge

- Repo Pages source must be set to **GitHub Actions** (one-time; can be done via `gh api`).
- On merge to `main`, the workflow runs and the page becomes available at `https://yasuflatland-lf.github.io/simple-archiver/`.

## Notes

- `site/index.html` is a vendored static asset (not hand-written code), which is why this PR's diff size is dominated by the embedded media.