### PR TITLE
perf(zip): widen extraction read buffer to cut blocking-pool round trips

### DIFF
--- a/crates/core/src/infrastructure/zip_extractor.rs
+++ b/crates/core/src/infrastructure/zip_extractor.rs
@@ -38,7 +38,11 @@ impl Extractor for ZipExtractor {
         // `tokio::fs::File` implements `AsyncSeek` but NOT `AsyncBufRead`, so the
         // `BufReader` adds the missing buffered-read layer.
         let file = tokio::fs::File::open(src_archive).await?; // io::Error -> ExtractError::Io
-        let buf = tokio::io::BufReader::new(file);
+
+        // A 256 KiB buffer cuts the number of blocking-pool read round trips ~32x versus
+        // the 8 KiB default, which matters on large archives where every fill_buf is a
+        // cross-thread dispatch on tokio::fs::File.
+        let buf = tokio::io::BufReader::with_capacity(256 * 1024, file);
         let mut reader = ZipFileReader::with_tokio(buf)
             .await
             .map_err(|e| ExtractError::Backend(e.to_string()))?;


### PR DESCRIPTION
## Summary

`ZipExtractor` wrapped the `tokio::fs::File` in a default 8 KiB `BufReader`; since `tokio::fs` dispatches every read to the blocking thread pool, that is ~130k cross-thread round trips per GiB of input. Widening the buffer to 256 KiB cuts those ~32×. Behavior-preserving one-line change in `crates/core`.

## Background / Motivation

- The seek reader (`ZipFileReader::with_tokio`) requires `AsyncBufRead`; `tokio::fs::File` provides `AsyncSeek` but not buffered reads, so the `BufReader` supplies that layer.
- At the 8 KiB default each `fill_buf` is a blocking-pool dispatch, adding a constant-factor delay that grows with archive size — a measurable tax on large zips.

## Changes

### Larger read buffer (`crates/core/src/infrastructure/zip_extractor.rs`)

- Replace `BufReader::new(file)` with `BufReader::with_capacity(256 * 1024, file)`, plus an English comment explaining the round-trip reduction.

## Tests

- No new behavior test: this is a constant-only change with no observable difference (entry names, CRC verification, and the zip-slip guard are all unchanged); a test would couple to the buffer capacity. The existing zip-extraction suite is the regression guard and stays green.

## Verification

- `cargo nextest run -p simple-archiver-core` — 257 passed
- `cargo nextest run -p simple-archiver-core --release` — 257 passed
- `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` — clean
- `cargo fmt -p simple-archiver-core --check` — no diff
- Recommended (not run in CI): extract a ~1 GB zip and compare wall time before/after; if the delta is under 5%, this can be closed without merging.

Closes #199
