### PR TITLE
fix(queue): resync grouped move on partial failure and guard decompose

### DIFF
--- a/crates/core/src/infrastructure/temp_workspace.rs
+++ b/crates/core/src/infrastructure/temp_workspace.rs
@@ -54,6 +54,34 @@ mod tests {
     }
 
     #[test]
+    fn drop_removes_a_populated_directory() {
+        // The "no half-written tree" guarantee on a cancelled or failed
+        // extraction relies on RAII removing the temp dir *with its contents*:
+        // both extractors return `Err` without handing back the guard, so a
+        // partially-written workspace is reclaimed by this `Drop`. Write a nested
+        // file and a top-level file to mimic a half-written extraction, then prove
+        // the whole tree is gone after the workspace drops.
+        let (root, nested, top) = {
+            let ws = TempWorkspace::new().expect("create temp workspace");
+            let nested_dir = ws.path().join("a").join("b");
+            std::fs::create_dir_all(&nested_dir).expect("create nested dirs");
+            let nested = nested_dir.join("deep.txt");
+            std::fs::write(&nested, b"partial").expect("write nested file");
+            let top = ws.path().join("top.txt");
+            std::fs::write(&top, b"partial").expect("write top file");
+            assert!(
+                nested.exists() && top.exists(),
+                "files written into the tree"
+            );
+            (ws.path().to_path_buf(), nested, top)
+        };
+        assert!(
+            !root.exists() && !nested.exists() && !top.exists(),
+            "a populated temp dir (a partially-written tree) must be removed on drop"
+        );
+    }
+
+    #[test]
     fn extracted_tree_path_matches_inherent_path() {
         let ws = TempWorkspace::new().expect("create temp workspace");
         let via_trait: &dyn ExtractedTree = &ws;

--- a/src/components/reorder-animation.test.tsx
+++ b/src/components/reorder-animation.test.tsx
@@ -1,0 +1,161 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
+
+// Mock the command wrappers so the store actions the hook drives resolve without
+// a Tauri backend. Each reorder returns a fresh snapshot so the post-move
+// `draft !== before` reference check in animateMove sees a real change.
+vi.mock("@/lib/archive", () => ({
+  addItems: vi.fn(),
+  reorder: vi.fn(),
+  removeItem: vi.fn(),
+  setNamingRule: vi.fn(),
+  setStartNumber: vi.fn(),
+  setOutputDir: vi.fn(),
+  setOutputMode: vi.fn(),
+  setConflictPolicy: vi.fn(),
+  clearItems: vi.fn(),
+  runJob: vi.fn(),
+  cancelJob: vi.fn(),
+  previewOutputName: vi.fn(),
+  subscribeProgress: vi.fn(),
+}));
+vi.mock("@/lib/output-dir-default", () => ({ persistOutputDir: vi.fn() }));
+
+import * as archive from "@/lib/archive";
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { useReorderAnimation } from "./reorder-animation";
+
+const mockArchive = vi.mocked(archive);
+
+function makeDraft(count: number): DraftSnapshot {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      path: `/tmp/item-${i}.rar`,
+      kind: "rar" as const,
+    })),
+    namingTemplate: null,
+    startNumber: 1,
+    outputDir: null,
+    outputMode: "zip",
+    conflictPolicy: "autoRename",
+  };
+}
+
+// Render the hook with a throwaway container. jsdom has no layout, so the FLIP
+// measurement reads zero rects and Element.animate is absent — both are guarded
+// in the hook — leaving the store mutation, the live announce, and the settle
+// flag (the behavior under test) to run normally.
+function renderAnimation() {
+  const containerRef = { current: document.createElement("div") };
+  return renderHook(() => useReorderAnimation(containerRef));
+}
+
+// Strip the zero-width-space the hook appends to force a live-region re-announce.
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+function announced(message: string): string {
+  return message.split(ZERO_WIDTH_SPACE).join("");
+}
+
+beforeEach(() => {
+  resetJobStore();
+  vi.clearAllMocks();
+  // A fresh object per call so the store commits a draft distinct from `before`.
+  mockArchive.reorder.mockImplementation(() => Promise.resolve(makeDraft(4)));
+  mockArchive.previewOutputName.mockResolvedValue("x.zip");
+});
+
+describe("useReorderAnimation grouped moves", () => {
+  it("announces the moved count and shows no single-row settle flash", async () => {
+    useJobStore.setState({
+      draft: makeDraft(4),
+      selectedIndices: [1, 2],
+      selectionAnchor: 1,
+    });
+    const { result } = renderAnimation();
+
+    await act(async () => {
+      await result.current.animatedMoveSelected("down");
+    });
+
+    // The whole block shifted down one slot via a single backend reorder.
+    expect(mockArchive.reorder).toHaveBeenCalledWith(3, 1);
+    // A grouped move announces only the count (the preserved selection highlight
+    // marks where the block went) and flags no single landing row.
+    expect(announced(result.current.liveMessage)).toBe("Moved 2 items");
+    expect(result.current.justMovedIndex).toBeNull();
+  });
+
+  it("relocates the whole selection on a drag drop and announces the count", async () => {
+    useJobStore.setState({
+      draft: makeDraft(5),
+      selectedIndices: [1, 3],
+      selectionAnchor: 1,
+    });
+    const { result } = renderAnimation();
+
+    await act(async () => {
+      await result.current.animatedMoveSelectedTo(5);
+    });
+
+    // The selection is gathered into a block at the bottom of the queue.
+    expect(mockArchive.reorder.mock.calls).toEqual([
+      [2, 1],
+      [4, 2],
+    ]);
+    expect(announced(result.current.liveMessage)).toBe("Moved 2 items");
+    expect(result.current.justMovedIndex).toBeNull();
+  });
+
+  it("suppresses the store call and the announce on a clamped no-op", async () => {
+    // A selection already flush with the top edge yields an identity permutation,
+    // so animateMove returns before applying: no backend reorder, no announce.
+    useJobStore.setState({
+      draft: makeDraft(4),
+      selectedIndices: [0, 1],
+      selectionAnchor: 0,
+    });
+    const { result } = renderAnimation();
+
+    await act(async () => {
+      await result.current.animatedMoveSelected("up");
+    });
+
+    expect(mockArchive.reorder).not.toHaveBeenCalled();
+    expect(result.current.liveMessage).toBe("");
+    expect(result.current.justMovedIndex).toBeNull();
+  });
+});
+
+describe("useReorderAnimation single-row reorder", () => {
+  it("flags the landing row and announces its 1-based position", async () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+    mockArchive.reorder.mockImplementation(() => Promise.resolve(makeDraft(3)));
+    const { result } = renderAnimation();
+
+    await act(async () => {
+      await result.current.animatedReorder(0, 2);
+    });
+
+    expect(mockArchive.reorder).toHaveBeenCalledWith(0, 2);
+    // A single move flags its landing row (to) for the settle highlight and
+    // announces the moved item at its new 1-based position.
+    expect(result.current.justMovedIndex).toBe(2);
+    expect(announced(result.current.liveMessage)).toContain("position 3");
+  });
+
+  it("is a no-op when from === to", async () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+    const { result } = renderAnimation();
+
+    await act(async () => {
+      await result.current.animatedReorder(1, 1);
+    });
+
+    expect(mockArchive.reorder).not.toHaveBeenCalled();
+    expect(result.current.justMovedIndex).toBeNull();
+    expect(result.current.liveMessage).toBe("");
+  });
+});

