### PR TITLE
ci: speed up app job via dev-profile smoke build, drop redundant steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,11 @@ jobs:
       # Belt and suspenders: mise.toml requests clippy components, but
       # ensure they exist on the active toolchain even if a cached install lacks them.
       - run: rustup component add clippy
-      - run: cargo nextest run -p simple-archiver-core --profile ci
+      # Core tests on Windows only: the `core` job already covers them on Linux,
+      # and macOS shares Linux's `/` path separator, so a macOS rerun adds nothing.
+      # Windows is kept because it is the sole job that catches `\` vs `/` regressions.
+      - if: matrix.os == 'windows-latest'
+        run: cargo nextest run -p simple-archiver-core --profile ci
       # PR6: the presentation crate's tests (Tauri command surface, progress
       # event sink, run_job integration) only build on runners with the Tauri
       # toolchain, which the app job has. Run them here so they are covered in CI.
@@ -116,5 +120,11 @@ jobs:
       - run: cargo nextest run -p simple-archiver --profile ci
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-      - run: pnpm build
-      - run: pnpm tauri build --no-bundle
+      # Smoke-build the app in the dev profile (--debug): this reuses the already
+      # compiled `target/debug` dependency tree from the nextest steps above, so
+      # the full dependency tree is no longer recompiled a second time under the
+      # release profile. `--no-bundle` keeps it a compile/link check, not an
+      # artifact build (release.yml builds the optimized, bundled binaries).
+      # tauri build runs `beforeBuildCommand: pnpm build`, so the frontend is
+      # built here too — a separate `pnpm build` step would be redundant.
+      - run: pnpm tauri build --no-bundle --debug


### PR DESCRIPTION
## Summary

The cross-platform `app` CI job (macOS / Windows) recompiled the entire Rust dependency tree twice per run — once in the dev profile for the `nextest` test steps, then again in the release profile for `pnpm tauri build --no-bundle`. The release-profile rebuild (`opt-level=3`) dominated the job's wall-clock time. This PR builds the smoke check in the dev profile so the dependency tree is compiled only once, and trims two redundant steps. No change to release output — `release.yml` still produces the optimized, bundled binaries.

## Background / Motivation

- `pnpm tauri build --no-bundle` used the default `release` profile, so all ~200 Tauri/image/codec crates were re-optimized at `opt-level=3` even though the step only verifies the app compiles and links — the long "Compiling ..." list visible in the job log.
- The standalone `pnpm build` step duplicated work: `tauri.conf.json` declares `beforeBuildCommand: "pnpm build"`, so `tauri build` already runs the frontend build itself.
- `cargo nextest run -p simple-archiver-core` ran on every matrix OS, but the `core` job already covers it on Linux and macOS shares Linux's `/` path separator, so the macOS rerun added no coverage.

## Changes

### Dev-profile smoke build

- `pnpm tauri build --no-bundle --debug` now builds in the dev profile, reusing the `target/debug` dependency tree already compiled by the `nextest` steps. This removes the second, release-profile compile of the full dependency tree.
- `--no-bundle` keeps it a compile/link check rather than an artifact build.

### Trim redundant steps

- Drop the standalone `pnpm build` step (covered by `tauri build`'s `beforeBuildCommand`).
- Gate `cargo nextest run -p simple-archiver-core` behind `if: matrix.os == 'windows-latest'` — Windows is retained because it is the sole job that catches `\` vs `/` path regressions.

## Verification

- `ci.yml` parses as valid YAML.
- Confirmed against `tauri.conf.json` (`beforeBuildCommand: "pnpm build"`) and the absence of any custom `[profile.*]` in the workspace Cargo manifests, so `--debug` selects the same dev profile the test steps already built.
- On the next CI run, the `app` job log should no longer show a second release-profile "Compiling ..." sweep after the tests, and the macOS job should skip the core-crate `nextest` step.

## Test plan

- [ ] `app (macos-latest)` and `app (windows-latest)` jobs pass on this PR.
- [ ] The `app` job log shows the Tauri build reusing already-compiled crates (no full release-profile recompile).
- [ ] `app (macos-latest)` skips `cargo nextest run -p simple-archiver-core`; `app (windows-latest)` still runs it.
- [ ] `core`, `loom`, `hygiene`, and `frontend` jobs remain green (unchanged).
