### PR TITLE
fix(core): poll cancellation token inside archiver/extractor work loops

### DIFF
--- a/crates/core/src/application/extract_context.rs
+++ b/crates/core/src/application/extract_context.rs
@@ -1,0 +1,76 @@
+//! Per-extraction cancellation context handed to the `Extractor`.
+
+use tokio_util::sync::CancellationToken;
+
+/// Context passed to `Extractor::extract`, carrying a read-only view of the
+/// job's cancellation signal so a long per-archive extraction can abort
+/// promptly between entries instead of running the current file to completion.
+///
+/// Mirrors [`crate::application::compress_context::CompressContext`]'s
+/// cancellation design: an extractor may only OBSERVE cancellation via
+/// [`ExtractContext::is_cancelled`]. Exposing the token itself would let an
+/// adapter call `.cancel()` and tear down the whole job, so only this read-only
+/// predicate is exposed.
+///
+/// `Clone` so the synchronous `unrar` adapter can move an observer into its
+/// `spawn_blocking` closure and poll it between entries.
+#[derive(Clone)]
+pub struct ExtractContext {
+    cancellation_token: CancellationToken,
+}
+
+impl ExtractContext {
+    /// Build a context observing `cancellation_token`.
+    pub(crate) fn new(cancellation_token: CancellationToken) -> Self {
+        Self { cancellation_token }
+    }
+
+    /// Build a context not tied to any job; the token is freshly created and
+    /// never cancelled, so `is_cancelled()` is always `false`. Used by callers
+    /// (and tests) that extract outside a cancellable run.
+    pub fn detached() -> Self {
+        Self::new(CancellationToken::new())
+    }
+
+    /// Observe whether the owning job has been cancelled. Extractors may only
+    /// OBSERVE cancellation — exposing the token itself would let an adapter
+    /// call `.cancel()` and tear down the whole job, so only this read-only
+    /// predicate is exposed.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation_token.is_cancelled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detached_is_never_cancelled() {
+        let ctx = ExtractContext::detached();
+        assert!(!ctx.is_cancelled());
+    }
+
+    #[test]
+    fn is_cancelled_observes_the_shared_token() {
+        let token = CancellationToken::new();
+        let ctx = ExtractContext::new(token.clone());
+
+        assert!(!ctx.is_cancelled());
+        token.cancel();
+        assert!(ctx.is_cancelled());
+    }
+
+    #[test]
+    fn a_clone_observes_the_same_cancellation() {
+        // The `unrar` adapter clones the context into its blocking closure, so a
+        // clone MUST see a cancel fired through the original token.
+        let token = CancellationToken::new();
+        let ctx = ExtractContext::new(token.clone());
+        let moved = ctx.clone();
+
+        assert!(!moved.is_cancelled());
+        token.cancel();
+        assert!(moved.is_cancelled());
+    }
+}

--- a/crates/core/src/application/format_registry.rs
+++ b/crates/core/src/application/format_registry.rs
@@ -6,6 +6,7 @@
 //! the temp directory lives exactly as long as the value is held by the caller
 //! (the engine drops it after compression).
 
+use crate::application::extract_context::ExtractContext;
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
 use crate::domain::source_item::SourceItem;
 use std::path::{Path, PathBuf};
@@ -52,12 +53,18 @@ impl<E: Extractor> FormatRegistry<E> {
     }
 
     /// Resolve `source` into a `Prepared` directory, extracting rar/zip files.
-    pub(crate) async fn prepare(&self, source: &SourceItem) -> Result<Prepared, ExtractError> {
+    /// `ctx` carries the cancellation observation handed to the extractor so a
+    /// long extraction can abort mid-stream.
+    pub(crate) async fn prepare(
+        &self,
+        source: &SourceItem,
+        ctx: &ExtractContext,
+    ) -> Result<Prepared, ExtractError> {
         match source {
             SourceItem::Folder(path) => Ok(Prepared::Folder(path.clone())),
-            SourceItem::RarFile(path) | SourceItem::ZipFile(path) => {
-                Ok(Prepared::Extracted(self.extractor.extract(path).await?))
-            }
+            SourceItem::RarFile(path) | SourceItem::ZipFile(path) => Ok(Prepared::Extracted(
+                self.extractor.extract(path, ctx).await?,
+            )),
         }
     }
 }