--- a/src/components/reorder-dnd.test.tsx
+++ b/src/components/reorder-dnd.test.tsx
@@ -2,9 +2,31 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Mock the command wrappers so a drop can route through the store actions (which
+// the drop fires) without a Tauri backend. previewOutputName resolves to
+// undefined by default, which is enough for recomputePreviews to settle.
+vi.mock("@/lib/archive", () => ({
+  addItems: vi.fn(),
+  reorder: vi.fn(),
+  removeItem: vi.fn(),
+  setNamingRule: vi.fn(),
+  setStartNumber: vi.fn(),
+  setOutputDir: vi.fn(),
+  setOutputMode: vi.fn(),
+  setConflictPolicy: vi.fn(),
+  clearItems: vi.fn(),
+  runJob: vi.fn(),
+  cancelJob: vi.fn(),
+  previewOutputName: vi.fn(),
+  subscribeProgress: vi.fn(),
+}));
+
+import * as archive from "@/lib/archive";
 import { resetJobStore, useJobStore } from "@/store/jobStore";
 
 import { ReorderDndProvider, useReorderRow } from "./reorder-dnd";
+
+const mockArchive = vi.mocked(archive);
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -54,20 +76,25 @@ function Harness({
   );
 }
 
+// A draft snapshot with `count` rar items and a null template.
+function draftSnapshot(count: number) {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      path: `/tmp/item-${i}.rar`,
+      kind: "rar" as const,
+    })),
+    namingTemplate: null,
+    startNumber: 1,
+    outputDir: null,
+    outputMode: "zip" as const,
+    conflictPolicy: "autoRename" as const,
+  };
+}
+
 // Seed the store so the provider's `count` / `enabled` derive from real state.
 function seed(count: number, extra: Record<string, unknown> = {}) {
   useJobStore.setState({
-    draft: {
-      items: Array.from({ length: count }, (_, i) => ({
-        path: `/tmp/item-${i}.rar`,
-        kind: "rar" as const,
-      })),
-      namingTemplate: null,
-      startNumber: 1,
-      outputDir: null,
-      outputMode: "zip",
-      conflictPolicy: "autoRename",
-    },
+    draft: draftSnapshot(count),
     previewNames: [],
     ...extra,
   });
@@ -124,6 +151,11 @@ let frames: Array<() => void>;
 
 beforeEach(() => {
   resetJobStore();
+  vi.clearAllMocks();
+  // A drop fires store.reorder, which commits the returned snapshot; default it to
+  // a valid draft (so it never becomes undefined) and let previews resolve.
+  mockArchive.reorder.mockResolvedValue(draftSnapshot(5));
+  mockArchive.previewOutputName.mockResolvedValue("x.zip");
   frames = [];
   raf = vi.fn((callback: () => void) => {
     frames.push(callback);
@@ -137,7 +169,19 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  // jsdom does not define elementFromPoint; remove any per-test stub so it does
+  // not leak the "function exists" branch into tests that rely on its absence.
+  delete (document as { elementFromPoint?: unknown }).elementFromPoint;
 });
+
+// Stub document.elementFromPoint (absent in jsdom, so assign rather than spy):
+// `resolve` picks the element under the pointer, letting a test model a row that
+// has scrolled under a stationary pointer.
+function stubElementFromPoint(resolve: () => Element | null) {
+  (
+    document as { elementFromPoint?: (x: number, y: number) => Element | null }
+  ).elementFromPoint = () => resolve();
+}
 
 // Run the single pending animation frame (the loop reschedules a fresh one).
 function flushFrame() {
@@ -235,5 +279,79 @@ describe("ReorderDndProvider edge auto-scroll", () => {
     dragToY(98);
     expect(raf).not.toHaveBeenCalled();
     expect(el.scrollTop).toBe(0);
+  });
+});
+
+describe("ReorderDndProvider drop lands at the scrolled-to gap", () => {
+  // These cover the feature's core promise: a row can be dropped at a position
+  // that started off-screen. As the edge-scroll loop moves content under a
+  // stationary pointer, recomputeGapAtPointer re-resolves the drop gap via
+  // elementFromPoint, and the drop must commit to THAT gap, not the one the
+  // pointer last hit before scrolling.
+
+  it("commits a single-row drop to the row revealed by the auto-scroll", async () => {
+    seed(5);
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={5} />);
+
+    // Before scrolling, the pointer sits over row 2; once the container scrolls,
+    // row 4 has moved under the (stationary) pointer. Rows have zero-size rects in
+    // jsdom, so recomputeGapAtPointer resolves the gap to index+1.
+    stubElementFromPoint(() =>
+      el.scrollTop > 0
+        ? screen.getByTestId("row-4")
+        : screen.getByTestId("row-2"),
+    );
+
+    // Arm a drag from row 0 and hold the pointer in the bottom edge zone.
+    dragToY(98);
+    expect(raf).toHaveBeenCalled();
+
+    // One auto-scroll step moves content and re-resolves the gap to row 4 (gap 5).
+    flushFrame();
+    expect(el.scrollTop).toBeGreaterThan(0);
+
+    fireEvent.pointerUp(screen.getByTestId("row-2"), {
+      clientX: 0,
+      clientY: 98,
+    });
+    await act(async () => {});
+
+    // Single-row remove-then-insert: dropping row 0 at gap 5 maps to to = gap - 1.
+    // Had the gap NOT been re-resolved during the scroll it would be 3 -> to = 2.
+    expect(mockArchive.reorder).toHaveBeenCalledWith(0, 4);
+  });
+
+  it("commits a multi-row drop to the scrolled-to gap (PR #185 x #187)", async () => {
+    // Selecting rows 0 and 1 and dragging the selection routes the drop through
+    // moveSelectedTo(gap); with the gap re-resolved to 5 by the scroll, the block
+    // is relocated to the bottom via the decomposed backend reorders.
+    seed(5, { selectedIndices: [0, 1], selectionAnchor: 0 });
+    const { el, ref } = makeScroller(0, 100);
+    render(<Harness scrollContainerRef={ref} count={5} />);
+
+    stubElementFromPoint(() =>
+      el.scrollTop > 0
+        ? screen.getByTestId("row-4")
+        : screen.getByTestId("row-2"),
+    );
+
+    dragToY(98);
+    flushFrame();
+    expect(el.scrollTop).toBeGreaterThan(0);
+
+    fireEvent.pointerUp(screen.getByTestId("row-2"), {
+      clientX: 0,
+      clientY: 98,
+    });
+    await act(async () => {});
+
+    // planRelocateSelection(5, [0,1], 5) decomposes to these three reorders;
+    // gap 3 (un-recomputed) would emit only [2,0].
+    expect(mockArchive.reorder.mock.calls).toEqual([
+      [2, 0],
+      [3, 1],
+      [4, 2],
+    ]);
   });
 });

--- a/src/lib/queue-move.test.ts
+++ b/src/lib/queue-move.test.ts
@@ -104,3 +104,38 @@ describe("planRelocateSelection", () => {
     expect(plan.selected).toEqual([1, 2]);
   });
 });
