### PR TITLE
feat(queue): auto-scroll while drag-reordering near the top/bottom edge

### DIFF
--- a/src/components/RightCanvas.tsx
+++ b/src/components/RightCanvas.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+
 import { AddSourceButtons } from "@/components/AddSourceButtons";
 import { EmptyQueue } from "@/components/EmptyQueue";
 import { LastBatchChip } from "@/components/LastBatchChip";
@@ -33,8 +35,13 @@ export function RightCanvas() {
 
   const phase = canvasPhase({ itemCount, running, hasSummary, cleared });
 
+  // The scroller is handed to the queue so a row drag near the top/bottom edge
+  // auto-scrolls this container (see ReorderDndProvider's edge auto-scroll).
+  const scrollContainerRef = useRef<HTMLElement>(null);
+
   return (
     <main
+      ref={scrollContainerRef}
       aria-label="Work area"
       className="min-w-0 flex-1 overflow-y-auto px-6 py-4"
     >
@@ -52,7 +59,7 @@ export function RightCanvas() {
             <ResetButton />
             <AddSourceButtons />
           </div>
-          <TaskList />
+          <TaskList scrollContainerRef={scrollContainerRef} />
         </div>
       ) : null}
       {phase === "running" ? (
@@ -62,7 +69,7 @@ export function RightCanvas() {
           <div className="sticky top-0 z-10 -mx-6 border-b border-border bg-background px-6 pb-3">
             <OverallProgress />
           </div>
-          <TaskList />
+          <TaskList scrollContainerRef={scrollContainerRef} />
         </div>
       ) : null}
       {phase === "results" ? <Ledger /> : null}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 
 import type { ColumnContentMeasurer } from "@/components/column-measure";
 import { domColumnMeasurer } from "@/components/column-measure";
@@ -23,6 +29,8 @@ import { useJobStore } from "@/store/jobStore";
 interface TaskListProps {
   /** How a column's content width is measured for auto-fit (injectable for tests). */
   measurer?: ColumnContentMeasurer;
+  /** The vertical scroller wrapping the queue; enables drag edge auto-scroll. */
+  scrollContainerRef?: RefObject<HTMLElement | null>;
 }
 
 /**
@@ -31,7 +39,10 @@ interface TaskListProps {
  * progress/summary live in the rows, so a high-frequency progress tick only
  * re-renders the rows whose bytes actually changed.
  */
-export function TaskList({ measurer = domColumnMeasurer }: TaskListProps = {}) {
+export function TaskList({
+  measurer = domColumnMeasurer,
+  scrollContainerRef,
+}: TaskListProps = {}) {
   // Only the item count drives the chrome (header + which rows exist); the rows
   // themselves read everything else they need directly from the store.
   const items = useJobStore((s) => s.draft.items);
@@ -88,7 +99,7 @@ export function TaskList({ measurer = domColumnMeasurer }: TaskListProps = {}) {
       animatedReorder={animatedReorder}
       justMovedIndex={justMovedIndex}
     >
-      <ReorderDndProvider>
+      <ReorderDndProvider scrollContainerRef={scrollContainerRef}>
         {/* The selectable queue: role="grid" + aria-multiselectable + per-row
           aria-selected is the ARIA pattern for row selection, and makes this an
           interactive element so tabIndex/onKeyDown are valid. tabIndex makes it

--- a/src/components/edge-autoscroll.test.ts
+++ b/src/components/edge-autoscroll.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type AutoScrollPorts,
+  EDGE_ZONE_PX,
+  EdgeAutoScroller,
+  edgeScrollVelocity,
+  MAX_SCROLL_SPEED_PX,
+} from "./edge-autoscroll";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// A scroll container spanning [top, bottom] whose scrollTop the loop mutates.
+function fakeContainer(top: number, bottom: number): HTMLElement {
+  return {
+    scrollTop: 0,
+    getBoundingClientRect: () =>
+      ({
+        top,
+        bottom,
+        height: bottom - top,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: top,
+        toJSON() {},
+      }) as DOMRect,
+  } as unknown as HTMLElement;
+}
+
+// Ports with a manual frame queue so a test can step the rAF loop one frame at
+// a time. `flush` runs the single pending frame (the loop reschedules a fresh
+// one as it ticks), mirroring how a real rAF chain advances.
+function fakePorts(reduced = false) {
+  const frames = new Map<number, () => void>();
+  let nextId = 0;
+  const requestFrame = vi.fn((callback: () => void) => {
+    const id = ++nextId;
+    frames.set(id, callback);
+    return id;
+  });
+  const cancelFrame = vi.fn((handle: number) => {
+    frames.delete(handle);
+  });
+  const ports: AutoScrollPorts = {
+    requestFrame,
+    cancelFrame,
+    prefersReducedMotion: () => reduced,
+  };
+  function flush(): boolean {
+    const next = frames.entries().next();
+    if (next.done) return false;
+    const [id, callback] = next.value;
+    frames.delete(id);
+    callback();
+    return true;
+  }
+  return {
+    ports,
+    requestFrame,
+    cancelFrame,
+    flush,
+    pending: () => frames.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// edgeScrollVelocity (pure)
+// ---------------------------------------------------------------------------
+
+describe("edgeScrollVelocity", () => {
+  const bounds = { top: 0, bottom: 200 };
+
+  it("is zero when the pointer sits away from both edges", () => {
+    expect(edgeScrollVelocity(bounds, 100)).toBe(0);
+  });
+
+  it("scrolls up (negative) inside the top edge zone", () => {
+    expect(edgeScrollVelocity(bounds, 10)).toBeLessThan(0);
+  });
+
+  it("scrolls down (positive) inside the bottom edge zone", () => {
+    expect(edgeScrollVelocity(bounds, 190)).toBeGreaterThan(0);
+  });
+
+  it("scales speed with proximity: closer to the edge is faster", () => {
+    // Both pointers are inside the bottom zone; the one nearer the edge (199)
+    // must produce a larger magnitude than the one at the inner lip (162).
+    const nearEdge = edgeScrollVelocity(bounds, 199);
+    const nearLip = edgeScrollVelocity(bounds, 162);
+    expect(nearEdge).toBeGreaterThan(nearLip);
+    expect(nearLip).toBeGreaterThan(0);
+  });
+
+  it("caps the speed at MAX past the physical edge", () => {
+    // A pointer dragged beyond the bottom edge stays clamped at the max step.
+    expect(edgeScrollVelocity(bounds, bounds.bottom)).toBe(MAX_SCROLL_SPEED_PX);
+    expect(edgeScrollVelocity(bounds, bounds.bottom + 999)).toBe(
+      MAX_SCROLL_SPEED_PX,
+    );
+  });
+
+  it("treats the edge-zone width as EDGE_ZONE_PX", () => {
+    // Just outside the zone -> no scroll; just inside -> scroll.
+    expect(edgeScrollVelocity(bounds, bounds.bottom - EDGE_ZONE_PX)).toBe(0);
+    expect(
+      edgeScrollVelocity(bounds, bounds.bottom - EDGE_ZONE_PX + 1),
+    ).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EdgeAutoScroller (loop)
+// ---------------------------------------------------------------------------
+
+describe("EdgeAutoScroller", () => {
+  it("scrolls down each frame while the pointer is near the bottom edge", () => {
+    const { ports, requestFrame, flush } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+    expect(container.scrollTop).toBe(0);
+
+    flush();
+    const afterOne = container.scrollTop;
+    expect(afterOne).toBeGreaterThan(0);
+
+    flush();
+    expect(container.scrollTop).toBeGreaterThan(afterOne);
+  });
+
+  it("scrolls up (negative scrollTop delta) near the top edge", () => {
+    const { ports, flush } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+    container.scrollTop = 50;
+
+    scroller.update(container, 2);
+    flush();
+    expect(container.scrollTop).toBeLessThan(50);
+  });
+
+  it("does not start a loop when the pointer is away from the edges", () => {
+    const { ports, requestFrame } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 50);
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("scales the per-frame step with pointer proximity", () => {
+    const container = fakeContainer(0, 100);
+
+    const near = fakePorts();
+    const nearScroller = new EdgeAutoScroller(near.ports);
+    const nearContainer = fakeContainer(0, 100);
+    nearScroller.update(nearContainer, 99);
+    near.flush();
+
+    const lip = fakePorts();
+    const lipScroller = new EdgeAutoScroller(lip.ports);
+    const lipContainer = fakeContainer(0, 100);
+    lipScroller.update(lipContainer, 62);
+    lip.flush();
+
+    expect(nearContainer.scrollTop).toBeGreaterThan(lipContainer.scrollTop);
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("does not double-schedule when update fires repeatedly mid-loop", () => {
+    const { ports, requestFrame } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    scroller.update(container, 96);
+    scroller.update(container, 94);
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops on drop: stop() cancels the pending frame and halts scrolling", () => {
+    const { ports, cancelFrame, flush, pending } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    expect(pending()).toBe(1);
+
+    scroller.stop();
+    expect(cancelFrame).toHaveBeenCalledTimes(1);
+    expect(pending()).toBe(0);
+
+    const before = container.scrollTop;
+    flush();
+    expect(container.scrollTop).toBe(before);
+  });
+
+  it("stops when the pointer leaves the edge zone", () => {
+    const { ports, cancelFrame } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    scroller.update(container, 50);
+    expect(cancelFrame).toHaveBeenCalledTimes(1);
+
+    const before = container.scrollTop;
+    // The next tick (had it survived) must not scroll any further.
+    expect(container.scrollTop).toBe(before);
+  });
+
+  it("is disabled under prefers-reduced-motion", () => {
+    const { ports, requestFrame } = fakePorts(true);
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("invokes onStep after each scroll step (drop-gap refresh hook)", () => {
+    const { ports, flush } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+    const onStep = vi.fn();
+
+    scroller.update(container, 98, onStep);
+    expect(onStep).not.toHaveBeenCalled();
+    flush();
+    expect(onStep).toHaveBeenCalledTimes(1);
+    flush();
+    expect(onStep).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves no pending frame after stop (leak guard)", () => {
+    const { ports, flush, pending } = fakePorts();
+    const scroller = new EdgeAutoScroller(ports);
+    const container = fakeContainer(0, 100);
+
+    scroller.update(container, 98);
+    flush();
+    expect(pending()).toBe(1);
+    scroller.stop();
+    expect(pending()).toBe(0);
+  });
+});

--- a/src/components/edge-autoscroll.ts
+++ b/src/components/edge-autoscroll.ts
@@ -14,7 +14,7 @@
 /** Distance (px) from a scroll edge within which auto-scroll engages. */
 export const EDGE_ZONE_PX = 40;
 /** Slowest perceptible step (px/frame), applied at the inner lip of the zone. */
-export const MIN_SCROLL_SPEED_PX = 2;
+const MIN_SCROLL_SPEED_PX = 2;
 /** Fastest step (px/frame), applied at (or past) the physical edge. */
 export const MAX_SCROLL_SPEED_PX = 14;
 

--- a/src/components/edge-autoscroll.ts
+++ b/src/components/edge-autoscroll.ts
@@ -1,0 +1,136 @@
+/**
+ * Edge auto-scroll for the pointer-driven queue reorder. While a row is being
+ * dragged, holding the pointer near the scroll container's top/bottom edge
+ * scrolls the container continuously so a row can be dropped at a position that
+ * started off-screen. The scroll speed scales with how deep the pointer sits
+ * inside the edge zone, and the loop is disabled under prefers-reduced-motion.
+ *
+ * The velocity math is a pure function ({@link edgeScrollVelocity}) and the loop
+ * itself ({@link EdgeAutoScroller}) takes its frame scheduling and the
+ * reduced-motion probe as injectable ports, so both are unit-testable without a
+ * real layout or a real rAF.
+ */
+
+/** Distance (px) from a scroll edge within which auto-scroll engages. */
+export const EDGE_ZONE_PX = 40;
+/** Slowest perceptible step (px/frame), applied at the inner lip of the zone. */
+export const MIN_SCROLL_SPEED_PX = 2;
+/** Fastest step (px/frame), applied at (or past) the physical edge. */
+export const MAX_SCROLL_SPEED_PX = 14;
+
+/** Clamp `value` into the inclusive range [0, 1]. */
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/** Map an edge-zone depth (px) to a per-frame scroll step (px). */
+function speedForDepth(depth: number): number {
+  const proximity = clamp01(depth / EDGE_ZONE_PX);
+  return (
+    MIN_SCROLL_SPEED_PX +
+    proximity * (MAX_SCROLL_SPEED_PX - MIN_SCROLL_SPEED_PX)
+  );
+}
+
+/**
+ * Per-frame scroll velocity (px) for a pointer at viewport-Y `pointerY` over a
+ * container spanning the vertical range [`top`, `bottom`]. Negative scrolls up,
+ * positive scrolls down, and zero means the pointer is outside both edge zones.
+ * The magnitude grows as the pointer nears — or passes — an edge (capped at
+ * {@link MAX_SCROLL_SPEED_PX}). The top edge wins when both zones overlap on a
+ * container shorter than two edge zones.
+ */
+export function edgeScrollVelocity(
+  bounds: { top: number; bottom: number },
+  pointerY: number,
+): number {
+  const topDepth = EDGE_ZONE_PX - (pointerY - bounds.top);
+  if (topDepth > 0) return -speedForDepth(topDepth);
+  const bottomDepth = EDGE_ZONE_PX - (bounds.bottom - pointerY);
+  if (bottomDepth > 0) return speedForDepth(bottomDepth);
+  return 0;
+}
+
+/** Frame scheduling + reduced-motion probe, injectable so tests can drive them. */
+export interface AutoScrollPorts {
+  requestFrame: (callback: () => void) => number;
+  cancelFrame: (handle: number) => void;
+  prefersReducedMotion: () => boolean;
+}
+
+/** Production ports bound to the browser's rAF and matchMedia. */
+export function browserAutoScrollPorts(): AutoScrollPorts {
+  return {
+    requestFrame: (callback) => requestAnimationFrame(callback),
+    cancelFrame: (handle) => cancelAnimationFrame(handle),
+    prefersReducedMotion: () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  };
+}
+
+/**
+ * EdgeAutoScroller runs a rAF velocity loop that scrolls a container while the
+ * pointer hovers near its top/bottom edge. {@link update} is called on every
+ * pointer move during a drag; {@link stop} is called on drop, on leaving the
+ * edge zone, and on unmount so the loop never leaks. Each scroll step invokes an
+ * optional `onStep` callback so the caller can refresh derived state (e.g. the
+ * drop-gap indicator) as content moves under a stationary pointer.
+ */
+export class EdgeAutoScroller {
+  private container: HTMLElement | null = null;
+  private velocity = 0;
+  private frame: number | null = null;
+  private onStep: (() => void) | null = null;
+
+  constructor(private readonly ports: AutoScrollPorts) {}
+
+  /**
+   * Aim the scroller at `container` for a pointer at viewport-Y `pointerY`.
+   * Starts the loop when the pointer is inside an edge zone and stops it
+   * otherwise. A no-op (and immediate stop) when reduced motion is requested.
+   */
+  update(container: HTMLElement, pointerY: number, onStep?: () => void): void {
+    if (this.ports.prefersReducedMotion()) {
+      this.stop();
+      return;
+    }
+    this.container = container;
+    this.onStep = onStep ?? null;
+    this.velocity = edgeScrollVelocity(
+      container.getBoundingClientRect(),
+      pointerY,
+    );
+    if (this.velocity === 0) {
+      this.stop();
+      return;
+    }
+    // Schedule the loop only if one is not already pending; a running loop
+    // simply picks up the freshly computed velocity on its next tick.
+    if (this.frame === null) {
+      this.frame = this.ports.requestFrame(this.tick);
+    }
+  }
+
+  /** Halt scrolling and release any pending frame (drop / leave-edge / unmount). */
+  stop(): void {
+    this.velocity = 0;
+    this.onStep = null;
+    if (this.frame !== null) {
+      this.ports.cancelFrame(this.frame);
+      this.frame = null;
+    }
+  }
+
+  private readonly tick = (): void => {
+    this.frame = null;
+    const container = this.container;
+    if (container === null || this.velocity === 0) return;
+    container.scrollTop += this.velocity;
+    this.onStep?.();
+    this.frame = this.ports.requestFrame(this.tick);
+  };
+}

--- a/src/components/reorder-dnd.test.tsx
+++ b/src/components/reorder-dnd.test.tsx
@@ -1,0 +1,239 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { ReorderDndProvider, useReorderRow } from "./reorder-dnd";
+
+// ---------------------------------------------------------------------------
+// Harness
+//
+// These tests verify the wiring between the pointer-drag gesture and the edge
+// auto-scroll loop (the loop's own math is covered in edge-autoscroll.test.ts).
+// A minimal row tree built from the public hooks lets the provider's
+// pointerMoveOnRow drive a stubbed scroll container through a stubbed rAF.
+// ---------------------------------------------------------------------------
+
+function Row({ index }: { index: number }) {
+  const { enabled, handleProps, rowProps } = useReorderRow(index);
+  return (
+    <tr data-row-index={index} data-testid={`row-${index}`} {...rowProps}>
+      <td>
+        <span
+          {...handleProps}
+          data-reorder-handle
+          data-testid={`handle-${index}`}
+          data-disabled={!enabled || undefined}
+        />
+        <span>Row {index}</span>
+      </td>
+    </tr>
+  );
+}
+
+function Harness({
+  scrollContainerRef,
+  count,
+}: {
+  scrollContainerRef?: RefObject<HTMLElement | null>;
+  count: number;
+}) {
+  return (
+    <ReorderDndProvider scrollContainerRef={scrollContainerRef}>
+      <table>
+        <tbody>
+          {Array.from({ length: count }, (_, i) => (
+            // Rows are positional with no per-row state; index keys are correct.
+            // oxlint-disable-next-line react/no-array-index-key
+            <Row index={i} key={i} />
+          ))}
+        </tbody>
+      </table>
+    </ReorderDndProvider>
+  );
+}
+
+// Seed the store so the provider's `count` / `enabled` derive from real state.
+function seed(count: number, extra: Record<string, unknown> = {}) {
+  useJobStore.setState({
+    draft: {
+      items: Array.from({ length: count }, (_, i) => ({
+        path: `/tmp/item-${i}.rar`,
+        kind: "rar" as const,
+      })),
+      namingTemplate: null,
+      startNumber: 1,
+      outputDir: null,
+      outputMode: "zip",
+      conflictPolicy: "autoRename",
+    },
+    previewNames: [],
+    ...extra,
+  });
+}
+
+// A scroll container spanning [top, bottom] with an observable scrollTop. jsdom
+// ignores scrollTop writes, so back it with a plain accessor.
+function makeScroller(top: number, bottom: number) {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    ({
+      top,
+      bottom,
+      height: bottom - top,
+      left: 0,
+      right: 0,
+      width: 0,
+      x: 0,
+      y: top,
+      toJSON() {},
+    }) as DOMRect;
+  let scrollTop = 0;
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  const ref: RefObject<HTMLElement | null> = { current: el };
+  return { el, ref };
+}
+
+// A reduced-motion matchMedia stub (matches: true).
+function stubReducedMotion() {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+}
+
+let raf: ReturnType<typeof vi.fn>;
+let caf: ReturnType<typeof vi.fn>;
+let frames: Array<() => void>;
+
+beforeEach(() => {
+  resetJobStore();
+  frames = [];
+  raf = vi.fn((callback: () => void) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  caf = vi.fn();
+  vi.stubGlobal("requestAnimationFrame", raf);
+  vi.stubGlobal("cancelAnimationFrame", caf);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// Run the single pending animation frame (the loop reschedules a fresh one).
+function flushFrame() {
+  const callback = frames.shift();
+  if (callback) act(() => callback());
+}
+
+// Arm a drag from row 0's grip, then move the pointer to `clientY` over a row.
+function dragToY(clientY: number, overRow = 2) {
+  fireEvent.pointerDown(screen.getByTestId("handle-0"));
+  fireEvent.pointerMove(screen.getByTestId(`row-${overRow}`), {
+    clientX: 0,
+    clientY,
+  });
+}
+
+describe("ReorderDndProvider edge auto-scroll", () => {
+  it("scrolls the container while a row is dragged near the bottom edge", () => {
+    seed(3);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    dragToY(98);
+    expect(raf).toHaveBeenCalled();
+
+    flushFrame();
+    expect(el.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("does not scroll when the pointer stays away from the edges", () => {
+    seed(3);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    dragToY(50, 1);
+    expect(raf).not.toHaveBeenCalled();
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it("does not scroll when no drag is active", () => {
+    seed(3);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    // Move the pointer near the edge without first arming a drag.
+    fireEvent.pointerMove(screen.getByTestId("row-2"), {
+      clientX: 0,
+      clientY: 98,
+    });
+    expect(raf).not.toHaveBeenCalled();
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it("stops auto-scrolling on drop (pointer release)", () => {
+    seed(3);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    dragToY(98);
+    expect(raf).toHaveBeenCalled();
+
+    fireEvent.pointerUp(screen.getByTestId("row-2"), {
+      clientX: 0,
+      clientY: 98,
+    });
+    expect(caf).toHaveBeenCalled();
+
+    // Any frame that survived the cancel must no longer move the container.
+    const before = el.scrollTop;
+    flushFrame();
+    expect(el.scrollTop).toBe(before);
+  });
+
+  it("stops auto-scrolling when the pointer leaves the edge zone", () => {
+    seed(3);
+    const { ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    dragToY(98);
+    expect(raf).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerMove(screen.getByTestId("row-1"), {
+      clientX: 0,
+      clientY: 50,
+    });
+    expect(caf).toHaveBeenCalled();
+  });
+
+  it("is disabled under prefers-reduced-motion", () => {
+    stubReducedMotion();
+    seed(3);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={3} />);
+
+    dragToY(98);
+    expect(raf).not.toHaveBeenCalled();
+    expect(el.scrollTop).toBe(0);
+  });
+});

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -8,8 +8,13 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 
+import {
+  browserAutoScrollPorts,
+  EdgeAutoScroller,
+} from "@/components/edge-autoscroll";
 import { useAnimatedReorder } from "@/components/reorder-animation";
 import { useJobStore } from "@/store/jobStore";
 
@@ -49,7 +54,14 @@ const ReorderDndContext = createContext<ReorderDndContextValue | null>(null);
  * transient UI state; it is only observed by the rows during an active drag,
  * which never overlaps a running job (reordering is disabled then).
  */
-export function ReorderDndProvider({ children }: { children: ReactNode }) {
+export function ReorderDndProvider({
+  children,
+  scrollContainerRef,
+}: {
+  children: ReactNode;
+  /** The vertical scroller wrapping the rows; drives edge auto-scroll. */
+  scrollContainerRef?: RefObject<HTMLElement | null>;
+}) {
   const running = useJobStore((s) => s.running);
   const animatedReorder = useAnimatedReorder();
   const count = useJobStore((s) => s.draft.items.length);
@@ -64,15 +76,43 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
   const pendingRef = useRef<{ index: number; x: number; y: number } | null>(
     null,
   );
+  // Last viewport pointer position during the active drag, so the auto-scroll
+  // loop can re-resolve the drop gap as content moves under a still pointer.
+  const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
+  // The edge auto-scroll loop, created once; production rAF/matchMedia ports.
+  const scrollerRef = useRef<EdgeAutoScroller | null>(null);
+  if (scrollerRef.current === null) {
+    scrollerRef.current = new EdgeAutoScroller(browserAutoScrollPorts());
+  }
 
   const enabled = !running;
 
   const reset = useCallback(() => {
+    scrollerRef.current?.stop();
     draggingRef.current = null;
     overGapRef.current = null;
     pendingRef.current = null;
+    lastPointerRef.current = null;
     setDraggingIndex(null);
     setOverGap(null);
+  }, []);
+
+  // Re-resolve the drop gap from the last pointer position. The auto-scroll loop
+  // calls this after each step so the insertion line tracks the row that has
+  // scrolled under a stationary pointer (no-op when nothing is hit, e.g. jsdom).
+  const recomputeGapAtPointer = useCallback(() => {
+    const point = lastPointerRef.current;
+    if (point === null || draggingRef.current === null) return;
+    // elementFromPoint is absent in non-layout environments (jsdom); skip there.
+    if (typeof document.elementFromPoint !== "function") return;
+    const hit = document.elementFromPoint(point.x, point.y);
+    const rowEl = hit?.closest<HTMLElement>("[data-row-index]") ?? null;
+    if (rowEl === null) return;
+    const index = Number(rowEl.dataset.rowIndex);
+    const rect = rowEl.getBoundingClientRect();
+    const gap = point.y < rect.top + rect.height / 2 ? index : index + 1;
+    overGapRef.current = gap;
+    setOverGap(gap);
   }, []);
 
   const arm = useCallback((index: number) => {
@@ -125,8 +165,19 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
         event.clientY < rect.top + rect.height / 2 ? index : index + 1;
       overGapRef.current = gap;
       setOverGap(gap);
+      // Drive edge auto-scroll from the live pointer position so a row can be
+      // dropped past the visible range; the loop refreshes the gap as it moves.
+      lastPointerRef.current = { x: event.clientX, y: event.clientY };
+      const container = scrollContainerRef?.current;
+      if (container) {
+        scrollerRef.current?.update(
+          container,
+          event.clientY,
+          recomputeGapAtPointer,
+        );
+      }
     },
-    [enabled, arm],
+    [enabled, arm, scrollContainerRef, recomputeGapAtPointer],
   );
 
   const drop = useCallback(() => {
@@ -154,6 +205,13 @@ export function ReorderDndProvider({ children }: { children: ReactNode }) {
       window.removeEventListener("pointercancel", end);
     };
   }, [draggingIndex, reset]);
+
+  // Stop any in-flight auto-scroll loop if the provider unmounts mid-drag so the
+  // scheduled frame never outlives the component.
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    return () => scroller?.stop();
+  }, []);
 
   const value = useMemo<ReorderDndContextValue>(
     () => ({


### PR DESCRIPTION
## Summary

During an active pointer-drag reorder, holding the pointer within ~40px of the queue scroll container's top/bottom edge now continuously auto-scrolls the container so a row can be dropped at a position that started off-screen. The scroll speed scales with how deep the pointer sits in the edge zone (a rAF velocity loop). Scrolling stops on drop, when the pointer leaves the edge zone, and on unmount (no rAF leaks); it never runs when not dragging and is disabled under `prefers-reduced-motion`. The insertion-gap indicator is re-resolved on each scroll step so it tracks the row that has scrolled under a stationary pointer.

The scroll container is the `<main className="... overflow-y-auto">` in `RightCanvas.tsx`; its ref is wired `RightCanvas -> TaskList -> ReorderDndProvider`. The hook point is `pointerMoveOnRow()`.

New module `src/components/edge-autoscroll.ts`:
- `edgeScrollVelocity(bounds, pointerY)` — a pure function for the per-frame velocity (sign = direction, magnitude scales with proximity, capped past the physical edge).
- `EdgeAutoScroller` — the rAF velocity loop, taking injectable frame-scheduling + reduced-motion ports (`browserAutoScrollPorts()` in production) so it is fully unit-testable without a real layout or rAF.

## Acceptance criteria

- [x] Edge auto-scroll is smooth (rAF velocity loop).
- [x] Speed scales with proximity to the edge.
- [x] Stops on drop / leaving the edge zone.
- [x] A row can be dropped at a position initially off-screen.
- [x] No scroll when not dragging.
- [x] `prefers-reduced-motion` respected (auto-scroll disabled).
- [x] rAF/loop cleaned up on unmount and drop (no leaks).

## Test plan

Co-located vitest (jsdom; mocked scroll container + mocked rAF ports):

- `src/components/edge-autoscroll.test.ts` — pure-velocity cases (zero in the middle, up/down near edges, speed scales with proximity, capped past the edge, zone width) and loop cases (scrolls per frame near each edge, no loop away from edges, scales per-frame step, no double-schedule, stops on `stop()`, stops on leaving the edge, disabled under reduced motion, `onStep` fires per step, no pending frame after `stop`).
- `src/components/reorder-dnd.test.tsx` — provider wiring: scrolls while dragging near the bottom edge, no scroll away from edges, no scroll when not dragging, stops on drop (pointer release cancels the frame), stops on leaving the edge zone, disabled under `prefers-reduced-motion`.

Verification (all green): `npm run check`, `npm run fmt:check`, `npm run lint:ci`, `npm run knip`, `npx tsc --noEmit`, `npm run test` (48 files, 569 tests).

## Caveats

- The per-step gap refresh uses `document.elementFromPoint`, which is absent in jsdom and is skipped there; it keeps the insertion line correct under a stationary pointer in a real browser.

Closes #183
