### PR TITLE
fix(ui): guard runJob against re-entrancy

### DIFF
--- a/src/store/jobStore.test.ts
+++ b/src/store/jobStore.test.ts
@@ -990,6 +990,17 @@ describe("runJob", () => {
     expect(useJobStore.getState().taskIdByIndex).toEqual([33, 44]);
     expect(useJobStore.getState().summary).toEqual(summary);
   });
+
+  it("ignores a re-entrant runJob while a run is in flight", async () => {
+    // A run owns `running`; a second invocation mid-run must be a no-op so its
+    // rejected catch cannot flip running:false while job #1 is still live.
+    useJobStore.setState({ running: true });
+
+    await useJobStore.getState().runJob();
+
+    expect(mockArchive.runJob).not.toHaveBeenCalled();
+    expect(useJobStore.getState().running).toBe(true);
+  });
 });
 
 describe("applyProgress", () => {

--- a/src/store/jobStore.ts
+++ b/src/store/jobStore.ts
@@ -410,6 +410,11 @@ export const useJobStore = create<JobState>()((set, get) => ({
   },
 
   runJob: async () => {
+    // A run owns `running`; a second invocation mid-run must not touch it. Without
+    // this guard a re-entrant call is rejected by the backend ("a job is already
+    // running") and its catch would flip running:false while job #1 is still live,
+    // making the UI read idle during an active run.
+    if (get().running) return;
     // Starting the next run supersedes the residual chip, just like queuing.
     set({
       running: true,


### PR DESCRIPTION
## Summary

`runJob` had no re-entrancy guard — a second invocation mid-run was rejected by the backend, but its `catch` flipped `running: false` while job #1 was still live, making the UI read idle during an active run. `runJob` now no-ops if a run is already in flight.

## Background / Motivation

- The only guard was the `RunControls` disabled state; the store itself had none, so correctness depended on the render layer.
- A re-entrant `runJob` (future UI change, keybinding, test-external race) → backend returns `"a job is already running"` → the second call's `catch` sets `running: false` → Run reappears and Cancel vanishes mid-run until job #1's promise resolves.

## Changes

### Store-level re-entrancy guard (`src/store/jobStore.ts`)

- Add `if (get().running) return;` as the first statement of `runJob`, before the opening `set(...)`, with an English comment. A run owns `running`; a second invocation must not touch it.

### Tests

- New `ignores a re-entrant runJob while a run is in flight` in `src/store/jobStore.test.ts`: with `running: true`, `runJob` does not call `mockArchive.runJob` and leaves `running` true. Failed pre-fix (backend called once), passes post-fix.

## Verification

- `pnpm test` — 611 passed (incl. the new test)
- `pnpm lint:ci` / `pnpm fmt:check` — clean
- `pnpm build` (tsc + vite) — ok
- `pnpm knip` — clean

## Stacking

This PR is **stacked on #205** (base `fix/clear-progress-on-rerun`), because B3 and B4 both edit `runJob`. The diff here is only the guard + its test (`src/store/jobStore.ts`, `src/store/jobStore.test.ts`). Merge #205 first, then retarget this PR to `main`; the `Closes #203` reference registers as auto-closing only once the base is the default branch.

Closes #203
