### PR TITLE
feat(ui): relabel output mode pills as Re-archive / Unarchive

### DIFF
--- a/src/components/OutputModeToggle.test.tsx
+++ b/src/components/OutputModeToggle.test.tsx
@@ -10,20 +10,20 @@ it("renders the radiogroup with short pill labels, zip selected by default", () 
   render(<OutputModeToggle />);
 
   expect(screen.getByRole("radiogroup", { name: /output as/i })).toBeTruthy();
-  const zip = screen.getByRole("radio", { name: /zip files/i });
-  const folder = screen.getByRole("radio", { name: /folders/i });
+  const zip = screen.getByRole("radio", { name: /re-archive/i });
+  const folder = screen.getByRole("radio", { name: /unarchive/i });
   expect(zip.getAttribute("aria-checked")).toBe("true");
   expect(folder.getAttribute("aria-checked")).toBe("false");
   // The sliding thumb is decorative and present for the visual treatment.
   expect(screen.getByTestId("mode-thumb")).toBeTruthy();
 });
 
-it("calls setOutputMode('folder') when the Folders segment is clicked", () => {
+it("calls setOutputMode('folder') when the Unarchive segment is clicked", () => {
   const spy = vi
     .spyOn(useJobStore.getState(), "setOutputMode")
     .mockResolvedValue();
 
   render(<OutputModeToggle />);
-  fireEvent.click(screen.getByRole("radio", { name: /folders/i }));
+  fireEvent.click(screen.getByRole("radio", { name: /unarchive/i }));
   expect(spy).toHaveBeenCalledWith("folder");
 });

--- a/src/components/OutputModeToggle.tsx
+++ b/src/components/OutputModeToggle.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
 const OPTIONS: { value: OutputMode; label: string; Icon: LucideIcon }[] = [
-  { value: "zip", label: "Zip files", Icon: Package },
-  { value: "folder", label: "Folders", Icon: Folder },
+  { value: "zip", label: "Re-archive", Icon: Package },
+  { value: "folder", label: "Unarchive", Icon: Folder },
 ];
 
 /**


### PR DESCRIPTION
## Summary

The OUTPUT mode toggle pills read `Zip files` / `Folders` — names for the *output artifact* rather than the *action* each mode performs. This relabels them to the verb forms **Re-archive** / **Unarchive**, so each segment names what the run does to its items. Presentation-only — the `zip` / `folder` store values, the `Output as` radiogroup semantics, and all `bindings/*` / domain / IPC are unchanged.

## Background / Motivation

- **The pills named the output, not the action.** After the #163 result-led redesign the segments shortened to `Zip files` / `Folders`; a user scanning the rail still had to infer that `Folders` means *unarchive* (extract) and `Zip files` means *re-archive* (rebundle).
- **The design spec left the final wording open.** The OUTPUT-rail design spec recorded the pill label as an unresolved choice between short nouns (`Zip files` / `Folders`) and verbs (`Rebundle` / `Unarchive`); this PR settles it on the verb framing, symmetric and action-first.

## Changes

### Verb-form pill labels (`src/components/OutputModeToggle.tsx`)

- `Zip files` → **Re-archive** and `Folders` → **Unarchive** in the `OPTIONS` array. The `zip` / `folder` `OutputMode` values, the `Package` / `Folder` lucide icons, the sliding `data-testid="mode-thumb"`, and the `role="radiogroup"` (`aria-label="Output as"`) / `role="radio"` semantics are all unchanged — visible text only.

### Tests (`src/components/OutputModeToggle.test.tsx`)

- Radio-name matchers updated to the new labels (`/re-archive/i`, `/unarchive/i`) and the click-target description renamed to the `Unarchive` segment; the default-selection and `setOutputMode('folder')`-on-click assertions are otherwise unchanged. No other test references these labels.

## Verification

- In the running app, the OUTPUT rail's sliding pill shows two segments labelled **Re-archive** / **Unarchive**, with the navy thumb sliding under the selected one on change.
- In the DOM, the radiogroup is `div[role="radiogroup"][aria-label="Output as"]`; the two `button[role="radio"]` accessible names resolve to `Re-archive` and `Unarchive`, and the decorative thumb is `span[data-testid="mode-thumb"]`.

## Test plan

- [x] `pnpm test` (vitest) — 531 passed (45 files)
- [x] `pnpm lint:ci` (oxlint --deny-warnings) — exit 0
- [x] `pnpm fmt:check` (oxfmt) — exit 0
- [x] `pnpm build` (tsc && vite build) — exit 0
- [x] `pnpm knip` — exit 0
