### PR TITLE
perf(ui): coalesce progress events with requestAnimationFrame

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -133,13 +133,62 @@ describe("App", () => {
       overallEtaMs: null,
     };
 
-    await act(async () => {
-      capturedCallback?.(progressEvent);
+    capturedCallback?.(progressEvent);
+
+    // The rAF coalescer defers each event to the next animation frame, so the
+    // store update is now asynchronous; poll until the frame flush lands.
+    await waitFor(() =>
+      expect(useJobStore.getState().progress).toEqual(progressEvent),
+    );
+    expect(useJobStore.getState().taskIdByIndex).toEqual([1]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2b. Coalesces multiple events within a frame to the latest snapshot
+  // -------------------------------------------------------------------------
+  it("coalesces multiple progress events within a frame to the latest", async () => {
+    let capturedCallback: ((event: ProgressEvent) => void) | undefined;
+    vi.mocked(archiveMock.subscribeProgress).mockImplementation((cb) => {
+      capturedCallback = cb;
+      return Promise.resolve(() => {});
     });
 
-    // Verify the store reflects the routed progress event.
-    expect(useJobStore.getState().progress).toEqual(progressEvent);
-    expect(useJobStore.getState().taskIdByIndex).toEqual([1]);
+    // Spy on the store action the effect drives; the state object returned by
+    // getState() is stable, so the spy survives the rAF flush.
+    const applySpy = vi.spyOn(useJobStore.getState(), "applyProgress");
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(archiveMock.subscribeProgress).toHaveBeenCalledTimes(1),
+    );
+    expect(capturedCallback).toBeDefined();
+
+    const eventA: ProgressEvent = {
+      overall: { bytesDone: 1, bytesTotal: 10 },
+      perTask: [{ taskId: 1, bytesDone: 1, bytesTotal: 10, etaMs: null }],
+      elapsedMs: 1,
+      overallEtaMs: null,
+    };
+    const eventB: ProgressEvent = {
+      overall: { bytesDone: 7, bytesTotal: 10 },
+      perTask: [{ taskId: 1, bytesDone: 7, bytesTotal: 10, etaMs: null }],
+      elapsedMs: 2,
+      overallEtaMs: null,
+    };
+
+    // Two events arrive back-to-back within the same animation frame.
+    capturedCallback?.(eventA);
+    capturedCallback?.(eventB);
+
+    // Only the latest snapshot is applied, exactly once, when the frame flushes.
+    await waitFor(() =>
+      expect(useJobStore.getState().progress).toEqual(eventB),
+    );
+    expect(applySpy).toHaveBeenCalledTimes(1);
+    expect(applySpy).toHaveBeenCalledWith(eventB);
+
+    applySpy.mockRestore();
   });
 
   // -------------------------------------------------------------------------

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import "./App.css";
+import type { ProgressEvent } from "@/bindings/ProgressEvent";
 import { AppShell } from "@/components/AppShell";
 import { DropOverlay } from "@/components/DropOverlay";
 import { LeftRail } from "@/components/LeftRail";
@@ -22,7 +23,26 @@ function App() {
     // before the subscription promise resolves.
     let active = true;
 
-    subscribeProgress((event) => useJobStore.getState().applyProgress(event))
+    // Coalesce high-frequency progress events to at most one store update per
+    // animation frame. Each event is a full snapshot, so applying only the
+    // latest per frame is lossless; the authoritative final state comes from
+    // runJob's returned summary, not the last event.
+    let latest: ProgressEvent | null = null;
+    let frame: number | null = null;
+    const flush = () => {
+      frame = null;
+      if (latest !== null) {
+        useJobStore.getState().applyProgress(latest);
+        latest = null;
+      }
+    };
+
+    subscribeProgress((event) => {
+      latest = event;
+      if (frame === null) {
+        frame = requestAnimationFrame(flush);
+      }
+    })
       .then((fn) => {
         if (active) {
           unlisten = fn;
@@ -38,6 +58,10 @@ function App() {
 
     return () => {
       active = false;
+      // Drop any frame still pending so flush cannot fire after unmount.
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
       unlisten?.();
     };
   }, []);


### PR DESCRIPTION
## Summary

Backend progress events were routed straight into `applyProgress`, one zustand `setState` per event; a high-frequency run re-rendered every `TaskRow` on each event. `App.tsx` now buffers the latest event and applies at most one store update per animation frame. Each event is a full snapshot, so dropping intra-frame events is lossless.

## Background / Motivation

- `subscribeProgress` invoked `applyProgress` per event; with one event per compressed file that is hundreds–thousands of `setState`s/sec, each triggering selector re-evaluation and a React commit — UI jank and sluggish Cancel.
- Pairs with backend emit throttling (#197); coalescing on the frontend hardens against bursts regardless of the source rate.

## Changes

### rAF coalescing (`src/App.tsx`)

- Buffer the latest `ProgressEvent`; schedule a single `requestAnimationFrame(flush)` that applies it and clears the buffer. Unmount cleanup `cancelAnimationFrame`s any pending flush.
- Add `import type { ProgressEvent } from "@/bindings/ProgressEvent"`.

### Tests (`src/App.test.tsx`)

- New `coalesces multiple progress events within a frame to the latest`: two events in one frame → `applyProgress` runs once and the store holds the latest. Failed pre-impl (called 2×).
- Update the existing `subscribes to progress on mount…` test to `await` the rAF flush via `waitFor` (application is now asynchronous). No fake timers in this file, so jsdom rAF fires on real timers and `waitFor` polling is stable.

## Verification

- `pnpm test` — 610 passed
- `pnpm lint:ci` / `pnpm fmt:check` — clean
- `pnpm build` (tsc + vite) — ok
- `pnpm knip` — clean

Out of scope: store selector granularity and `TaskRow` memo boundaries (already reviewed as sound) — this PR only coalesces events in `App.tsx`.

Closes #201
