### PR TITLE
fix(zip): decode non-UTF-8 (CP932) entry filenames instead of failing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3793,6 +3813,8 @@ name = "simple-archiver-core"
 version = "0.10.0"
 dependencies = [
  "async_zip",
+ "chardetng",
+ "encoding_rs",
  "lalrpop",
  "lalrpop-util",
  "logos",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 async_zip = { version = "0.0.18", features = ["tokio", "deflate"] }
+chardetng = "0.1"
+encoding_rs = "0.8"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "sync"] }
 tokio-util = "0.7.18"
 walkdir = "2"

--- a/crates/core/src/infrastructure/zip_extractor.rs
+++ b/crates/core/src/infrastructure/zip_extractor.rs
@@ -57,16 +57,13 @@ impl Extractor for ZipExtractor {
             // `reader.file()` is released before the `&mut self` entry reader call.
             let (is_dir, name) = {
                 let entry = &reader.file().entries()[i];
-                let is_dir = entry
-                    .dir()
-                    .map_err(|e| ExtractError::Backend(e.to_string()))?;
-                let name = entry
-                    .filename()
-                    .as_str()
-                    .map_err(|e| {
-                        ExtractError::Backend(format!("entry {i} has a non-UTF-8 name: {e}"))
-                    })?
-                    .to_owned();
+                let filename = entry.filename();
+                // Resolve to UTF-8, decoding legacy non-UTF-8 (e.g. CP932) names
+                // instead of failing. Derive directory-ness from the resolved
+                // name's trailing slash, because `entry.dir()` itself calls
+                // `as_str()` and would fail first on a non-UTF-8 name.
+                let name = resolve_entry_name(filename.as_str().ok(), filename.as_bytes());
+                let is_dir = name.ends_with('/');
                 (is_dir, name)
             };
             if is_dir {
@@ -106,6 +103,25 @@ impl Extractor for ZipExtractor {
     }
 }
 
+/// Resolve a zip entry filename to a UTF-8 `String`.
+///
+/// `utf8` is the backend's UTF-8 view when available (`ZipString::as_str().ok()`):
+/// present for entries with the UTF-8 flag set, an Info-ZIP Unicode Path
+/// alternative, or a pure-ASCII name. When it is `None` the name is a legacy
+/// non-UTF-8 byte string (e.g. CP932/Shift-JIS), so detect its charset with
+/// `chardetng` and decode it with `encoding_rs`. Best-effort and never fails: a
+/// mis-detected name still yields a usable string (possibly with U+FFFD) instead
+/// of aborting the whole extraction.
+fn resolve_entry_name(utf8: Option<&str>, raw: &[u8]) -> String {
+    if let Some(s) = utf8 {
+        return s.to_owned();
+    }
+    let mut detector = chardetng::EncodingDetector::new();
+    detector.feed(raw, true);
+    let encoding = detector.guess(None, true);
+    encoding.decode(raw).0.into_owned()
+}
+
 /// Validate a zip entry name and reduce it to a safe relative path.
 ///
 /// Returns `Ok(Some(rel))` for a path built only from normal components,
@@ -140,6 +156,35 @@ mod tests {
     use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
 
+    #[test]
+    fn resolve_entry_name_passes_through_utf8() {
+        // When the backend already gives a UTF-8 name, return it verbatim.
+        let name = "青の祓魔師/第01話.txt";
+        assert_eq!(resolve_entry_name(Some(name), name.as_bytes()), name);
+    }
+
+    #[test]
+    fn resolve_entry_name_decodes_cp932_when_not_utf8() {
+        // A legacy non-UTF-8 name (None from the backend) is detected + decoded.
+        use encoding_rs::SHIFT_JIS;
+        let expected = "[加藤和恵] 青の祓魔師 第08巻/第01話.txt";
+        let (sjis, _, had_errors) = SHIFT_JIS.encode(expected);
+        assert!(!had_errors, "fixture must encode cleanly to Shift_JIS");
+        assert_eq!(resolve_entry_name(None, &sjis), expected);
+    }
+
+    #[test]
+    fn resolve_entry_name_keeps_trailing_slash_on_decoded_dir() {
+        // Directory entries keep their trailing slash after decoding, so callers
+        // can detect them without calling `entry.dir()`.
+        use encoding_rs::SHIFT_JIS;
+        let expected = "青の祓魔師 第08巻/";
+        let (sjis, _, _) = SHIFT_JIS.encode(expected);
+        let name = resolve_entry_name(None, &sjis);
+        assert_eq!(name, expected);
+        assert!(name.ends_with('/'));
+    }
+
     /// Build an in-memory zip on disk from `(name, bytes)` pairs using the sync
     /// `zip` dev-dependency. `start_file` accepts arbitrary names (including
     /// traversal sequences), which is exactly what the zip-slip test needs.
@@ -169,6 +214,43 @@ mod tests {
         writer.write_all(b"deep").expect("write bytes");
         writer.finish().expect("finalize zip");
         tmp
+    }
+
+    #[tokio::test]
+    async fn extracts_legacy_cp932_filename_without_utf8_flag() {
+        use async_zip::base::write::ZipFileWriter;
+        use async_zip::{Compression, StringEncoding, ZipEntryBuilder, ZipString};
+        use encoding_rs::SHIFT_JIS;
+
+        // Build a zip whose single entry name is CP932 with NO UTF-8 flag: a
+        // `StringEncoding::Raw` filename makes the async_zip writer omit general
+        // purpose bit 11, reproducing a legacy Japanese zip that the old code
+        // rejected with "attempted to convert non-UTF8 bytes to a string/str".
+        let display_name = "青の祓魔師 第08巻/第01話.txt";
+        let (sjis, _, _) = SHIFT_JIS.encode(display_name);
+        let zip_name = ZipString::new(sjis.into_owned(), StringEncoding::Raw);
+        let entry = ZipEntryBuilder::new(zip_name, Compression::Stored);
+
+        let tmp = tempfile::NamedTempFile::new().expect("temp zip file");
+        let file = tokio::fs::File::create(tmp.path())
+            .await
+            .expect("create temp zip");
+        let mut writer = ZipFileWriter::with_tokio(file);
+        writer
+            .write_entry_whole(entry, b"chapter")
+            .await
+            .expect("write cp932 entry");
+        writer.close().await.expect("finalize zip");
+
+        let tree = ZipExtractor::new()
+            .extract(tmp.path(), &ExtractContext::detached())
+            .await
+            .expect("legacy CP932 zip should extract, not error");
+
+        let root = tree.path();
+        let extracted = std::fs::read(root.join("青の祓魔師 第08巻").join("第01話.txt"))
+            .expect("file extracted under decoded UTF-8 name");
+        assert_eq!(extracted, b"chapter");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Legacy Japanese zip archives failed to extract — 7 of 27 in a real batch — with `extract error: attempted to convert non-UTF8 bytes to a string/str`. These zips store entry filenames in CP932/Shift-JIS without the ZIP UTF-8 flag, which `async_zip` cannot expose as a `&str`. `ZipExtractor` now decodes such names instead of aborting the whole archive. Backend-only change in `crates/core`.

## Background / Motivation

- The ZIP spec only guarantees UTF-8 entry names when general-purpose **bit 11** (the EFS flag) is set. Older Windows zip tools (common for Japanese content) store names in **CP932** with the flag unset and no Info-ZIP Unicode Path extra field, so `async_zip` tags them `StringEncoding::Raw`.
- In `zip_extractor.rs` the extract loop called `entry.dir()` (internally `filename().as_str()`) and `entry.filename().as_str()`, both of which return `ZipError::StringNotUtf8` on a Raw name — its `Display` is exactly the error users saw. A single such entry aborted the entire archive.
- zips with the UTF-8 flag, an Info-ZIP Unicode alternative, or pure-ASCII names already worked and are unchanged. `.rar` is unaffected (UnRAR resolves names itself), so the fix is scoped to zip.

## Changes

### Decode non-UTF-8 entry names (`crates/core/src/infrastructure/zip_extractor.rs`)

- Add a pure, IO-free helper `resolve_entry_name(utf8: Option<&str>, raw: &[u8]) -> String`: returns the backend's UTF-8 view when available, otherwise auto-detects the charset with `chardetng` and decodes the raw bytes with `encoding_rs`. Best-effort — never fails.
- Use it in the extract loop and derive directory-ness from the resolved name's trailing slash, **removing the `entry.dir()` call** that failed first on a Raw name.
- The zip-slip guard (`safe_relative_path`) and CRC-checked read are unchanged and now run on the resolved name, so traversal protection is preserved.

### Dependencies (`crates/core/Cargo.toml`)

- Add `chardetng` and `encoding_rs` (pure additions; no fixed library swapped).

## Tests

- `resolve_entry_name`: UTF-8 passthrough; CP932 round-trip decode; trailing-slash directory detection.
- Integration: a zip with a CP932 name and **no UTF-8 flag** (built via the `async_zip` writer with `StringEncoding::Raw`) now extracts to the decoded Japanese path instead of erroring — this test reproduces the original failure verbatim before the fix.
- All existing extractor tests (UTF-8/ASCII, directory entries, zip-slip, corrupt input, encrypted entry, empty zip, cancellation) stay green.

## Limitations

Charset auto-detection can mis-guess on very short/ambiguous filenames; such entries are still extracted under a best-effort name (possibly with `U+FFFD`), which is strictly better than the previous all-or-nothing failure.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` — clean
- `cargo nextest run -p simple-archiver-core --profile ci` — 256/256 passed
