### PR TITLE
fix(core): clean up partial copied tree on folder placement error

### DIFF
--- a/crates/core/src/infrastructure/fs_placer.rs
+++ b/crates/core/src/infrastructure/fs_placer.rs
@@ -48,7 +48,7 @@ fn place_blocking(
     match policy {
         ConflictPolicy::AutoRename => {
             let dest = non_colliding(desired);
-            copy_tree(src, &dest)?;
+            copy_tree_or_cleanup(src, &dest)?;
             Ok(dest)
         }
         ConflictPolicy::Skip => {
@@ -56,17 +56,30 @@ fn place_blocking(
                 // Leave the existing folder untouched; nothing is copied.
                 return Ok(desired.to_path_buf());
             }
-            copy_tree(src, desired)?;
+            copy_tree_or_cleanup(src, desired)?;
             Ok(desired.to_path_buf())
         }
         ConflictPolicy::Overwrite => {
             if desired.exists() {
                 std::fs::remove_dir_all(desired)?;
             }
-            copy_tree(src, desired)?;
+            copy_tree_or_cleanup(src, desired)?;
             Ok(desired.to_path_buf())
         }
     }
+}
+
+/// Copy `src` into `dest`; on failure best-effort remove the partial `dest` this
+/// call created, mirroring `ZipArchiver`'s partial-output cleanup, so a failed
+/// task never leaves a half-copied tree that looks like complete output.
+fn copy_tree_or_cleanup(src: &Path, dest: &Path) -> Result<(), PlaceError> {
+    if let Err(e) = copy_tree(src, dest) {
+        // Best-effort: removal errors are intentionally swallowed (a logging
+        // pass is deferred, matching `remove_partial_output`).
+        let _ = std::fs::remove_dir_all(dest);
+        return Err(PlaceError::Io(e));
+    }
+    Ok(())
 }
 
 /// Return `desired` if it does not exist, else `desired (2)`, `desired (3)`, …
@@ -201,5 +214,33 @@ mod tests {
             std::fs::read(dest.join("sub").join("b.txt")).unwrap(),
             b"beta"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn copy_error_removes_the_partial_destination() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"alpha").unwrap();
+        let locked = src.path().join("locked.bin");
+        std::fs::write(&locked, b"x").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        let dest = out.path().join("foo");
+
+        let err = FsPlacer::new()
+            .place(src.path(), &dest, ConflictPolicy::AutoRename)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, PlaceError::Io(_)), "got {err:?}");
+        assert!(
+            !dest.exists(),
+            "a placement error must not leave a partial destination tree"
+        );
+
+        // Restore perms so the TempDir can clean up.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o644)).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Folder-mode placement copies a tree file-by-file; a mid-copy error (disk-full, permissions, unreadable source) propagated but left a half-copied directory in the output folder that looks like finished output — asymmetric with `ZipArchiver`'s partial-output cleanup. `FsPlacer` now removes the partial destination on a copy error. Backend-only change in `crates/core`.

## Background / Motivation

- `copy_tree` creates `dest` then recurses; on error it returned `Err` but the partially-populated `dest` remained in `out_dir`.
- The task was reported Failed while the output folder kept a convincing half-copy.
- Under `ConflictPolicy::Overwrite` the existing folder is `remove_dir_all`'d before copying, so a failure lost the original and left the partial stand-in.

## Changes

### Cleanup helper (`crates/core/src/infrastructure/fs_placer.rs`)

- Add `copy_tree_or_cleanup(src, dest)`: on a `copy_tree` error, best-effort `remove_dir_all(dest)` then return `PlaceError::Io(e)`, mirroring `ZipArchiver`'s `remove_partial_output`.
- Wire it into all three `ConflictPolicy` branches (AutoRename / Skip-new-copy / Overwrite); the Skip "return existing" path is unchanged.

### Tests

- New Unix-only `copy_error_removes_the_partial_destination`: a `0o000` source file forces `std::fs::copy` to fail after `dest` is created; asserts `PlaceError::Io` AND `!dest.exists()`. Failed pre-fix, passes post-fix.

## Verification

- `cargo nextest run -p simple-archiver-core` — 258 passed
- `cargo nextest run -p simple-archiver-core --release` — 258 passed
- `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` — clean
- `cargo fmt -p simple-archiver-core --check` — no diff

Out of scope: preserving the original folder under `Overwrite` (temp dir + rename) — tracked separately.

Closes #198
