### PR TITLE
fix(zip): extract archives with an oversized extra-field subfield

### DIFF
--- a/crates/core/src/application/run_archive_job.rs
+++ b/crates/core/src/application/run_archive_job.rs
@@ -128,9 +128,8 @@ impl<A: Archiver + 'static, E: Extractor + 'static, P: Placer + 'static> RunArch
 
         // Drive the aggregation loop, then join workers (compress outcomes are
         // already captured as terminal events). A panicked worker yields a join
-        // error here; we ignore it because the task is still tallied as `failed`
-        // via `into_summary`'s state reconciliation (it never reached a terminal
-        // status), so no behavior change is needed.
+        // error here; we ignore it because its `TerminalGuard` has already reported
+        // the panic as that task's terminal `Fail`, so there is nothing to recover.
         let summary = drive_aggregation(job, clock, sink, rx).await;
         for handle in handles {
             let _ = handle.await;
@@ -255,9 +254,77 @@ async fn drive_aggregation<C: Clock, S: ProgressSink>(
     aggregator.into_summary()
 }
 
+/// Guarantees a worker always reports a terminal event, even when it dies.
+///
+/// [`run_one_inner`] sends exactly one terminal event on every path it returns
+/// from, so the guard is disarmed the moment that body returns. A guard that drops
+/// while still armed means the worker never got there — a panic inside a backend
+/// library, or the future being dropped — and it emits `Fail` so the task carries a
+/// cause instead of being reconciled into the opaque "did not reach a terminal
+/// state", which names the symptom rather than the bug.
+struct TerminalGuard {
+    task: TaskId,
+    tx: mpsc::UnboundedSender<WorkerMsg>,
+    armed: bool,
+}
+
+impl TerminalGuard {
+    fn new(task: TaskId, tx: mpsc::UnboundedSender<WorkerMsg>) -> Self {
+        Self {
+            task,
+            tx,
+            armed: true,
+        }
+    }
+
+    /// Stand down: the body reported its own terminal event.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // `panicking()` holds only while this thread unwinds, which separates a
+        // worker that panicked from one whose future was dropped before finishing.
+        let reason = if std::thread::panicking() {
+            "worker panicked before reporting a result"
+        } else {
+            "worker stopped before reporting a result"
+        };
+        let _ = self.tx.send(WorkerMsg::Status {
+            task: self.task,
+            event: TaskEvent::Fail {
+                reason: reason.to_string(),
+            },
+        });
+    }
+}
+
+/// Execute a single work item under a [`TerminalGuard`], so a panicking backend
+/// still yields a terminal event for the task.
+async fn run_one<A: Archiver, E: Extractor, P: Placer>(
+    archiver: &A,
+    registry: &FormatRegistry<E>,
+    placer: &P,
+    item: WorkItem,
+    tx: mpsc::UnboundedSender<WorkerMsg>,
+    cancellation_token: CancellationToken,
+) {
+    let mut guard = TerminalGuard::new(item.task, tx.clone());
+    run_one_inner(archiver, registry, placer, item, tx, cancellation_token).await;
+    guard.disarm();
+}
+
 /// Execute a single work item: checkpoint → extract → write → emit terminal.
 /// The "write" phase is compression (Zip) or placement (Folder).
