### PR TITLE
perf(ci): drop the duplicated pnpm test from the app job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,10 @@ jobs:
       - if: matrix.os == 'macos-latest'
         run: cargo clippy -p simple-archiver --all-targets -- -D warnings
       - run: cargo nextest run -p simple-archiver --profile ci
+      # node_modules is installed for `pnpm tauri build` below (beforeBuildCommand: pnpm build),
+      # not for tests: the vitest suite is jsdom-only with no OS-dependent behaviour, so it runs
+      # once in the `frontend` job rather than a third time here on each OS.
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
       # Smoke-build the app in the dev profile (--debug): this reuses the already
       # compiled `target/debug` dependency tree from the nextest steps above, so
       # the full dependency tree is no longer recompiled a second time under the

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,7 +101,7 @@ This project is designed around TDD. **Write tests before implementation.**
 | `loom` | ubuntu | loom-clippy + loom-nextest for `simple-archiver-core` (concurrency model verification) |
 | `hygiene` | ubuntu | cargo-machete (unused deps) + cargo-modules orphan check on the core crate |
 | `frontend` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm run test:coverage`, Codecov upload (`frontend` flag), `pnpm build` |
-| `app` | macos + windows (matrix) | nextest for `simple-archiver-core`; clippy (macOS only) + nextest for the presentation crate `simple-archiver`; `pnpm test`, `pnpm build`, `pnpm tauri build --no-bundle` |
+| `app` | macos + windows (matrix) | nextest for `simple-archiver-core`; clippy (macOS only) + nextest for the presentation crate `simple-archiver`; `pnpm install --frozen-lockfile`, then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend; Vitest runs once in the `frontend` job (jsdom-only, with no OS-dependent behaviour) |
 
 The presentation-crate clippy + nextest steps in the `app` job were added in PR6; the Tauri toolchain (gtk/webkit headers on Linux) is unavailable on ubuntu, so those steps run only on the mac/windows runners.
 


### PR DESCRIPTION
## Summary

The `app` job re-ran the frontend vitest suite on both macOS and Windows, duplicating what the `frontend` job already runs on Linux — 39s of that sat on the workflow's single longest job. This deletes the `- run: pnpm test` step from the `app` job and leaves a comment explaining why `pnpm install --frozen-lockfile` stays. CI-only change; no application code, no coverage change.

## Background / Motivation

- The same 50 vitest files under `src/**/*.{test,spec}.{ts,tsx}` were executed three times per run: `pnpm run test:coverage` in `frontend` (31s, Linux), `pnpm test` in `app (windows)` (39s) and `pnpm test` in `app (macos)` (19s). `package.json` defines `"test": "vitest run"` and `"test:coverage": "vitest run --coverage"` — same files, same `jsdom` environment, same `src/test/setup.ts`.
- `app (windows)` is the critical path of the whole workflow: 7m20s with a mise cache hit (run [30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776)) and 15m11s on a cache miss (run [30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)). `app (macos)` is 4m08s / 11m37s. The duplicate vitest run is 39s of the Windows critical path.
- The only justification for re-running a JS suite on a second OS is OS-dependent behaviour, and `src/` has none: `grep -rn "node:path\|process\.platform\|navigator\.platform" src/` returns no matches, and so does a search for path separators outside tests. The suite is jsdom-only React/TypeScript that never touches the filesystem. `vitest.config.ts` uses `node:path` solely to build the `@` alias, which vite resolves identically on every OS.
- The OS split that *is* load-bearing stays untouched: `cargo nextest run -p simple-archiver-core --profile ci` still runs on Windows only, because Windows is the sole job that catches `\` vs `/` regressions in Rust path handling.

## Changes

### `app` job step removal (`.github/workflows/ci.yml`)

- Removed the single `- run: pnpm test` step from the `app` matrix job (macOS + Windows). Expected saving: −39s on `app (windows)`, −19s on `app (macos)`, in both the cache-hit and cache-miss modes.
- Kept `- run: pnpm install --frozen-lockfile`. It is not there for the tests: `src-tauri/tauri.conf.json` sets `beforeBuildCommand: pnpm build`, so the following `pnpm tauri build --no-bundle --debug` needs `node_modules` present. Removing it would break the smoke build.
- Added an English comment above the install step recording that `node_modules` exists for `pnpm tauri build`, not for tests, so the removed step is not "restored" by a later reader.

### CI documentation (`docs/development.md`)

- The CI-jobs table's `app` row still listed `pnpm test` (and a `pnpm build` step that has never existed as its own step). The row now says the job runs `pnpm install --frozen-lockfile` and then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend, and that Vitest runs once in the `frontend` job because it is jsdom-only with no OS-dependent behaviour. The nextest/clippy clause of that row is left for #248.

### Not touched

- The `frontend` job — it remains the single owner of the vitest suite and of the `coverage/lcov.info` upload to Codecov under the `frontend` flag, so coverage is unaffected.
- All cargo steps in the `app` job (merging the two Windows `nextest` invocations is #232), the workflow header (#228 / #229) and the `jdx/mise-action` steps (#230). Those lanes edit disjoint regions and merge independently.

## Verification

- `actionlint .github/workflows/ci.yml` → exit 0, workflow still parses.
- `git diff origin/main -- .github/workflows/ci.yml` → 3 insertions, 1 deletion, one file. The only removed line is `- run: pnpm test`; `git diff origin/main -- .github/workflows/ci.yml | grep '^-' | grep -c 'pnpm'` returns `1`.
- `grep -n "pnpm test" .github/workflows/ci.yml` → no matches; `grep -n "pnpm install --frozen-lockfile"` still reports both the `frontend` and the `app` occurrence.
- After merge, compare the run against the cache-hit baseline (`app (windows)` 7m20s, `app (macos)` 4m08s):
  `gh run view <run-id> --json jobs --jq '.jobs[] | "\(.name): \(.startedAt) -> \(.completedAt)"'`

## Test plan

- [x] `actionlint .github/workflows/ci.yml` passes
- [x] Two files changed: `.github/workflows/ci.yml` (exactly one `- run: pnpm test` line removed) and `docs/development.md` (one table row corrected)
- [x] `- run: pnpm install --frozen-lockfile` is still present in the `app` job
- [x] Every added comment is in English
- [x] `docs/development.md`'s CI-jobs table no longer claims the `app` job runs `pnpm test`
- [ ] All 6 CI jobs green on this PR
- [ ] `pnpm tauri build --no-bundle --debug` still succeeds on both `app (macos)` and `app (windows)`, proving `pnpm install` was correctly kept
- [ ] `frontend` still uploads `coverage/lcov.info` to Codecov under the `frontend` flag
- [ ] Measured: record `app (windows)` and `app (macos)` totals and compare against the 7m20s / 4m08s cache-hit baseline

Closes #231