+
+describe("malformed selection input", () => {
+  // An out-of-range index would otherwise feed an unsatisfiable target into the
+  // decompose loop and spin the UI thread forever; the planners must drop such
+  // indices up front instead of hanging.
+  it("drops an out-of-range index in planShiftSelection (no hang, no-op plan)", () => {
+    const plan = planShiftSelection(4, [99], "up");
+    expect(plan.moves).toEqual([]);
+    expect(plan.order).toEqual([0, 1, 2, 3]);
+    expect(plan.selected).toEqual([]);
+  });
+
+  it("drops an out-of-range index in planRelocateSelection (no hang, no-op plan)", () => {
+    const plan = planRelocateSelection(4, [99], 0);
+    expect(plan.moves).toEqual([]);
+    expect(plan.order).toEqual([0, 1, 2, 3]);
+    expect(plan.selected).toEqual([]);
+  });
+
+  it("keeps the in-range indices when a selection mixes valid and out-of-range", () => {
+    // Row 1 is valid; 99 and -1 are dropped. The plan relocates just row 1.
+    const plan = planRelocateSelection(4, [-1, 1, 99], 0);
+    expect(plan.order).toEqual([1, 0, 2, 3]);
+    expect(plan.selected).toEqual([0]);
+    expect(applyMoves(4, plan)).toEqual(plan.order);
+  });
+
+  it("de-duplicates repeated selection indices", () => {
+    // A duplicate must not corrupt the decompose loop or the resulting plan.
+    const plan = planShiftSelection(4, [2, 2], "up");
+    expect(plan.order).toEqual([0, 2, 1, 3]);
+    expect(plan.selected).toEqual([1]);
+    expect(applyMoves(4, plan)).toEqual(plan.order);
+  });
+});

