### PR TITLE
fix(ui): clear prior run progress when a new run starts

### DIFF
--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -945,6 +945,32 @@ describe("runJob", () => {
     expect(useJobStore.getState().lastBatch).toBeNull();
   });
 
+  it("clears stale progress when a new run starts", async () => {
+    // A completed run leaves progress at the final ~100% event. Re-running must
+    // drop it synchronously so the UI does not flash the prior batch's bars/ETA
+    // before the first new event arrives.
+    const staleProgress: ProgressEvent = {
+      overall: { bytesDone: 100, bytesTotal: 100 },
+      perTask: [{ taskId: 11, bytesDone: 50, bytesTotal: 50, etaMs: 0 }],
+      elapsedMs: 1000,
+      overallEtaMs: 0,
+    };
+    useJobStore.setState({ progress: staleProgress });
+
+    const summary: JobSummaryDto = {
+      succeeded: [11],
+      cancelled: [],
+      failed: [],
+      results: [],
+    };
+    mockArchive.runJob.mockResolvedValue(summary);
+
+    const pending = useJobStore.getState().runJob();
+    // Progress is dropped synchronously by the opening set(), before the await.
+    expect(useJobStore.getState().progress).toBeNull();
+    await pending;
+  });
+
   it("keeps the existing taskIdByIndex when no progress was emitted", async () => {
     // With progress === null, runJob falls back to the existing taskIdByIndex
     // instead of wiping it to []. Seed it via setState since addItems/reorder

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -417,6 +417,9 @@ export const useJobStore = create<JobState>()((set, get) => ({
       error: null,
       lastBatch: null,
       cleared: false,
+      // Clear the prior run's final progress so a re-run does not flash the
+      // previous batch's ~100% bars/ETA before the first new event arrives.
+      progress: null,
       // A run owns the positional progress arrays; drop any pending row selection
       // so a stale highlight cannot linger over a now-running queue.
       selectedIndices: [],


### PR DESCRIPTION
## Summary

`runJob`'s opening `set` cleared `summary` / `error` / `lastBatch` but not `progress`, so re-running a completed batch flashed the previous run's ~100% bars and ETA for a few frames until the first new event arrived. It now clears `progress` on start.

## Background / Motivation

- After a run, `progress` retained the last batch's near-100% snapshot; the result phase leaves Run enabled, so the same queue can be re-run.
- On re-run `RightCanvas` renders the execute phase immediately, showing the stale full bars / ETA — "just started but nearly done" — until it self-heals on the first real event.

## Changes

### Clear stale progress (`src/store/jobStore.ts`)

- Add `progress: null` to `runJob`'s opening `set`, before `selectedIndices`, with an English comment. On start `OverallProgress` returns null and rows show "Processing" until the first real event — the intended empty state.

### Tests

- New `clears stale progress when a new run starts` in `src/store/jobStore.test.ts`: asserts `progress === null` synchronously after `runJob()` (before the awaited resolve). Failed pre-fix (stale event retained), passes post-fix. The `taskIdByIndex` no-event fallback path is unaffected (existing test still green).

## Verification

- `pnpm test` — 610 passed
- `pnpm lint:ci` / `pnpm fmt:check` — clean
- `pnpm build` (tsc + vite) — ok
- `pnpm knip` — clean

Closes #202
