### PR TITLE
perf(ci): declare cargo-binstall in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,11 @@
 rust = { version = "1.97.1", components = "rustfmt,clippy,llvm-tools-preview" }
 node = "24.18.0"
 pnpm = "11.16.0"
+# `cargo.binstall = true` below is a no-op unless cargo-binstall is on PATH: mise's cargo backend
+# probes for the binary and silently falls back to a from-source `cargo install` when it is absent.
+# Declaring it here makes mise install it first (from a prebuilt aqua release, ~2 s) and then use it
+# to fetch the `cargo:` tools below as prebuilt binaries instead of compiling them.
+cargo-binstall = "1.21.1"
 "cargo:cargo-nextest" = "0.9.137"
 "cargo:cargo-llvm-cov" = "0.8.7"
 # The dependency-hygiene tools (cargo-modules, cargo-machete) live in mise.ci-hygiene.toml: both
@@ -12,5 +17,5 @@ pnpm = "11.16.0"
 # them out of this shared config avoids that compile in the core / frontend / app jobs.
 
 [settings]
-# Prefer binary fetch via cargo-binstall when available (faster installs)
+# Fetch `cargo:` tools as prebuilt binaries via cargo-binstall (declared in [tools] above).
 cargo.binstall = true


### PR DESCRIPTION
## Summary

`mise.toml` already asked for binary installs via `cargo.binstall = true`, but that setting is inert unless `cargo-binstall` is on PATH — it is not, on any CI runner — so every cache-miss run compiled `cargo-nextest` and `cargo-llvm-cov` from source, costing 4–6 minutes in each of the six jobs. Declaring `cargo-binstall = "1.21.1"` in `[tools]` makes mise install it first from a prebuilt aqua release and then fetch the `cargo:` tools as prebuilt binaries. One file, one tool entry, plus a corrected comment.

## Background / Motivation

- The `cargo.binstall = true` setting in `[settings]` is a no-op on its own: mise's `cargo` backend probes for a `cargo-binstall` binary on PATH and silently falls back to a from-source `cargo install` when it is absent. Nothing in the repo or in `jdx/mise-action` installs it.
- Measured on the cache-miss run [30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615) (2026-07-26), the `jdx/mise-action` step alone was: `app (windows)` **6m37s**, `app (macos)` **5m50s**, `hygiene` **9m23s**, `loom` **4m30s**, `core` **4m03s**, `frontend` **4m21s**. Its logs contain `Compiling cargo-nextest v0.9.137` and ``Finished `release` profile [optimized] target(s) in 6m 05s``.
- That cache-miss mode is not rare: `gh api repos/{owner}/{repo}/actions/cache/usage` reports `active_caches_size_in_bytes: 12485528599` (12.49 GB) across 53 caches against GitHub's 10 GB per-repo limit, so LRU eviction keeps pushing runs back into it.
- On the cache-hit run [30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776) the same step takes 3–8s, which is what a cache miss should approach once the tools are downloaded rather than built.
- `cargo-modules` (the `hygiene` job, via `mise.ci-hygiene.toml`) publishes no release assets at all, so it keeps compiling from source — tracked separately in #233, out of scope here.

## Changes

### `[tools]` — declare `cargo-binstall` ahead of the `cargo:` entries

- Added `cargo-binstall = "1.21.1"` between `pnpm` and the `"cargo:…"` entries in `mise.toml`. mise's registry resolves the bare name to `aqua:cargo-bins/cargo-binstall` (a prebuilt GitHub release, ~2s) with `cargo:cargo-binstall` only as a fallback — verify with `mise registry | grep '^cargo-binstall'`.
- mise installs it before the `cargo:` tools that consume it, so no ordering directive is needed.
- The version is pinned rather than `"latest"` to stay consistent with the rest of `mise.toml`; `renovate.json` already groups `matchManagers: ["mise"]`, so the new pin is tracked with no `renovate.json` change.

### `[settings]` — correct the misleading comment

- The old comment (`Prefer binary fetch via cargo-binstall when available`) implied the setting worked on its own. It now reads `Fetch cargo: tools as prebuilt binaries via cargo-binstall (declared in [tools] above)`, so the dependency between the two blocks is explicit.

### Not touched

- `mise.ci-hygiene.toml` (#233) and `.github/workflows/ci.yml` (#228 / #229 / #230 / #231 / #232 / #234) are untouched — `git diff --name-only origin/main` prints exactly `mise.toml`.

## Verification

Locally, in a checkout of this branch:

```bash
git diff --name-only origin/main          # -> mise.toml (only)
mise registry | grep '^cargo-binstall'    # -> aqua:cargo-bins/cargo-binstall  cargo:cargo-binstall
mise install                              # exit 0
mise exec -- cargo binstall -V            # -> 1.21.1
mise ls | grep -E 'cargo-binstall|cargo:cargo-(nextest|llvm-cov)'
```

`mise ls` resolves `cargo-binstall 1.21.1`, `cargo:cargo-nextest 0.9.137` and `cargo:cargo-llvm-cov 0.8.7` from this worktree's `mise.toml`, all installed.

On CI, this PR touches `mise.toml`, so its own run is guaranteed to be a cache-miss (Mode B) run — the ideal A/B against the baseline table above. Read the per-job step timings with:

```bash
gh api repos/yasuflatland-lf/simple-archiver/actions/runs/<run-id>/jobs \
  --jq '.jobs[] | "=== \(.name) ===", (.steps[] | "  \(.completed_at) \(.name)")'
```

Reviewer note: when binstall finds no prebuilt binary it logs `Fallback to cargo-install is disabled` and mise retries with `cargo install`. That is the documented fallback path, not an error, and it is exactly what `cargo-modules` will keep doing until #233.

## Test plan

- [x] `git diff --name-only origin/main` prints exactly `mise.toml`
- [x] `mise install` exits 0 in the repo root and `mise exec -- cargo binstall -V` prints `1.21.1`
- [x] `mise ls` shows `cargo-binstall`, `cargo:cargo-nextest` and `cargo:cargo-llvm-cov` installed from this `mise.toml`
- [x] `mise.toml` parses as valid TOML and all comments are in English
- [ ] All 6 CI jobs green on this PR
- [ ] The `jdx/mise-action` step drops below ~1 min on `core`, `loom`, `frontend` and both `app` jobs (baseline: 4m03s / 4m30s / 4m21s / 6m37s / 5m50s)
- [ ] `hygiene` stays at ~9 min — expected, `cargo-modules` has no prebuilt binary (#233)
- [ ] Record the measured per-job `jdx/mise-action` durations from this PR's run in a comment

## Stacking

None. C1 has no dependencies and is fully parallel with the rest of the CI batch (#228–#234); this PR targets `main` directly and touches a file no other item in the batch edits.

Closes #227