-async fn run_one<A: Archiver, E: Extractor, P: Placer>(
+///
+/// Every path that returns from here has sent exactly one terminal event, which is
+/// what lets [`run_one`] disarm its guard on return.
+async fn run_one_inner<A: Archiver, E: Extractor, P: Placer>(
     archiver: &A,
     registry: &FormatRegistry<E>,
     placer: &P,
@@ -519,6 +586,20 @@ mod tests {
         }
     }
 
+    /// An extractor that panics instead of returning, standing in for a bug in a
+    /// backend library (the real one: `async_zip` panicking on an overflow check
+    /// while rejecting a malformed header).
+    struct PanickingExtractor;
+    impl Extractor for PanickingExtractor {
+        async fn extract(
+            &self,
+            _src: &Path,
+            _ctx: &ExtractContext,
+        ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
+            panic!("backend exploded");
+        }
+    }
+
     /// A fake placer: records each dest it is asked to place and always succeeds
     /// (returns the desired path). The engine test only checks that place was
     /// called with the right destination paths; it does not create on-disk state.
@@ -640,6 +721,40 @@ mod tests {
         assert!(
             seen.iter().all(|p| *p == ConflictPolicy::Overwrite),
             "every compress call must receive the job's policy, got {seen:?}"
+        );
+    }
+
+    /// A panicking worker used to emit no terminal event at all, leaving the task
+    /// stuck mid-flight; `into_summary` then reconciled it into the opaque "task did
+    /// not reach a terminal state (status: Extracting)". That message names the
+    /// symptom, not the cause, so the worker must report the panic itself.
+    #[tokio::test]
+    async fn a_panicking_worker_reports_its_task_as_failed_by_panic() {
+        let job = ArchiveJob::plan(
+            vec![SourceItem::RarFile(PathBuf::from("a.rar"))],
+            NamingRule::parse("f{n}").unwrap(),
+            OutputDirectory::new(PathBuf::from("/out")),
+        )
+        .unwrap();
+        let ids: Vec<TaskId> = job.tasks().iter().map(|t| t.id()).collect();
+        let engine = RunArchiveJob::new(
+            Arc::new(FakeArchiver::new()),
+            Arc::new(PanickingExtractor),
+            Arc::new(FakePlacer::new()),
+            nz(2),
+        );
+        let sink = RecordingSink::default();
+        let clock = FixedClock(Instant::now());
+
+        let summary = engine.execute(job, &clock, &sink).await;
+
+        assert!(summary.succeeded.is_empty() && summary.cancelled.is_empty());
+        assert_eq!(summary.failed.len(), 1, "the panicked task is tallied once");
+        let (id, reason) = &summary.failed[0];
+        assert_eq!(*id, ids[0]);
+        assert!(
+            reason.contains("panicked"),
+            "the failure must name the panic, got {reason:?}"
         );
     }
 

--- a/crates/core/src/domain/archive_job.rs
+++ b/crates/core/src/domain/archive_job.rs
@@ -343,9 +343,11 @@ impl ArchiveJob {
     ///
     /// This is the domain's run-summary policy: `Completed` is a success,
     /// `Cancelled` is its own bucket (NOT a failure), and `Failed { reason }`
-    /// carries its reason. Non-terminal tasks (e.g. a worker that panicked before
-    /// emitting `Complete`/`Fail`) are reconciled as `Failed` with a synthesized
-    /// reason so the result is total — every task is always accounted for.
+    /// carries its reason. Non-terminal tasks (e.g. a worker whose terminal status
+    /// was dropped because the aggregator had already torn down) are reconciled as
+    /// `Failed` with a synthesized reason so the result is total — every task is
+    /// always accounted for. This is the last line of defence: workers report even
+    /// a panic as a real `Fail`, so a reconciled reason means the event was lost.
     ///
     /// Outcomes are returned in job/task order, matching [`ArchiveJob::tasks`].
     pub fn outcomes(&self) -> Vec<TaskOutcome> {

--- a/crates/core/src/infrastructure/mod.rs
+++ b/crates/core/src/infrastructure/mod.rs
@@ -22,3 +22,5 @@ pub mod unrar_extractor;
 pub mod zip_archiver;
 #[cfg(not(loom))]
 pub mod zip_extractor;
+#[cfg(not(loom))]
+mod zip_repair;

--- a/crates/core/src/infrastructure/zip_extractor.rs
+++ b/crates/core/src/infrastructure/zip_extractor.rs
@@ -11,6 +11,7 @@ use crate::application::extract_context::ExtractContext;
 use crate::application::ports::{ExtractError, ExtractedTree, Extractor};
 use crate::infrastructure::path_utils::{classified_components, PathPart};
 use crate::infrastructure::temp_workspace::TempWorkspace;
+use crate::infrastructure::zip_repair::{self, RepairedZip};
 use async_zip::tokio::read::seek::ZipFileReader;
 use std::path::{Path, PathBuf};
 
@@ -33,11 +34,20 @@ impl Extractor for ZipExtractor {
     ) -> Result<Box<dyn ExtractedTree>, ExtractError> {
         let workspace = TempWorkspace::new()?; // io::Error -> ExtractError::Io
 
+        // Some repackers emit an extra field `async_zip` refuses to parse, which
+        // fails an otherwise valid archive outright (and panics on the overflow
+        // check while building that error). Clamp those declared sizes into a temp
+        // copy first; an archive that needs no repair is read in place, at the cost
+        // of one central-directory read. `repaired` owns the copy, so it stays bound
+        // for the whole extraction.
+        let repaired = zip_repair::repair_extra_fields(src_archive).await?;
+        let source = repaired.as_ref().map_or(src_archive, RepairedZip::path);
+
         // Open the archive with tokio and wrap in a buffered reader: the seek
         // reader (`ZipFileReader::with_tokio`) requires `AsyncBufRead + AsyncSeek`.
         // `tokio::fs::File` implements `AsyncSeek` but NOT `AsyncBufRead`, so the
         // `BufReader` adds the missing buffered-read layer.
-        let file = tokio::fs::File::open(src_archive).await?; // io::Error -> ExtractError::Io
+        let file = tokio::fs::File::open(source).await?; // io::Error -> ExtractError::Io
 
         // A 256 KiB buffer cuts the number of blocking-pool read round trips ~32x versus
         // the 8 KiB default, which matters on large archives where every fill_buf is a
@@ -156,6 +166,7 @@ fn safe_relative_path(name: &str) -> Result<Option<PathBuf>, ExtractError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::infrastructure::zip_repair::zip_with_oversized_extra_field;
     use std::io::Write as _;
     use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
@@ -255,6 +266,23 @@ mod tests {
         let extracted = std::fs::read(root.join("青の祓魔師 第08巻").join("第01話.txt"))
             .expect("file extracted under decoded UTF-8 name");
         assert_eq!(extracted, b"chapter");
+    }
+
+    #[tokio::test]
+    async fn extracts_zip_whose_extra_field_declares_more_bytes_than_it_has() {
+        // `async_zip` rejects the whole archive when an extra field's declared
+        // subfield size overruns the field (and, with overflow checks on, panics
+        // building that error). Every other extractor ignores the unparseable
+        // field, so the entry data — which is intact — must still come out.
+        let zip = zip_with_oversized_extra_field("scan_01.jpg", b"jpeg-bytes");
+
+        let tree = ZipExtractor::new()
+            .extract(zip.path(), &ExtractContext::detached())
+            .await
+            .expect("a malformed extra field must not fail an otherwise valid zip");
+
+        let extracted = std::fs::read(tree.path().join("scan_01.jpg")).expect("entry extracted");
+        assert_eq!(extracted, b"jpeg-bytes");
     }
 
     #[tokio::test]

--- a/crates/core/src/infrastructure/zip_repair.rs
+++ b/crates/core/src/infrastructure/zip_repair.rs
@@ -1,0 +1,491 @@
+//! Repairs zip archives whose extra fields `async_zip` refuses to parse.
+//!
+//! Some Windows repackers emit a proprietary extra-field subfield whose declared
+//! data size overruns the field it lives in. `unzip`, macOS and 7-Zip ignore an
+//! unparseable extra field; `async_zip` instead fails the whole archive (and, with
+//! overflow checks on, panics while building that error), so an otherwise valid
+//! archive cannot be opened at all.
+//!
+//! This module scans an archive for such subfields and, when it finds any, writes
+//! a repaired copy with each offending declared size CLAMPED to the bytes actually
+//! present. Clamping rewrites two bytes in place, so every local-header, central
+//! directory and end-of-central-directory offset stays valid and the entry data is
+//! untouched — the copy differs from the original only in those size fields.
+
+use crate::infrastructure::temp_workspace::TempWorkspace;
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+/// A repaired copy of an archive. `Drop` removes it along with its temp directory.
+#[derive(Debug)]
+pub(crate) struct RepairedZip {
+    // Held for its `Drop`: it owns the temp directory `path` lives in.
+    _workspace: TempWorkspace,
+    path: PathBuf,
+}
+
+impl RepairedZip {
+    /// The path of the repaired copy, valid until this guard drops.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Scan `src` for extra fields whose declared subfield size overruns the field and,
+/// if there are any, write a repaired copy with those sizes clamped.
+///
+/// Returns `Ok(None)` when the archive needs no repair — nothing is copied, so the
+/// common case costs one central-directory read and one small read per entry.
+/// A scan that cannot proceed confidently (no end-of-central-directory record, a
+/// zip64 archive, an unexpected header signature) also yields `Ok(None)`, leaving
+/// the original archive for `async_zip` to accept or reject on its own terms.
+pub(crate) async fn repair_extra_fields(src: &Path) -> std::io::Result<Option<RepairedZip>> {
+    let fixups = scan_fixups(src).await?;
+    if fixups.is_empty() {
+        return Ok(None);
+    }
+
+    let workspace = TempWorkspace::new()?;
+    let path = workspace.path().join(REPAIRED_FILE_NAME);
+    tokio::fs::copy(src, &path).await?;
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .await?;
+    for (offset, clamped) in fixups {
+        file.seek(SeekFrom::Start(offset)).await?;
+        file.write_all(&clamped.to_le_bytes()).await?;
+    }
+    file.flush().await?;
+
+    Ok(Some(RepairedZip {
+        _workspace: workspace,
+        path,
+    }))
+}
+
+/// Name given to the repaired copy inside its temp directory.
+const REPAIRED_FILE_NAME: &str = "repaired.zip";
+
+/// Signatures and fixed header lengths from the zip spec (APPNOTE 4.3.7/4.3.12/4.3.16).
+const LOCAL_HEADER_SIGNATURE: [u8; 4] = [b'P', b'K', 3, 4];
+const CD_ENTRY_SIGNATURE: [u8; 4] = [b'P', b'K', 1, 2];
+const EOCD_SIGNATURE: [u8; 4] = [b'P', b'K', 5, 6];
+const LOCAL_HEADER_FIXED_LEN: usize = 30;
+const CD_ENTRY_FIXED_LEN: usize = 46;
+const EOCD_FIXED_LEN: usize = 22;
+/// Values replaced by these sentinels live in a zip64 record instead.
+const ZIP64_SENTINEL_U16: u16 = u16::MAX;
+const ZIP64_SENTINEL_U32: u32 = u32::MAX;
+
+/// Absolute file offset of a 2-byte declared-size field, and the size to write there.
+type Fixup = (u64, u16);
+
+/// Collect the size fields that need clamping, in both the central directory and
+/// the local headers (`async_zip` parses the extra fields of both).
+///
+/// An empty result means "nothing to repair" and is also what every give-up path
+/// returns: this scan is an opportunistic repair, so anything it cannot walk with
+/// confidence is left to `async_zip`.
+///
+/// The offset arithmetic below cannot overflow: the record rejects the zip64
+/// sentinels, so the central directory is at most `u32::MAX` bytes long and every
+/// length read out of a header is `u16`-bounded — sums stay far inside a 64-bit
+/// `usize`. That is the very trap this module exists to work around, so it is
+/// worth stating rather than assuming.
+async fn scan_fixups(src: &Path) -> std::io::Result<Vec<Fixup>> {
+    let mut file = tokio::fs::File::open(src).await?;
+    let file_len = file.metadata().await?.len();
+
+    let Some((cd_offset, cd_len, entries)) = read_eocd(&mut file, file_len).await? else {
+        return Ok(Vec::new());
+    };
+    if cd_offset + cd_len > file_len {
+        return Ok(Vec::new());
+    }
+
+    let mut cd = vec![0u8; cd_len as usize];
+    file.seek(SeekFrom::Start(cd_offset)).await?;
+    file.read_exact(&mut cd).await?;
+
+    let mut fixups = Vec::new();
+    let mut local_offsets = Vec::with_capacity(entries);
+    let mut pos = 0usize;
+    for _ in 0..entries {
+        if pos + CD_ENTRY_FIXED_LEN > cd.len() || cd[pos..pos + 4] != CD_ENTRY_SIGNATURE {
+            return Ok(Vec::new());
+        }
+        let name_len = le_u16(&cd, pos + 28) as usize;
+        let extra_len = le_u16(&cd, pos + 30) as usize;
+        let comment_len = le_u16(&cd, pos + 32) as usize;
+        let local_offset = le_u32(&cd, pos + 42);
+        let extra_start = pos + CD_ENTRY_FIXED_LEN + name_len;
+        if extra_start + extra_len + comment_len > cd.len() || local_offset == ZIP64_SENTINEL_U32 {
+            return Ok(Vec::new());
+        }
+
+        if let Some((at, clamped)) = overrunning_subfield(&cd[extra_start..extra_start + extra_len])
+        {
+            fixups.push((cd_offset + (extra_start + at) as u64, clamped));
+        }
+        local_offsets.push(u64::from(local_offset));
+        pos = extra_start + extra_len + comment_len;
+    }
+
+    for local_offset in local_offsets {
+        match local_header_fixup(&mut file, file_len, local_offset).await? {
+            Some(Some(fixup)) => fixups.push(fixup),
+            Some(None) => {}               // header read fine, nothing to clamp
+            None => return Ok(Vec::new()), // unwalkable header: give up entirely
+        }
+    }
+
+    Ok(fixups)
+}
+
+/// Inspect the local header at `offset`. The outer `None` means the header could
+/// not be walked; the inner `None` means it holds nothing that needs clamping.
+async fn local_header_fixup(
+    file: &mut tokio::fs::File,
+    file_len: u64,
+    offset: u64,
+) -> std::io::Result<Option<Option<Fixup>>> {
+    if offset + LOCAL_HEADER_FIXED_LEN as u64 > file_len {
+        return Ok(None);
+    }
+    let mut header = [0u8; LOCAL_HEADER_FIXED_LEN];
+    file.seek(SeekFrom::Start(offset)).await?;
+    file.read_exact(&mut header).await?;
+    if header[0..4] != LOCAL_HEADER_SIGNATURE {
+        return Ok(None);
+    }
+
+    let name_len = u64::from(le_u16(&header, 26));
+    let extra_len = le_u16(&header, 28) as usize;
+    let extra_start = offset + LOCAL_HEADER_FIXED_LEN as u64 + name_len;
+    if extra_start + extra_len as u64 > file_len {
+        return Ok(None);
+    }
+    if extra_len == 0 {
+        return Ok(Some(None));
+    }
+
+    let mut extra = vec![0u8; extra_len];
+    file.seek(SeekFrom::Start(extra_start)).await?;
+    file.read_exact(&mut extra).await?;
+    Ok(Some(
+        overrunning_subfield(&extra).map(|(at, clamped)| (extra_start + at as u64, clamped)),
+    ))
+}
+
+/// Locate the end-of-central-directory record and return
+/// `(central directory offset, central directory length, entry count)`.
+///
+/// `None` means there is no usable record: the file is not a zip, the record is
+/// buried further back than a maximal comment allows, or the archive is zip64 (whose
+/// real values live in a separate record this opportunistic scan does not read).
+async fn read_eocd(
+    file: &mut tokio::fs::File,
+    file_len: u64,
+) -> std::io::Result<Option<(u64, u64, usize)>> {
+    // The record sits at the very end, followed only by a comment of at most
+    // u16::MAX bytes, so that tail is the whole search space.
+    let tail_len = (EOCD_FIXED_LEN as u64 + u64::from(u16::MAX)).min(file_len);
+    let tail_start = file_len - tail_len;
+    let mut tail = vec![0u8; tail_len as usize];
+    file.seek(SeekFrom::Start(tail_start)).await?;
+    file.read_exact(&mut tail).await?;
+
+    let Some(at) = tail
+        .windows(EOCD_SIGNATURE.len())
+        .rposition(|w| w == EOCD_SIGNATURE)
+    else {
+        return Ok(None);
+    };
+    let eocd = &tail[at..];
+    if eocd.len() < EOCD_FIXED_LEN {
+        return Ok(None);
+    }
+
+    let entries = le_u16(eocd, 10);
+    let cd_len = le_u32(eocd, 12);
+    let cd_offset = le_u32(eocd, 16);
+    if entries == ZIP64_SENTINEL_U16
+        || cd_len == ZIP64_SENTINEL_U32
+        || cd_offset == ZIP64_SENTINEL_U32
+    {
+        return Ok(None);
+    }
+    Ok(Some((
+        u64::from(cd_offset),
+        u64::from(cd_len),
+        entries as usize,
+    )))
+}
+
+/// Read the little-endian `u16` at `at`. Callers bound-check the slice first.
+fn le_u16(bytes: &[u8], at: usize) -> u16 {
+    u16::from_le_bytes([bytes[at], bytes[at + 1]])
+}
+
+/// Read the little-endian `u32` at `at`. Callers bound-check the slice first.
+fn le_u32(bytes: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]])
+}
+
+/// Locate the one subfield in `extra` whose declared size overruns the block.
+///
+/// Returns the offset of that subfield's 2-byte size field within `extra` and the
+/// size it must be clamped to. At most one such subfield can exist: everything
+/// after it lies inside its (clamped) data, so the walk ends there.
+///
+/// The walk mirrors `async_zip`'s own parser, including its `cursor + 4 < len`
+/// bound — a trailing block too short to hold another header is ignored by both.
+fn overrunning_subfield(extra: &[u8]) -> Option<(usize, u16)> {
+    let mut cursor = 0;
+    while cursor + 4 < extra.len() {
+        let declared = u16::from_le_bytes([extra[cursor + 2], extra[cursor + 3]]);
+        let available = extra.len() - cursor - 4;
+        if declared as usize > available {
+            // `available` came from a `u16`-bounded extra field, so it always fits.
+            return Some((cursor + 2, available as u16));
+        }
+        cursor += 4 + declared as usize;
+    }
+    None
+}
+
+/// The proprietary subfield id the real-world broken archives carry.
+#[cfg(test)]
+pub(crate) const BROKEN_SUBFIELD_ID: u16 = 0x4004;
+/// Bytes actually present in that subfield.
+#[cfg(test)]
+pub(crate) const BROKEN_SUBFIELD_PRESENT: u16 = 13;
+/// Bytes it claims to have.
+#[cfg(test)]
+pub(crate) const BROKEN_SUBFIELD_DECLARED: u16 = 600;
+
+/// Build a zip whose entries carry a MALFORMED extra field, reproducing what some
+/// Windows repackers emit: subfield [`BROKEN_SUBFIELD_ID`] declares
+/// [`BROKEN_SUBFIELD_DECLARED`] data bytes while only [`BROKEN_SUBFIELD_PRESENT`]
+/// are present.
+///
+/// The field is written with its true size first and the declared size is then
+/// patched in the finished bytes, so only the two size bytes change — every header
+/// offset stays valid, exactly as in the real archives. `unzip`, macOS and 7-Zip
+/// ignore an unparseable extra field and open such archives fine.
+#[cfg(test)]
+pub(crate) fn zip_with_oversized_extra_field(name: &str, bytes: &[u8]) -> tempfile::NamedTempFile {
+    use std::io::{Cursor, Write as _};
+    use zip::write::{ExtendedFileOptions, FileOptions};
+    use zip::ZipWriter;
+
+    let mut options: FileOptions<'static, ExtendedFileOptions> = FileOptions::default();
+    options
+        .add_extra_data(
+            BROKEN_SUBFIELD_ID,
+            &vec![0u8; BROKEN_SUBFIELD_PRESENT as usize][..],
+            false,
+        )
+        .expect("add proprietary extra field");
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    writer.start_file(name, options).expect("start zip entry");
+    writer.write_all(bytes).expect("write zip entry bytes");
+    let mut raw = writer.finish().expect("finalize zip").into_inner();
+
+    // Patch every `id + true size` header to declare the oversized length. Both
+    // the local header and the central directory carry a copy of the field.
+    let mut sound = BROKEN_SUBFIELD_ID.to_le_bytes().to_vec();
+    sound.extend_from_slice(&BROKEN_SUBFIELD_PRESENT.to_le_bytes());
+    let mut broken = BROKEN_SUBFIELD_ID.to_le_bytes().to_vec();
+    broken.extend_from_slice(&BROKEN_SUBFIELD_DECLARED.to_le_bytes());
+    let mut patched = 0;
+    for i in 0..raw.len().saturating_sub(3) {
+        if raw[i..i + 4] == sound[..] {
+            raw[i..i + 4].copy_from_slice(&broken);
+            patched += 1;
+        }
+    }
+    assert_eq!(
+        patched, 2,
+        "fixture must corrupt the local header and central directory copies"
+    );
+
+    let tmp = tempfile::NamedTempFile::new().expect("temp zip file");
+    std::fs::write(tmp.path(), &raw).expect("write fixture zip");
+    tmp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build one extra-field block from `(header_id, declared_size, data)` triples.
+    /// `declared_size` is written verbatim so a test can declare more than it gives.
+    fn block(subfields: &[(u16, u16, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (id, declared, data) in subfields {
+            out.extend_from_slice(&id.to_le_bytes());
+            out.extend_from_slice(&declared.to_le_bytes());
+            out.extend_from_slice(data);
+        }
+        out
+    }
+
+    #[test]
+    fn well_formed_single_subfield_needs_no_clamp() {
+        let extra = block(&[(0x5455, 5, &[1, 2, 3, 4, 5])]);
+        assert_eq!(overrunning_subfield(&extra), None);
+    }
+
+    #[test]
+    fn well_formed_consecutive_subfields_need_no_clamp() {
+        let extra = block(&[(0x5455, 5, &[1, 2, 3, 4, 5]), (0x7875, 3, &[9, 9, 9])]);
+        assert_eq!(overrunning_subfield(&extra), None);
+    }
+
+    #[test]
+    fn empty_block_needs_no_clamp() {
+        assert_eq!(overrunning_subfield(&[]), None);
+    }
+
+    #[test]
+    fn trailing_bytes_too_short_for_a_header_are_ignored() {
+        // Three leftover bytes cannot hold an id + size pair. `async_zip` stops
+        // there too, so there is nothing to repair.
+        let mut extra = block(&[(0x5455, 5, &[1, 2, 3, 4, 5])]);
+        extra.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+        assert_eq!(overrunning_subfield(&extra), None);
+    }
+
+    #[test]
+    fn oversized_subfield_is_clamped_to_the_bytes_present() {
+        // The real-world shape: id 0x4004 declares 600 bytes, 13 are present.
+        let extra = block(&[(0x4004, 600, &[0u8; 13])]);
+        assert_eq!(overrunning_subfield(&extra), Some((2, 13)));
+    }
+
+    #[test]
+    fn oversized_subfield_after_a_valid_one_is_clamped() {
+        // The walk must reach the second subfield before clamping, so the reported
+        // offset is relative to the whole block, not to the offending subfield.
+        let extra = block(&[(0x5455, 5, &[1, 2, 3, 4, 5]), (0x4004, 600, &[0u8; 13])]);
+        assert_eq!(overrunning_subfield(&extra), Some((9 + 2, 13)));
+    }
+
+    #[test]
+    fn subfield_overrunning_by_one_byte_is_clamped() {
+        // Boundary case: declared size exceeds the remaining bytes by exactly one.
+        let extra = block(&[(0x4004, 6, &[0u8; 5])]);
+        assert_eq!(overrunning_subfield(&extra), Some((2, 5)));
+    }
+
+    /// Build a zip with no extra fields at all, using the sync `zip` dev-dependency.
+    fn plain_zip(name: &str, bytes: &[u8]) -> tempfile::NamedTempFile {
+        use std::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("temp zip file");
+        let mut writer = zip::ZipWriter::new(tmp.reopen().expect("reopen temp zip"));
+        writer
+            .start_file(name, zip::write::SimpleFileOptions::default())
+            .expect("start zip entry");
+        writer.write_all(bytes).expect("write zip entry bytes");
+        writer.finish().expect("finalize zip");
+        tmp
+    }
+
+    #[tokio::test]
+    async fn sound_archive_is_left_alone() {
+        // No overrunning subfield means no copy: the happy path must not pay for
+        // duplicating an archive that `async_zip` can already open.
+        let zip = plain_zip("a.txt", b"alpha");
+
+        let repaired = repair_extra_fields(zip.path())
+            .await
+            .expect("scan should succeed");
+
+        assert!(
+            repaired.is_none(),
+            "an archive with parseable extra fields needs no repaired copy"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_zip_input_is_left_alone() {
+        // Without an end-of-central-directory record there is nothing to walk, so
+        // the scan declines and leaves the original for `async_zip` to reject.
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        std::io::Write::write_all(&mut tmp, b"not a zip").expect("write bytes");
+
+        let repaired = repair_extra_fields(tmp.path())
+            .await
+            .expect("scan should succeed");
+
+        assert!(repaired.is_none(), "a non-zip input needs no repaired copy");
+    }
+
+    #[tokio::test]
+    async fn broken_archive_is_copied_with_only_the_size_fields_changed() {
+        // The repair must be byte-for-byte identical to the original except for the
+        // clamped size fields — that is what keeps every header offset, and the
+        // entry data itself, valid.
+        let zip = zip_with_oversized_extra_field("scan_01.jpg", b"jpeg-bytes");
+        let original = std::fs::read(zip.path()).expect("read original");
+
+        let repaired = repair_extra_fields(zip.path())
+            .await
+            .expect("scan should succeed")
+            .expect("a malformed extra field must produce a repaired copy");
+        let fixed = std::fs::read(repaired.path()).expect("read repaired copy");
+
+        assert_eq!(
+            original.len(),
+            fixed.len(),
+            "repair must not resize the file"
+        );
+        let differing: Vec<usize> = (0..original.len())
+            .filter(|&i| original[i] != fixed[i])
+            .collect();
+        // Two size fields of two bytes each, and both bytes of each differ
+        // (600 = 0x0258 vs 13 = 0x000D), so the changes form two adjacent pairs.
+        assert_eq!(
+            differing.len(),
+            4,
+            "only the two size fields (2 bytes each) may change, got {differing:?}"
+        );
+        for pair in differing.chunks_exact(2) {
+            let (at, next) = (pair[0], pair[1]);
+            assert_eq!(next, at + 1, "a size field occupies two adjacent bytes");
+            assert_eq!(
+                u16::from_le_bytes([original[at], original[at + 1]]),
+                BROKEN_SUBFIELD_DECLARED,
+                "the fixture must have declared the oversized length here"
+            );
+            assert_eq!(
+                u16::from_le_bytes([fixed[at], fixed[at + 1]]),
+                BROKEN_SUBFIELD_PRESENT,
+                "each declared size must be clamped to the bytes present"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn repaired_copy_is_removed_when_dropped() {
+        let zip = zip_with_oversized_extra_field("scan_01.jpg", b"jpeg-bytes");
+
+        let path = {
+            let repaired = repair_extra_fields(zip.path())
+                .await
+                .expect("scan should succeed")
+                .expect("repaired copy");
+            repaired.path().to_path_buf()
+        };
+
+        assert!(
+            !path.exists(),
+            "the repaired copy must not outlive its guard"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A zip whose extra fields declare a subfield larger than the field itself could not be extracted at all: `async_zip` rejects the whole archive, and the `usize` arithmetic building that error underflows, so a dev build panics and the worker dies without reporting an outcome. `ZipExtractor` now clamps those declared sizes into a temp copy before opening, and a worker that dies mid-flight reports a real failure reason instead of a stuck task. Backend-only change in `crates/core`.

## Background / Motivation

- The reported archive (246 entries; `unzip -t` reports the data intact) carries a proprietary subfield `0x4004` in every central-directory entry declaring 600 data bytes while the whole extra field is 17 bytes long. `unzip`, macOS and 7-Zip ignore an extra field they cannot parse and open it fine.
- `async_zip` 0.0.18 instead fails the archive in `spec/parse.rs:274`, whose error value computes `data.len() - cursor - 8 - field_size` on `usize`. That underflows: dev builds panic with `attempt to subtract with overflow`; release wraps and reports `extra field size was indicated to be 600 but only 18446744073709551025 bytes remain`.
- The panic killed the worker before it emitted a terminal event, so `ArchiveJob::outcomes` reconciled the task into `task did not reach a terminal state (status: Extracting)` — a message that names the symptom, not the cause.
- 0.0.18 is the latest release and upstream `master` is still unfixed, so there is no version to bump to; `async_zip`'s `spec` module is `pub(crate)`, so there is no hook to override either.

## Changes

### Extra-field repair (`crates/core/src/infrastructure/zip_repair.rs`, new)

- `overrunning_subfield` walks one extra-field block exactly as `async_zip` does (including its `cursor + 4 < len` bound) and returns the offset and clamped value of the subfield whose declared size overruns the block. At most one can exist — everything after it lies inside its clamped data.
- `repair_extra_fields` scans the central directory and every local header (`async_zip` parses the extra fields of both). With nothing to fix it returns `None` and copies nothing, so a sound archive pays only one central-directory read plus one small read per entry.
- When there is something to fix it copies the archive into a `TempWorkspace` and overwrites only the 2-byte declared-size fields. The byte length never changes, so every local-header / central-directory / EOCD offset and all entry data stay valid.
- Anything the scan cannot walk confidently — no EOCD record, a zip64 sentinel, an unexpected signature — yields `None`, leaving the original archive for `async_zip` to accept or reject exactly as before.
- `RepairedZip` owns the temp copy and removes it on drop.

### Extractor wiring (`crates/core/src/infrastructure/zip_extractor.rs`)

- `ZipExtractor::extract` runs the repair first and opens the repaired copy when one exists, holding the guard for the whole extraction. CRC checking via `read_to_end_checked`, the zip-slip guard and CP932 name decoding are untouched.

### Terminal guard for dying workers (`crates/core/src/application/run_archive_job.rs`)

- `run_one` is split into a guard wrapper plus `run_one_inner`. Every path returning from the inner body has already sent exactly one terminal event, which is what lets the wrapper disarm on return.
- A `TerminalGuard` that drops while still armed emits `TaskEvent::Fail` — `worker panicked before reporting a result`, or `worker stopped before reporting a result` when the future was dropped rather than unwound (`std::thread::panicking()`). Defence in depth for any panicking backend, not just this one.
- `ArchiveJob::outcomes`' doc comment now describes reconciliation as the last line of defence rather than as the panic path.

### Tests

- `zip_with_oversized_extra_field` builds the fixture by writing a real `0x4004` subfield and then patching only its declared size, reproducing the reported archive's exact byte layout. Pre-fix it panics at `parse.rs:274:70`, identical to the real file.
- 7 unit tests for `overrunning_subfield`: well-formed single/consecutive, empty, tail too short for a header, oversized first, oversized after a valid one, overrunning by exactly one byte.
- 4 tests for `repair_extra_fields`: a sound archive and a non-zip input are not copied; the repaired copy differs from the original in exactly the four size-field bytes; the copy is removed on drop.
- `extracts_zip_whose_extra_field_declares_more_bytes_than_it_has` in `zip_extractor.rs`. Failed pre-fix, passes post-fix.
- `a_panicking_worker_reports_its_task_as_failed_by_panic` with a `PanickingExtractor` double. Pre-fix it failed with the exact production string `task did not reach a terminal state (status: Extracting)`.

## Verification

- Reported archive (65 MB, 246 entries) now extracts 246/246 — 1.44s debug, 288ms release. Every entry is CRC-checked by `read_to_end_checked`.
- `cargo nextest run -p simple-archiver-core` — 274 passed (12 new)
- `cargo nextest run -p simple-archiver` — 102 passed
- `RUSTFLAGS="--cfg loom" cargo nextest run -p simple-archiver-core --features loom` — 177 passed
- `RUSTFLAGS="--cfg loom" cargo clippy -p simple-archiver-core --features loom --all-targets -- -D warnings` — clean
- `cargo clippy -p simple-archiver-core --all-targets -- -D warnings` and `-p simple-archiver` — clean
- `cargo fmt --check` — no diff
- `pnpm fmt:check` / `lint:ci` / `knip` / `test:coverage` / `build` — all pass

To confirm on a build: drop the reported archive onto the app and Run. The queue row must reach Completed and the output zip must contain 246 jpgs; any regression reappears as a `Failed` row.

No dependency added or changed.
