### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.13.0",
  "serde",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async_zip",
  "chardetng",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.10.0"
+version = "0.11.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release version bump `0.10.0` → `0.11.0` ahead of cutting the `v0.11.0` release.

Bumps the version in all six tracked locations:

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `crates/core/Cargo.toml`
- `Cargo.lock` (`simple-archiver` + `simple-archiver-core`)

## What ships in v0.11.0 (since v0.10.0)

- Move multiple selected queue rows together via keyboard and drag (#187)
- Auto-scroll while drag-reordering near the top/bottom edge (#185)
- Poll the cancellation token inside the archiver/extractor work loops for snappier cancel (#186)
- Resync grouped move on partial failure and guard decompose (#188)
- Decode non-UTF-8 (CP932) zip entry filenames instead of failing (#189)

## Verification

- `cargo metadata --locked` exits 0 (lockfile consistent)
- Diff is exactly the six version lines, nothing else