@@ -93,7 +100,11 @@ mod tests {
         }
     }
     impl Extractor for FakeExtractor {
-        async fn extract(&self, src: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+        async fn extract(
+            &self,
+            src: &Path,
+            _ctx: &ExtractContext,
+        ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let name = src.file_name().unwrap().to_string_lossy().to_string();
             if self.fail_names.contains(&name) {
@@ -112,7 +123,10 @@ mod tests {
         let registry = FormatRegistry::new(Arc::new(fake));
 
         let prepared = registry
-            .prepare(&SourceItem::Folder(PathBuf::from("/some/dir")))
+            .prepare(
+                &SourceItem::Folder(PathBuf::from("/some/dir")),
+                &ExtractContext::detached(),
+            )
             .await
             .expect("folder prepares");
 
@@ -127,7 +141,10 @@ mod tests {
         let registry = FormatRegistry::new(Arc::new(fake));
 
         let prepared = registry
-            .prepare(&SourceItem::RarFile(PathBuf::from("a.rar")))
+            .prepare(
+                &SourceItem::RarFile(PathBuf::from("a.rar")),
+                &ExtractContext::detached(),
+            )
             .await
             .expect("rar prepares");
 
@@ -146,7 +163,10 @@ mod tests {
         let registry = FormatRegistry::new(Arc::new(fake));
 
         let result = registry
-            .prepare(&SourceItem::RarFile(PathBuf::from("bad.rar")))
+            .prepare(
+                &SourceItem::RarFile(PathBuf::from("bad.rar")),
+                &ExtractContext::detached(),
+            )
             .await;
 
         assert!(matches!(result, Err(ExtractError::Backend(_))));
@@ -159,7 +179,10 @@ mod tests {
         let registry = FormatRegistry::new(Arc::new(fake));
 
         let prepared = registry
-            .prepare(&SourceItem::ZipFile(PathBuf::from("a.zip")))
+            .prepare(
+                &SourceItem::ZipFile(PathBuf::from("a.zip")),
+                &ExtractContext::detached(),
+            )
             .await
             .expect("zip prepares");
 
@@ -169,5 +192,43 @@ mod tests {
             "prepared dir should be a real directory"
         );
         assert!(matches!(prepared, Prepared::Extracted(_)));
+    }
+
+    /// A fake extractor that observes the context and aborts as `Cancelled` when
+    /// the token is already tripped — proving the cancellation observation
+    /// threads through `prepare` into the extractor.
+    struct CancelObservingExtractor;
+    impl Extractor for CancelObservingExtractor {
+        async fn extract(
+            &self,
+            _src: &Path,
+            ctx: &ExtractContext,
+        ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+            if ctx.is_cancelled() {
+                return Err(ExtractError::Cancelled);
+            }
+            Ok(Box::new(FakeTree {
+                dir: tempfile::tempdir().unwrap(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn prepare_threads_cancellation_into_the_extractor() {
+        let registry = FormatRegistry::new(Arc::new(CancelObservingExtractor));
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+
+        let result = registry
+            .prepare(
+                &SourceItem::ZipFile(PathBuf::from("a.zip")),
+                &ExtractContext::new(token),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ExtractError::Cancelled)),
+            "a cancelled context must surface as ExtractError::Cancelled"
+        );
     }
 }

--- a/crates/core/src/application/mod.rs
+++ b/crates/core/src/application/mod.rs
@@ -4,6 +4,7 @@
 pub mod compress_context;
 #[cfg(not(loom))]
 pub mod eta_estimator;
+pub mod extract_context;
 #[cfg(not(loom))]
 pub mod format_registry;
 #[cfg(loom)]

--- a/crates/core/src/application/ports.rs
+++ b/crates/core/src/application/ports.rs
@@ -7,6 +7,7 @@
 //! via the `CancellationToken` carried by `CompressContext`.
 
 use crate::application::compress_context::CompressContext;
+use crate::application::extract_context::ExtractContext;
 use crate::domain::conflict_policy::ConflictPolicy;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -66,10 +67,11 @@ pub trait Clock: Send + Sync {
 ///
 /// `Backend` carries a stringified message from the underlying extraction library
 /// (e.g. `unrar` or `async_zip`) so the port stays decoupled from any specific
-/// extraction backend. There is no `Cancelled`
-/// variant: extraction is not interrupted mid-stream in the MVP — cancellation is
-/// observed *before* extraction starts (in the engine) and the temp directory is
-/// always reclaimed by [`ExtractedTree`]'s drop.
+/// extraction backend. `Cancelled` is returned when the caller cancels via the
+/// [`ExtractContext`] carried into [`Extractor::extract`]: the work loop polls
+/// the token between entries and aborts the current archive promptly. The
+/// partially-extracted temp directory is always reclaimed by [`ExtractedTree`]'s
+/// drop (the guard is never returned on a cancelled extraction).
 #[derive(Debug, thiserror::Error)]
 pub enum ExtractError {
     /// Filesystem I/O failed while creating the temp dir or writing entries.
@@ -79,6 +81,10 @@ pub enum ExtractError {
     /// rar or zip, etc.).
     #[error("extract error: {0}")]
     Backend(String),
+    /// The extraction was cancelled by the caller (observed mid-stream via the
+    /// [`ExtractContext`] token between entries).
+    #[error("cancelled")]
+    Cancelled,
 }
 
 /// A handle to an extracted directory tree.
@@ -100,9 +106,17 @@ pub trait Extractor: Send + Sync {
     /// Extract every entry of `src_archive` (a rar or zip archive) into a new temp
     /// directory and return a guard whose `path()` holds the extracted tree;
     /// dropping it removes the dir.
+    ///
+    /// `ctx` carries a read-only cancellation observation: the implementation
+    /// MUST poll [`ExtractContext::is_cancelled`] between entries and return
+    /// [`ExtractError::Cancelled`] when it trips, so a long extraction aborts
+    /// promptly instead of running the current archive to completion. On a
+    /// cancelled (or otherwise failed) extraction no guard is returned, so the
+    /// partially-written temp directory is reclaimed by its `Drop`.
     fn extract(
         &self,
         src_archive: &Path,
+        ctx: &ExtractContext,
     ) -> impl Future<Output = Result<Box<dyn ExtractedTree>, ExtractError>> + Send;
 }
 

--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -11,8 +11,11 @@ use tokio_util::sync::CancellationToken;
 
 use crate::application::compress_context::{CompressContext, TaskProgressReport};
 use crate::application::eta_estimator::{EtaTracker, ETA_WINDOW};
+use crate::application::extract_context::ExtractContext;
 use crate::application::format_registry::{FormatRegistry, Prepared};
-use crate::application::ports::{ArchiveError, Archiver, Clock, Extractor, PlaceError, Placer};
+use crate::application::ports::{
+    ArchiveError, Archiver, Clock, ExtractError, Extractor, PlaceError, Placer,
+};
 use crate::application::progress::ProgressSink;
 use crate::application::progress_aggregator::{Aggregator, JobSummary, WorkerMsg};
 use crate::domain::archive_job::ArchiveJob;
@@ -218,7 +221,7 @@ async fn run_one<A: Archiver, E: Extractor, P: Placer>(
     if cancel_before_start(&item, &tx, &cancellation_token) {
         return;
     }
-    let Some(prepared) = extract_phase(&item, registry, &tx).await else {
+    let Some(prepared) = extract_phase(&item, registry, &tx, &cancellation_token).await else {
         return;
     };
     // `StartCompressing` doubles as "start writing output" for both modes so the
@@ -280,12 +283,16 @@ fn cancel_before_start(
 }
 
 /// Emits `StartExtracting` for sources that require extraction (folders skip it),
-/// then resolves the source to a prepared directory. On extract failure, emits
-/// `Fail` and returns `None` so the caller early-returns.
+/// then resolves the source to a prepared directory. The cancellation token is
+/// handed to the extractor (via `ExtractContext`) so a long extraction can abort
+/// mid-stream: a cancelled extraction emits `Cancel` (the task is marked
+/// cancelled, NOT failed); any other extract failure emits `Fail`. Either way it
+/// returns `None` so the caller early-returns and no partial output is written.
 async fn extract_phase<E: Extractor>(
     item: &WorkItem,
     registry: &FormatRegistry<E>,
     tx: &mpsc::UnboundedSender<WorkerMsg>,
+    cancellation_token: &CancellationToken,
 ) -> Option<Prepared> {
     // rar/zip files extract first; folders compress directly. Emit the extraction
     // status only for sources that actually extract, so the task walks the legal
@@ -297,8 +304,17 @@ async fn extract_phase<E: Extractor>(
         });
     }
 
-    match registry.prepare(&item.source).await {
+    let ctx = ExtractContext::new(cancellation_token.clone());
+    match registry.prepare(&item.source, &ctx).await {
         Ok(prepared) => Some(prepared),
+        // A mid-extraction cancel is terminal-cancelled, not a failure.
+        Err(ExtractError::Cancelled) => {
+            let _ = tx.send(WorkerMsg::Status {
+                task: item.task,
+                event: TaskEvent::Cancel,
+            });
+            None
+        }
         Err(e) => {
             let _ = tx.send(WorkerMsg::Status {
                 task: item.task,
@@ -440,7 +456,11 @@ mod tests {
         }
     }
     impl Extractor for FakeExtractor {
-        async fn extract(&self, src: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+        async fn extract(
+            &self,
+            src: &Path,
+            _ctx: &ExtractContext,
+        ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let name = src.file_name().unwrap().to_string_lossy().to_string();
             if self.fail_names.contains(&name) {
@@ -768,6 +788,78 @@ mod tests {
         );
         assert_eq!(summary.succeeded, vec![ids[0]]);
         assert!(summary.failed.is_empty());
+    }
+
+    /// A fake extractor that fires an externally-owned token from inside
+    /// `extract` (simulating a cancel landing partway through a long extraction),
+    /// then re-checks `ctx.is_cancelled()` to return `Cancelled` — proving the
+    /// live token threads through run_one -> ExtractContext -> extractor via
+    /// `ctx`, NOT via the engine's pre-start checkpoint.
+    struct LiveCancelExtractor {
+        token: CancellationToken,
+    }
+    impl Extractor for LiveCancelExtractor {
+        async fn extract(
+            &self,
+            _src: &Path,
+            ctx: &ExtractContext,
+        ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+            // Simulate an external cancel landing mid-extraction.
+            self.token.cancel();
+            // Observe cancellation ONLY through the context the engine wired up.
+            if ctx.is_cancelled() {
+                return Err(ExtractError::Cancelled);
+            }
+            Ok(Box::new(FakeTree {
+                dir: tempfile::tempdir().unwrap(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn live_token_fired_mid_extraction_cancels_task_via_ctx() {
+        // A single rar task: the engine's pre-start checkpoint sees an un-fired
+        // token (so extraction starts), then the extractor fires the token
+        // mid-stream and reads it back through `ctx`, ending the task as
+        // cancelled — NOT failed — and never reaching compression.
+        let job = ArchiveJob::plan(
+            vec![SourceItem::RarFile(PathBuf::from("a.rar"))],
+            NamingRule::parse("f{n}").unwrap(),
+            OutputDirectory::new(PathBuf::from("/out")),
+        )
+        .unwrap();
+        let ids: Vec<TaskId> = job.tasks().iter().map(|t| t.id()).collect();
+        let token = CancellationToken::new();
+        let archiver = Arc::new(FakeArchiver::new());
+        let calls = archiver.call_count();
+        let engine = RunArchiveJob::new(
+            archiver,
+            Arc::new(LiveCancelExtractor {
+                token: token.clone(),
+            }),
+            Arc::new(FakePlacer::new()),
+            nz(2),
+        );
+        let sink = RecordingSink::default();
+        let clock = FixedClock(Instant::now());
+
+        let summary = engine
+            .execute_with_cancellation(job, &clock, &sink, token)
+            .await;
+
+        // The in-progress extraction that observed the live token via `ctx` ends
+        // cancelled, the archiver is never reached, and nothing is compressed.
+        assert_eq!(summary.cancelled, ids);
+        assert!(
+            summary.failed.is_empty(),
+            "a cancelled extraction is not a failure"
+        );
+        assert!(summary.succeeded.is_empty());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "compression must not run after a cancelled extraction"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/infrastructure/archive_extractor.rs
+++ b/crates/core/src/infrastructure/archive_extractor.rs
@@ -3,6 +3,7 @@
 //! other (or missing) extension fails with a `Backend` error. The match is
 //! ASCII-case-insensitive so `.ZIP`/`.Rar` are accepted.
 
+use crate::application::extract_context::ExtractContext;
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
 use crate::domain::archive_format::ArchiveFormat;
 use crate::infrastructure::unrar_extractor::UnrarExtractor;
@@ -24,14 +25,18 @@ impl ArchiveExtractor {
 }
 
 impl Extractor for ArchiveExtractor {
-    async fn extract(&self, src_archive: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+    async fn extract(
+        &self,
+        src_archive: &Path,
+        ctx: &ExtractContext,
+    ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
         match src_archive
             .extension()
             .and_then(|e| e.to_str())
             .and_then(ArchiveFormat::from_extension)
         {
-            Some(ArchiveFormat::Rar) => self.rar.extract(src_archive).await,
-            Some(ArchiveFormat::Zip) => self.zip.extract(src_archive).await,
+            Some(ArchiveFormat::Rar) => self.rar.extract(src_archive, ctx).await,
+            Some(ArchiveFormat::Zip) => self.zip.extract(src_archive, ctx).await,
             None => Err(ExtractError::Backend(format!(
                 "unsupported archive: {}",
                 src_archive.display()
@@ -68,7 +73,7 @@ mod tests {
         let (_dir, path) = zip_in_tempdir(&[("a.txt", b"alpha")]);
 
         let tree = ArchiveExtractor::new()
-            .extract(&path)
+            .extract(&path, &ExtractContext::detached())
             .await
             .expect("zip route should succeed");
 
@@ -89,7 +94,7 @@ mod tests {
         writer.finish().expect("finalize zip");
 
         let tree = ArchiveExtractor::new()
-            .extract(&path)
+            .extract(&path, &ExtractContext::detached())
             .await
             .expect("uppercase .ZIP should route to zip adapter");
         let contents = std::fs::read(tree.path().join("a.txt")).expect("extracted file");
@@ -102,7 +107,9 @@ mod tests {
         let path = dir.path().join("foo.txt");
         std::fs::write(&path, b"plain text").expect("write file");
 
-        let result = ArchiveExtractor::new().extract(&path).await;
+        let result = ArchiveExtractor::new()
+            .extract(&path, &ExtractContext::detached())
+            .await;
         let kind = result.map(|_| "ok");
         match kind {
             Err(ExtractError::Backend(ref msg)) => {
@@ -121,7 +128,9 @@ mod tests {
         let path = dir.path().join("archive");
         std::fs::write(&path, b"whatever").expect("write file");
 
-        let result = ArchiveExtractor::new().extract(&path).await;
+        let result = ArchiveExtractor::new()
+            .extract(&path, &ExtractContext::detached())
+            .await;
         let kind = result.map(|_| "ok");
         match kind {
             Err(ExtractError::Backend(ref msg)) => {

--- a/crates/core/src/infrastructure/unrar_extractor.rs
+++ b/crates/core/src/infrastructure/unrar_extractor.rs
@@ -3,6 +3,7 @@
 //! runs on `tokio::task::spawn_blocking`. Extraction target is a fresh
 //! `TempWorkspace`, returned as a boxed `ExtractedTree` guard.
 
+use crate::application::extract_context::ExtractContext;
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
 use crate::infrastructure::temp_workspace::TempWorkspace;
 use std::path::Path;
@@ -20,8 +21,17 @@ impl UnrarExtractor {
 }
 
 impl Extractor for UnrarExtractor {
-    async fn extract(&self, src_rar: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+    async fn extract(
+        &self,
+        src_rar: &Path,
+        ctx: &ExtractContext,
+    ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
         let src = src_rar.to_path_buf();
+        // The blocking extraction polls a cancellation OBSERVER moved into the
+        // closure: `ExtractContext` is `Clone` and only exposes `is_cancelled()`,
+        // so the off-runtime worker can abort between entries without the ability
+        // to cancel the whole job.
+        let ctx = ctx.clone();
         // `unrar` is blocking and CPU/IO-bound; run it off the async runtime.
         let workspace =
             tokio::task::spawn_blocking(move || -> Result<TempWorkspace, ExtractError> {
@@ -38,6 +48,12 @@ impl Extractor for UnrarExtractor {
                     .read_header()
                     .map_err(|e| ExtractError::Backend(e.to_string()))?
                 {
+                    // Poll the token between entries so a long rar extraction aborts
+                    // promptly. Returning `Err` drops `workspace`, removing the
+                    // partially-extracted temp directory (no half-written tree).
+                    if ctx.is_cancelled() {
+                        return Err(ExtractError::Cancelled);
+                    }
                     archive = if header.entry().is_file() {
                         header
                             .extract_with_base(&dest)
@@ -61,6 +77,13 @@ impl Extractor for UnrarExtractor {
 mod tests {
     use super::*;
     use std::io::Write;
+    use tokio_util::sync::CancellationToken;
+
+    /// The committed RAR5 fixture (shared with the integration smoke test): a
+    /// single top-level `hello world.txt` = "hello world".
+    fn fixture() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.rar")
+    }
 
     #[tokio::test]
     async fn non_rar_input_fails_with_backend_error() {
@@ -71,7 +94,9 @@ mod tests {
             .expect("write bytes");
 
         let extractor = UnrarExtractor::new();
-        let result = extractor.extract(tmp.path()).await;
+        let result = extractor
+            .extract(tmp.path(), &ExtractContext::detached())
+            .await;
 
         // `Result` itself is not `Debug` (its `Ok` payload is a `dyn ExtractedTree`
         // trait object), so map it to a `Debug`-able marker before asserting.
@@ -79,6 +104,26 @@ mod tests {
         assert!(
             matches!(kind, Err(ExtractError::Backend(_))),
             "expected Backend error, got {kind:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_extraction_with_cancelled_error() {
+        // An already-cancelled context against the real fixture: the per-entry
+        // poll inside the blocking work loop trips before the file is extracted,
+        // so extraction returns `Cancelled` (and the temp dir is reclaimed on the
+        // early-return drop). The only path to this error is the in-loop
+        // `is_cancelled()` check, proving the unrar loop polls the token.
+        let token = CancellationToken::new();
+        token.cancel();
+        let ctx = ExtractContext::new(token);
+
+        let result = UnrarExtractor::new().extract(&fixture(), &ctx).await;
+
+        let kind = result.map(|_| "ok");
+        assert!(
+            matches!(kind, Err(ExtractError::Cancelled)),
+            "a cancelled extraction must return ExtractError::Cancelled, got {kind:?}"
         );
     }
 }

--- a/crates/core/src/infrastructure/zip_extractor.rs
+++ b/crates/core/src/infrastructure/zip_extractor.rs
@@ -7,6 +7,7 @@
 //! zip-slip guard: any entry whose path escapes the workspace (via `..`, an
 //! absolute root, or a Windows drive/UNC prefix) rejects the whole extraction.
 
+use crate::application::extract_context::ExtractContext;
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
 use crate::infrastructure::path_utils::{classified_components, PathPart};
 use crate::infrastructure::temp_workspace::TempWorkspace;
@@ -25,7 +26,11 @@ impl ZipExtractor {
 }
 
 impl Extractor for ZipExtractor {
-    async fn extract(&self, src_archive: &Path) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+    async fn extract(
+        &self,
+        src_archive: &Path,
+        ctx: &ExtractContext,
+    ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
         let workspace = TempWorkspace::new()?; // io::Error -> ExtractError::Io
 
         // Open the archive with tokio and wrap in a buffered reader: the seek
@@ -40,6 +45,14 @@ impl Extractor for ZipExtractor {
 
         let count = reader.file().entries().len();
         for i in 0..count {
+            // Poll the cancellation token between entries so a long extraction
+            // aborts promptly instead of running the whole archive to completion.
+            // Returning `Err` drops `workspace`, removing the partially-extracted
+            // temp directory — no half-written tree is left behind.
+            if ctx.is_cancelled() {
+                return Err(ExtractError::Cancelled);
+            }
+
             // Read the metadata into OWNED values FIRST so the immutable borrow of
             // `reader.file()` is released before the `&mut self` entry reader call.
             let (is_dir, name) = {
@@ -163,7 +176,7 @@ mod tests {
         let zip = make_zip(&[("hello.txt", b"hi"), ("nested/world.txt", b"world")]);
 
         let tree = ZipExtractor::new()
-            .extract(zip.path())
+            .extract(zip.path(), &ExtractContext::detached())
             .await
             .expect("extraction should succeed");
 
@@ -180,7 +193,7 @@ mod tests {
         let zip = make_zip_with_dir();
 
         let tree = ZipExtractor::new()
-            .extract(zip.path())
+            .extract(zip.path(), &ExtractContext::detached())
             .await
             .expect("extraction should succeed");
 
@@ -201,7 +214,9 @@ mod tests {
         // bytes are written outside the extraction tree.
         let zip = make_zip(&[("../escape.txt", b"pwned")]);
 
-        let result = ZipExtractor::new().extract(zip.path()).await;
+        let result = ZipExtractor::new()
+            .extract(zip.path(), &ExtractContext::detached())
+            .await;
         let kind = result.map(|_| "ok");
         match kind {
             Err(ExtractError::Backend(ref msg)) => {
@@ -227,7 +242,9 @@ mod tests {
         let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
         tmp.write_all(b"not a zip").expect("write bytes");
 
-        let result = ZipExtractor::new().extract(tmp.path()).await;
+        let result = ZipExtractor::new()
+            .extract(tmp.path(), &ExtractContext::detached())
+            .await;
         let kind = result.map(|_| "ok");
         assert!(
             matches!(kind, Err(ExtractError::Backend(_))),
@@ -258,7 +275,9 @@ mod tests {
             .expect("write encrypted entry bytes");
         writer.finish().expect("finalize zip");
 
-        let result = ZipExtractor::new().extract(tmp.path()).await;
+        let result = ZipExtractor::new()
+            .extract(tmp.path(), &ExtractContext::detached())
+            .await;
         let kind = result.map(|_| "ok");
         assert!(
             matches!(kind, Err(ExtractError::Backend(_))),
@@ -273,7 +292,7 @@ mod tests {
         let zip = make_zip(&[]);
 
         let tree = ZipExtractor::new()
-            .extract(zip.path())
+            .extract(zip.path(), &ExtractContext::detached())
             .await
             .expect("empty zip should extract successfully");
 
@@ -283,6 +302,51 @@ mod tests {
         assert!(
             entries.next().is_none(),
             "an empty zip must extract to an empty directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_extraction_with_cancelled_error() {
+        // A multi-entry zip with an already-cancelled context: the per-entry poll
+        // trips inside the work loop, so extraction returns `Cancelled` instead
+        // of running the whole archive to completion. The only way this error can
+        // arise is the in-loop `is_cancelled()` check, so it proves the loop polls
+        // the token between entries.
+        let zip = make_zip(&[("a.txt", b"alpha"), ("b.txt", b"beta"), ("c.txt", b"gamma")]);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let ctx = ExtractContext::new(token);
+
+        let result = ZipExtractor::new().extract(zip.path(), &ctx).await;
+        let kind = result.map(|_| "ok");
+        assert!(
+            matches!(kind, Err(ExtractError::Cancelled)),
+            "a cancelled extraction must return ExtractError::Cancelled, got {kind:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_leaves_no_extracted_files_behind() {
+        // On cancel the extractor returns `Err` WITHOUT handing back the tree
+        // guard, so the partially-built `TempWorkspace` is dropped and its temp
+        // directory (with any bytes written so far) is removed by RAII. We cannot
+        // name that internal temp dir, but we can assert no extracted entry leaked
+        // into the input zip's own parent directory (the same check the zip-slip
+        // test uses for "nothing escaped the tree").
+        let zip = make_zip(&[("a.txt", b"alpha"), ("b.txt", b"beta")]);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let ctx = ExtractContext::new(token);
+
+        let result = ZipExtractor::new().extract(zip.path(), &ctx).await;
+        assert!(matches!(result.map(|_| "ok"), Err(ExtractError::Cancelled)));
+
+        let parent = zip.path().parent().expect("temp parent");
+        assert!(
+            !parent.join("a.txt").exists() && !parent.join("b.txt").exists(),
+            "a cancelled extraction must not leave extracted files outside its tree"
         );
     }
 }

--- a/crates/core/tests/unrar_extractor_smoke.rs
+++ b/crates/core/tests/unrar_extractor_smoke.rs
@@ -1,6 +1,7 @@
 #![cfg(not(loom))]
 //! Integration smoke test for the real `unrar` adapter against a committed fixture.
 
+use simple_archiver_core::application::extract_context::ExtractContext;
 use simple_archiver_core::application::ports::Extractor;
 use simple_archiver_core::infrastructure::unrar_extractor::UnrarExtractor;
 use std::path::Path;
@@ -13,7 +14,7 @@ fn fixture() -> std::path::PathBuf {
 async fn extracts_fixture_into_a_temp_directory() {
     let extractor = UnrarExtractor::new();
     let tree = extractor
-        .extract(&fixture())
+        .extract(&fixture(), &ExtractContext::detached())
         .await
         .expect("extraction succeeds");
 
@@ -29,7 +30,7 @@ async fn temp_directory_is_removed_when_tree_is_dropped() {
     let extractor = UnrarExtractor::new();
     let path = {
         let tree = extractor
-            .extract(&fixture())
+            .extract(&fixture(), &ExtractContext::detached())
             .await
             .expect("extraction succeeds");
         tree.path().to_path_buf()


### PR DESCRIPTION
## Summary

On Windows, pressing Cancel did not stop a running batch promptly: the
`CancellationToken` was only checked at `cancel_before_start()` (before
extraction) and between compression entries via `CompressContext::is_cancelled()`.
A long per-file **extraction** never polled the token, so an in-progress archive
ran to completion before the cancel was observed.

This PR threads a read-only cancellation observation into the `Extractor` port
and polls it inside the extractor work loops, so an in-progress file aborts
promptly:

- New `application::extract_context::ExtractContext` mirrors `CompressContext`'s
  design: an extractor may only **observe** cancellation via `is_cancelled()`;
  the token itself is never exposed (so an adapter cannot `.cancel()` the whole
  job). It is `Clone` so the synchronous `unrar` adapter can move an observer
  into its `spawn_blocking` closure.
- New `ExtractError::Cancelled` variant.
- `ZipExtractor` and `UnrarExtractor` poll the token **between entries** and
  return `Cancelled`; `ArchiveExtractor` and `FormatRegistry` thread the context
  through.
- The engine (`run_archive_job`) maps a cancelled extraction to
  `TaskEvent::Cancel` — the task is marked **cancelled, not failed**.
- Compression already polled per-entry; no behavior change there.
- No partial/half-written output remains: a cancelled extraction never returns
  the tree guard, so the partially-written `TempWorkspace` is reclaimed by
  `Drop`; the compression cleanup path (`remove_partial_output`) is unchanged.

## Acceptance criteria

- [x] Poll the `CancellationToken` inside the extractor work loops (between
      entries) so an in-progress file aborts promptly.
- [x] Interrupted tasks are marked **cancelled**, not failed.
- [x] No partial/corrupt output remains after a mid-run cancel (extraction temp
      dir reclaimed on drop; compression partial output removed).
- [x] Respect layer boundaries — `domain` stays pure; cancellation observation
      lives behind the ports.
- [x] No library swaps; diff focused (9 files, ~400 insertions).

## Test plan

Deterministic, cross-platform (no real Windows required):

- `run_archive_job::live_token_fired_mid_extraction_cancels_task_via_ctx` — a
  token fired from inside `extract` and read back through `ctx` ends the task as
  **cancelled** (not failed) and never reaches compression.
- `run_archive_job::live_token_fired_mid_run_cancels_in_progress_task_via_ctx`
  (existing) — the mid-**compression** counterpart.
- `zip_extractor::cancellation_aborts_extraction_with_cancelled_error` and
  `unrar_extractor::cancellation_aborts_extraction_with_cancelled_error` — the
  real work loops poll the token and return `Cancelled`.
- `zip_extractor::cancellation_leaves_no_extracted_files_behind` and
  `zip_archiver::cancels_after_a_write_removes_the_partial_output` (existing) —
  no partial/corrupt output remains.
- `format_registry::prepare_threads_cancellation_into_the_extractor` and
  `extract_context::*` — the observation threads end-to-end and is read-only.

Verification (all green):

```
cargo fmt --check -p simple-archiver-core
cargo clippy -p simple-archiver-core --all-targets --all-features -- -D warnings
cargo nextest run -p simple-archiver-core   # 252 passed, 0 skipped
```

## Caveats

The "~1s on Windows" timing criterion cannot be measured on this Linux/WSL host,
so the token-polling logic and prompt-abort behavior are verified
deterministically via tests rather than by timing a real Windows run. Per task
instructions, `src-tauri` (which needs system webkit libs and already has the
cancel wiring) was not built; all `cargo` commands were scoped to
`simple-archiver-core`.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
