### PR TITLE
fix(site): unify heading font across platforms

### DIFF
--- a/site/src/styles/index.css
+++ b/site/src/styles/index.css
@@ -24,9 +24,14 @@ body {
   margin: 0;
   background: #000;
   color: var(--ink);
+  /* Use a non-condensed neo-grotesque stack so headings render consistently
+     across platforms. The previous stack listed condensed faces first
+     ("D-DIN" / "Arial Narrow" / "DIN Condensed"); Windows resolved them to
+     Arial Narrow (squished) while macOS fell through to Helvetica Neue, so the
+     two platforms looked noticeably different. Helvetica Neue (macOS) and
+     Arial (Windows) are near-identical, keeping the headings in sync. */
   font-family:
-    "D-DIN", "Arial Narrow", "DIN Condensed", "Helvetica Neue", Arial,
-    "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+    "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: geometricPrecision;
 }


### PR DESCRIPTION
## Summary

The `site/` landing-page headings inherit the `body` font stack, whose leading fallbacks were condensed faces (`D-DIN` / `Arial Narrow` / `DIN Condensed`). None of those are bundled, so the two OSes diverged: Windows resolved the stack to **Arial Narrow** (squished display headings) while macOS fell through to **Helvetica Neue** (clean, full-width bold). This drops the condensed faces from the stack so both platforms land on Helvetica Neue / Arial and render the headings consistently. Presentation/CSS only — no Tauri app code or `site/` component is touched.

## Background / Motivation

- The `body` rule's `font-family` led with `"D-DIN", "Arial Narrow", "DIN Condensed"`, but **none of those fonts are bundled** (no `@font-face`), so each OS picked a different fallback.
- **Windows** ships Arial Narrow, so the display headings rendered condensed and visibly off-design.
- **macOS** lacks those condensed faces and fell through to `Helvetica Neue` — the intended clean full-width bold — so the Mac looked correct while Windows did not.
- Every heading (`h1/h2/h3`, `.logo`, `.eyebrow`, `.btn`, `.nav a`, …) sets only `font-weight: 900` and inherits `font-family` from `body`, so the single body stack drives the whole page's display typography.

## Changes

### Body font stack (`site/src/styles/index.css`)

- Removed the condensed leading fallbacks (`"D-DIN"`, `"Arial Narrow"`, `"DIN Condensed"`) from the `body` `font-family`. The stack is now `"Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif` — matching the `p` rule's neo-grotesque stack and preserving the Japanese fallbacks.
- macOS rendering is unchanged (already on Helvetica Neue); Windows now resolves to Arial, which is near-identical, so the headings stay in sync across platforms.
- Added an explanatory comment documenting why the condensed faces were dropped.

## Verification

- In the rendered page on Windows, the hero / overview / install display headings render full-width (Arial Bold), matching the macOS Helvetica Neue rendering instead of the previous condensed Arial Narrow.
- Inspecting any heading's computed `font-family` resolves to `"Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif` with no condensed face.

## Test plan

- [x] `pnpm -C site build` (tsc && vite build) — exit 0
- [x] `pnpm -C site test` (vitest) — exit 0
- [x] `pnpm -C site lint:ci` (oxlint --deny-warnings) — exit 0
- [x] `pnpm -C site fmt:check` (oxfmt) — exit 0
- [x] `pnpm -C site knip` — exit 0
- [ ] Visual: on Windows, the landing-page headings render full-width (not condensed) and match the macOS appearance.