--- a/src/lib/queue-move.ts
+++ b/src/lib/queue-move.ts
@@ -37,7 +37,14 @@ function decompose(order: number[]): Array<[number, number]> {
     if (cur[p] === want) continue;
     // Positions [0, p) are already settled, so the wanted item is at some p+.
     let from = p + 1;
-    while (cur[from] !== want) from++;
+    while (from < order.length && cur[from] !== want) from++;
+    if (from >= order.length) {
+      // `order` is not a permutation of [0, length): the wanted old index is
+      // absent. The planners normalize their selection so this is unreachable,
+      // but bound the search and fail loudly rather than spinning the UI thread
+      // on a malformed permutation.
+      throw new Error(`decompose: ${want} is not present in the permutation`);
+    }
     moves.push([from, p]);
     cur.splice(from, 1);
     cur.splice(p, 0, want);
@@ -48,6 +55,27 @@ function decompose(order: number[]): Array<[number, number]> {
 /** Sorted-ascending copy (the selection invariant already excludes duplicates). */
 function sortedAsc(indices: number[]): number[] {
   return [...indices].sort((a, b) => a - b);
+}
+
+/**
+ * Sorted-ascending, de-duplicated selection restricted to valid row indices
+ * `[0, count)`. The selection store already maintains these invariants, but
+ * enforcing them here keeps a stale or out-of-range index from reaching
+ * {@link decompose}, where an absent target would otherwise loop forever.
+ */
+function normalizeSelection(
+  selectedIndices: number[],
+  count: number,
+): number[] {
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const i of selectedIndices) {
+    if (Number.isInteger(i) && i >= 0 && i < count && !seen.has(i)) {
+      seen.add(i);
+      out.push(i);
+    }
+  }
+  return out.sort((a, b) => a - b);
 }
 
 /**
@@ -67,7 +95,7 @@ export function planShiftSelection(
   // `slot[pos]` holds the old index currently at `pos`; `picked` tracks which
   // positions are selected as the block walks toward the edge.
   const slot = Array.from({ length: count }, (_, i) => i);
-  const picked = new Set(sortedAsc(selectedIndices));
+  const picked = new Set(normalizeSelection(selectedIndices, count));
   if (direction === "up") {
     for (let i = 1; i < count; i++) {
       // A selected row with a free (unselected) slot above swaps up into it.
@@ -106,7 +134,7 @@ export function planRelocateSelection(
   selectedIndices: number[],
   gap: number,
 ): MovePlan {
-  const selected = sortedAsc(selectedIndices);
+  const selected = normalizeSelection(selectedIndices, count);
   const pickedSet = new Set(selected);
   // The un-selected rows, in their original order.
   const rest: number[] = [];

--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -404,6 +404,86 @@ describe("moveSelectedTo", () => {
   });
 });
 
+describe("applyMovePlan partial-failure resync", () => {
+  it("commits the last successful backend snapshot when a mid-sequence reorder fails", async () => {
+    useJobStore.setState({
+      draft: makeDraft(5),
+      selectedIndices: [1, 3],
+      selectionAnchor: 1,
+    });
+    // moveSelectedTo(5) decomposes into two reorders ([2,1] then [4,2]). The
+    // first commits a (distinguishable) backend snapshot; the second rejects, so
+    // the backend is left half-moved. The store must commit that partial snapshot
+    // rather than silently keep showing the pre-move order.
+    const partial = makeDraft(5, null, "/partial-after-first-move");
+    mockArchive.reorder
+      .mockResolvedValueOnce(partial)
+      .mockRejectedValueOnce(new Error("ipc boom"));
+
+    await useJobStore.getState().moveSelectedTo(5);
+
+    const state = useJobStore.getState();
+    // Both moves were attempted, in order.
+    expect(mockArchive.reorder.mock.calls).toEqual([
+      [2, 1],
+      [4, 2],
+    ]);
+    // The store committed the backend's PARTIAL snapshot (distinguished by its
+    // outputDir), not the original — so the UI matches the real backend order.
+    expect(state.draft).toEqual(partial);
+    // The failure is surfaced and flags that the order may have changed.
+    expect(state.error).toContain("ipc boom");
+    expect(state.error).toMatch(/partial/i);
+    // The stale selection (its indices no longer map to the partial order) is
+    // dropped via draftEdit.
+    expect(state.selectedIndices).toEqual([]);
+    expect(state.selectionAnchor).toBeNull();
+  });
+
+  it("recomputes previews against the committed partial order and keeps the error", async () => {
+    useJobStore.setState({
+      draft: makeDraft(5, "photo_{n}"),
+      selectedIndices: [1, 3],
+      selectionAnchor: 1,
+    });
+    const partial = makeDraft(5, "photo_{n}", "/partial");
+    mockArchive.reorder
+      .mockResolvedValueOnce(partial)
+      .mockRejectedValueOnce(new Error("ipc boom"));
+    mockArchive.previewOutputName.mockImplementation((_template, seq) =>
+      Promise.resolve(`photo_${seq}.zip`),
+    );
+
+    await useJobStore.getState().moveSelectedTo(5);
+
+    // Previews are recomputed against the committed (partial) draft so they never
+    // stay aligned to the stale pre-move order; the move error survives the
+    // recompute (which itself clears `error` on success for a non-null template).
+    expect(useJobStore.getState().previewNames).toHaveLength(5);
+    expect(useJobStore.getState().error).toContain("ipc boom");
+  });
+
+  it("leaves the original order committed when the very first reorder fails", async () => {
+    const original = makeDraft(5);
+    useJobStore.setState({
+      draft: original,
+      selectedIndices: [1, 3],
+      selectionAnchor: 1,
+    });
+    // The first decomposed move rejects: the backend is unchanged (a single
+    // reorder is atomic), so the store keeps the original order and surfaces it.
+    mockArchive.reorder.mockRejectedValueOnce(new Error("ipc boom"));
+
+    await useJobStore.getState().moveSelectedTo(5);
+
+    const state = useJobStore.getState();
+    expect(mockArchive.reorder).toHaveBeenCalledTimes(1);
+    expect(state.draft).toEqual(original);
+    expect(state.error).toContain("ipc boom");
+    expect(state.selectedIndices).toEqual([]);
+  });
+});
+
 describe("removeItem", () => {
   it("calls archive.removeItem with the index and replaces the draft", async () => {
     const draft = makeDraft(2);

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -52,6 +52,15 @@ function draftEdit(draft: DraftSnapshot): Partial<JobState> {
  * re-applied afterwards to keep the highlight on the moved rows. A clamped /
  * inside-block plan has no moves and is a silent no-op that leaves the selection
  * untouched.
+ *
+ * The decomposed sequence is NOT atomic: if a later move rejects, the earlier
+ * moves are already committed backend-side, leaving the backend draft
+ * half-reordered. `draft` is hoisted out of the `try` so the catch can commit
+ * that last successful snapshot — keeping the UI in sync with the real backend
+ * order instead of silently showing the pre-move order, which would then
+ * disagree with every subsequent index-based action (and archive rows under the
+ * wrong names). Previews are recomputed on both paths so they never stay aligned
+ * to a stale order.
  */
 async function applyMovePlan(
   plan: MovePlan,
@@ -59,9 +68,10 @@ async function applyMovePlan(
   get: StoreApi<JobState>["getState"],
 ): Promise<void> {
   if (plan.moves.length === 0) return;
+  // Each backend reorder returns the full snapshot; the last successful one is
+  // the order both sides agree on, even if a later move then fails.
+  let draft = get().draft;
   try {
-    // Each backend reorder returns the full snapshot; the last is the result.
-    let draft = get().draft;
     for (const [from, to] of plan.moves) {
       draft = await archive.reorder(from, to);
     }
@@ -72,7 +82,16 @@ async function applyMovePlan(
     });
     await get().recomputePreviews();
   } catch (reason) {
-    set({ error: messageFromReason(reason) });
+    // A move failed mid-sequence: commit the last good snapshot so the queue
+    // reflects the real (partial) backend order, recompute previews against it,
+    // then surface the failure. The error is set LAST because a successful
+    // recompute clears `error` for a non-null template — setting it afterward
+    // keeps the failure visible. draftEdit drops the now-stale selection.
+    set(draftEdit(draft));
+    await get().recomputePreviews();
+    set({
+      error: `Reorder partially failed; the queue order may have changed. ${messageFromReason(reason)}`,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the post-merge review of #185 / #186 / #187. It fixes two correctness gaps surfaced there — a grouped queue move that silently desynced from the backend on a partial failure, and a `decompose` path that could hang the UI thread on malformed input — and closes three high-value test gaps. The behavior change is frontend-only; the rest is Rust + frontend test hardening.

## Background / Motivation

- The backend exposes only single `reorder(from, to)`, so a grouped (multi-row) move runs as a non-atomic sequence. If a later step rejected, the store kept showing the pre-move order while the backend was already half-reordered — a silent divergence that the next index-based action would expose, and that could archive rows under the wrong `{n}` numbering.
- `decompose` searched for each target with an unbounded `while (cur[from] !== want) from++`. A stale or out-of-range `selectedIndices` entry made the target unsatisfiable, spinning the loop forever and freezing the UI thread (latent today, but unguarded).
- Three behaviors were under-tested: the "no half-written tree" RAII cleanup on a cancelled/failed extraction (#186, only an empty dir was covered), the drop landing at a gap revealed by edge auto-scroll (#185, asserted only as "callback fired"), and the whole `reorder-animation` orchestration (#187, had no test file).

## Changes

### Grouped-move resync (`src/store/jobStore.ts`)

- `applyMovePlan` hoists `draft` out of the `try` so the catch can commit the last snapshot the backend actually returned, keeping the UI in sync with the real (partial) order.
- Previews are recomputed against that committed order on the failure path too; the error is set **last** so the recompute's success path (which clears `error` for a non-null template) cannot wipe it. The message flags that the queue order may have changed.

### `decompose` hardening (`src/lib/queue-move.ts`)

- New `normalizeSelection` (sorted, de-duplicated, restricted to `[0, count)`) runs at the top of both `planShiftSelection` and `planRelocateSelection`, so an out-of-range or duplicate index can never reach `decompose`.
- The inner search is bounded (`from < order.length`) and throws on a malformed permutation instead of looping forever.

### Tests

- `#186` — `temp_workspace::drop_removes_a_populated_directory`: writes a nested + top-level file, then proves RAII removes the whole tree on drop (the real "no half-written tree" guarantee).
- `#185` — `reorder-dnd` drop-landing tests (single-row + the multi-row #185×#187 cross-cutting case): a drag near the edge auto-scrolls, `recomputeGapAtPointer` re-resolves the gap via a stubbed `elementFromPoint`, and the drop commits to the scrolled-to gap (distinguished from the un-recomputed gap by the exact backend `reorder` calls).
- `#187` — new `reorder-animation.test.tsx`: grouped announce ("Moved N items") with no single-row settle flash, clamped identity no-op suppresses both the store call and the announce, and single-row reorder flags the landing row + announces its 1-based position.
- `#187` — `queue-move` (malformed/duplicate selection) and `jobStore` (partial-failure resync, first-move failure) coverage.

## Verification

- Grouped-move resync: with a multi-row selection, force the 2nd backend `reorder` to reject (e.g. throttle/kill IPC) — the queue now shows the half-moved order and a "Reorder partially failed; the queue order may have changed." banner, instead of looking unchanged.
- `decompose` guard: a grouped move with a stale out-of-range selection no longer freezes the window (it degrades to a no-op).

## Test plan

- [x] FE: `pnpm run fmt:check`, `pnpm run lint:ci`, `pnpm exec tsc --noEmit`, `pnpm run knip`
- [x] FE: `pnpm run test` — 50 files, 609 passed
- [x] Rust: `cargo fmt --check -p simple-archiver-core`
- [x] Rust: `cargo clippy -p simple-archiver-core --all-targets --all-features -- -D warnings`
- [x] Rust: `cargo nextest run -p simple-archiver-core` — 253 passed

## Caveats

- The fix keeps the frontend in sync with the real backend order on a partial failure; the backend may still hold an intermediate order, so the user resumes from there. An atomic backend `reorder_many(perm)` was the alternative, deliberately deferred to keep this change frontend-only and verifiable without building `src-tauri`.
- `src-tauri` was not built (needs system webkit libs); all `cargo` commands were scoped to `simple-archiver-core`.
