### PR TITLE
fix(queue): ignore file drops while a job is running

### DIFF
--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -177,6 +177,30 @@ describe("addItems", () => {
     expect(useJobStore.getState().lastBatch).toBeNull();
     expect(useJobStore.getState().cleared).toBe(false);
   });
+
+  it("ignores addItems while a job is running (preserves live progress)", async () => {
+    // The queue is read-only mid-run, like reorder/move. A drop can still reach
+    // addItems during a run (useFileDrop stays subscribed in every phase), and
+    // addItems runs draftEdit which would wipe the live progress arrays. Ignore
+    // it, mirroring the other queue mutations.
+    const progress: ProgressEvent = {
+      overall: { bytesDone: 100, bytesTotal: 100 },
+      perTask: [
+        { taskId: 10, bytesDone: 50, bytesTotal: 50, etaMs: null },
+        { taskId: 11, bytesDone: 50, bytesTotal: 50, etaMs: null },
+      ],
+      elapsedMs: 5,
+      overallEtaMs: null,
+    };
+    useJobStore.setState({ running: true, progress, taskIdByIndex: [10, 11] });
+
+    await useJobStore.getState().addItems(["/late.rar"]);
+
+    expect(mockArchive.addItems).not.toHaveBeenCalled();
+    expect(useJobStore.getState().progress).toEqual(progress);
+    expect(useJobStore.getState().taskIdByIndex).toEqual([10, 11]);
+    expect(useJobStore.getState().running).toBe(true);
+  });
 });
 
 describe("reorder", () => {

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -285,6 +285,11 @@ export const useJobStore = create<JobState>()((set, get) => ({
   selectionAnchor: null,
 
   addItems: async (paths) => {
+    // The queue is read-only mid-run, mirroring reorder/move. A drop can reach
+    // here during a run (useFileDrop stays subscribed in every phase), and
+    // addItems runs draftEdit which would wipe the live progress arrays. Ignore
+    // it, like the other queue mutations do.
+    if (get().running) return;
     try {
       const draft = await archive.addItems(paths);
       // Queuing the next batch discards the residual chip: it only ever refers


### PR DESCRIPTION
## Summary

Every queue mutation is guarded by `running` except `addItems`, and `useFileDrop` keeps the OS drag-and-drop subscription live in every phase — so a drop during a run reached `addItems`, whose `draftEdit` wipes the live `progress` / `taskIdByIndex` arrays. `addItems` now no-ops while a job is running, matching the other mutations.

## Background / Motivation

- `moveSelected` / `reorder` / `deleteSelected` are read-only mid-run (guarded, or reachable only from a disabled UI); `addItems` had no such guard.
- A "process this later" drop mid-run either wiped live progress (accepted add → `OverallProgress` vanishes, added rows freeze on "Processing" and never reach the Ledger) or showed a false error banner (rejected add). Both are wrong; the queue should be read-only during a run.

## Changes

### Store-level running guard (`src/store/jobStore.ts`)

- Add `if (get().running) return;` at the top of `addItems`, with a comment mirroring the reorder/move read-only-mid-run rationale. Placing the guard in the store covers both the drop path (`useFileDrop`) and the button path (`AddSourceButtons`).

### Tests

- New `ignores addItems while a job is running` in `src/store/jobStore.test.ts`: with `running: true`, `addItems` does not call `mockArchive.addItems` and leaves `progress` / `taskIdByIndex` / `running` intact. Failed pre-fix (backend called once), passes post-fix.

## Verification

- `pnpm test` — 610 passed (incl. the new test)
- `pnpm lint:ci` / `pnpm fmt:check` — clean
- `pnpm build` (tsc + vite) — ok
- `pnpm knip` — clean

Closes #200
