### PR TITLE
perf(ci): scope mise install_args to what each job runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Only the tools this job runs: rustfmt/clippy come from the `rust` entry's components,
       # and this is the sole job that uses cargo-llvm-cov.
+      # `install_args` restricts `mise install` to exactly the tools named, and mise does NOT pull in a
+      # declared-but-unnamed tool as a dependency: with cargo-binstall omitted the cargo backend finds no
+      # binstall on PATH and silently falls back to `cargo install <tool> --locked`, a from-source build.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
-          install_args: rust cargo:cargo-llvm-cov cargo:cargo-nextest
+          install_args: rust cargo-binstall cargo:cargo-llvm-cov cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -41,7 +44,8 @@ jobs:
       # No coverage is collected here, so cargo-llvm-cov is not installed.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
-          install_args: rust cargo:cargo-nextest
+          # cargo-binstall must be named or the `cargo:` tools below fall back to a source build.
+          install_args: rust cargo-binstall cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -68,7 +72,8 @@ jobs:
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
           # `rust` is required because both tools are cargo subcommands invoked as `cargo <sub>`.
-          install_args: rust cargo:cargo-machete cargo:cargo-modules
+          # cargo-binstall must be named or the `cargo:` tools below fall back to a source build.
+          install_args: rust cargo-binstall cargo:cargo-machete cargo:cargo-modules
       # Unused Cargo.toml dependencies across the whole workspace (no compilation needed).
       # Intentional declarations (transitive version pins, PR5 pre-declarations) are
       # allow-listed via `[package.metadata.cargo-machete]` in each crate's Cargo.toml.
@@ -117,7 +122,8 @@ jobs:
       # Runs nextest and the pnpm/tauri build; coverage is collected by the `core` job only.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
-          install_args: rust node pnpm cargo:cargo-nextest
+          # cargo-binstall must be named or the `cargo:` tools below fall back to a source build.
+          install_args: rust node pnpm cargo-binstall cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Only the tools this job runs: rustfmt/clippy come from the `rust` entry's components,
+      # and this is the sole job that uses cargo-llvm-cov.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          install_args: rust cargo:cargo-llvm-cov cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -34,7 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # No coverage is collected here, so cargo-llvm-cov is not installed.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          install_args: rust cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -59,6 +66,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          # `rust` is required because both tools are cargo subcommands invoked as `cargo <sub>`.
+          install_args: rust cargo:cargo-machete cargo:cargo-modules
       # Unused Cargo.toml dependencies across the whole workspace (no compilation needed).
       # Intentional declarations (transitive version pins, PR5 pre-declarations) are
       # allow-listed via `[package.metadata.cargo-machete]` in each crate's Cargo.toml.
@@ -74,7 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # This job is pure JavaScript; without install_args it installs the Rust toolchain and
+      # builds cargo-nextest + cargo-llvm-cov from source (4m21s on a cold cache) for nothing.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          install_args: node pnpm
       - run: pnpm install --frozen-lockfile
       # Frontend format check (config in .oxfmtrc.json); fails if any file is unformatted.
       - run: pnpm fmt:check
@@ -100,7 +114,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Runs nextest and the pnpm/tauri build; coverage is collected by the `core` job only.
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          install_args: rust node pnpm cargo:cargo-nextest
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Every job ran `jdx/mise-action` with no arguments, so every job installed every tool declared in `mise.toml` regardless of what it actually invoked. Each of the five mise steps now carries an explicit `install_args` naming only the tools that job runs, which stops the pure-JavaScript `frontend` job from compiling `cargo-nextest` and `cargo-llvm-cov` from source and leaves `cargo-llvm-cov` installed only in the one job that collects coverage. Every list that contains a `cargo:` entry also names `cargo-binstall`, without which `install_args` would silently cancel #227. Workflow-only change; every pinned action SHA is untouched.

## Background / Motivation

- On a mise cache miss (Mode B, [run 30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)) the `frontend` job spent **4m21s** in its mise step building the Rust toolchain plus `cargo-nextest` and `cargo-llvm-cov` — none of which it ever invokes; it only runs oxfmt / oxlint / knip / vitest / vite build.
- `cargo-llvm-cov` was installed by `core`, `loom`, `hygiene`, `frontend` and both `app` matrix legs, but `cargo llvm-cov` is run by exactly one job (`core`).
- `hygiene` sets `MISE_ENV=ci-hygiene`, which layers `mise.ci-hygiene.toml` *on top of* `mise.toml` — so it built `cargo-nextest` and `cargo-llvm-cov` in addition to `cargo-machete` / `cargo-modules`, and ran none of them.
- The same run shows the cost is a source build, not a download: the logs contain `Compiling cargo-nextest v0.9.137` and ``Finished `release` profile [optimized] target(s) in 6m 05s``. `mise.toml` sets `cargo.binstall = true`, but `cargo-binstall` itself is not installed, so mise falls back to `cargo install`.
- **`install_args` and #227 interact.** `install_args` restricts `mise install` to exactly the tools named, and mise does **not** pull in a declared-but-unnamed tool as a dependency. Without `cargo-binstall` in each list, #227's `cargo-binstall = "1.21.1"` entry in `mise.toml` would be resolved but never installed, and every `cargo:` tool would fall straight back to a from-source `cargo install` — i.e. this PR would silently undo #227 the moment both landed. See Verification for the reproduction.
- Mode B is not a rare event: `gh api repos/{owner}/{repo}/actions/cache/usage` reports `active_caches_size_in_bytes: 12485528599` (12.49 GB across 53 caches) against the 10 GB per-repo limit, so GitHub evicts LRU continuously.
- Mode B mise-step baseline to beat — `hygiene` 9m23s, `app (windows)` 6m37s, `app (macos)` 5m50s, `loom` 4m30s, `frontend` 4m21s, `core` 4m03s. Mode A (cache hit) mise steps are 3–8s and are unaffected by this change.

## Changes

### Rust-only jobs

- `core`: `install_args: rust cargo-binstall cargo:cargo-llvm-cov cargo:cargo-nextest` — the sole consumer of `cargo-llvm-cov`; `rustfmt`/`clippy` still arrive as components of the `rust` entry in `mise.toml`.
- `loom`: `install_args: rust cargo-binstall cargo:cargo-nextest` — no coverage is collected here, so `cargo-llvm-cov` is dropped.
- `hygiene`: `install_args: rust cargo-binstall cargo:cargo-machete cargo:cargo-modules`, added inside the existing step; the job keeps its `env: MISE_ENV: ci-hygiene`, which is what makes `mise.ci-hygiene.toml` visible. `rust` is required because both tools are invoked as `cargo <sub>`.

### JavaScript and mixed jobs

- `frontend`: `install_args: node pnpm` — removes the entire Rust toolchain and both `cargo:` builds from a job that never touches Rust. This is the one list with no `cargo:` entry, so it deliberately does not name `cargo-binstall`.
- `app` (macOS + Windows matrix): `install_args: rust node pnpm cargo-binstall cargo:cargo-nextest` — runs nextest and the pnpm/tauri build, but not coverage.

### `cargo-binstall` in every cargo list

- Naming it is order-independent with respect to #227: if #227 merges first, mise installs the pinned `1.21.1` from `mise.toml`; if this PR merges first, mise installs `latest` and emits a harmless `cargo-binstall installed but not activated — it is not in any config file` warning, exit code 0. So neither PR blocks the other.
- Each mise step carries a one-line English comment stating why the name has to be there; the `core` step carries the full three-line explanation.

### Deliberately untouched

- All five `jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4` pins are byte-identical; the diff is 23 added lines and 0 deletions.
- No step reordering, no `env:` changes, no `rustup component add` removals (those remain the belt-and-suspenders for a cached install missing a component), and no `mise.toml` / `mise.ci-hygiene.toml` edit.

### Why this cannot poison a cache

The action's default cache-key template (`src/index.ts:43` at the pinned SHA) includes `install_args_hash` alongside `platform`, `version`, `mise_env` and `file_hash`, so each distinct `install_args` string gets its own cache namespace — the node-only `frontend` cache can never be restored by `core`. `install_args` is also incompatible with `bootstrap: true`, which this workflow does not use.

## Verification

- `actionlint .github/workflows/ci.yml` — exit 0.
- SHA guard: `git diff origin/main -- .github/workflows/ci.yml | grep '^[-+].*mise-action@'` prints nothing.
- `git diff --stat origin/main...HEAD` — `.github/workflows/ci.yml | 23 +++++++++++++++++++++++`, one file changed.

### Reproducing the `cargo-binstall` interaction

Run against mise 2026.7.11 with a throwaway `MISE_DATA_DIR` and a `PATH` that contains no mise shims, using a config that declares `cargo-binstall` exactly as #227 does:

```toml
[tools]
cargo-binstall = "1.21.1"
"cargo:cargo-machete" = "0.9.2"
[settings]
cargo.binstall = true
```

- `mise install cargo:cargo-machete` (the tool named, binstall omitted — what this PR would do without the fix) → `mise ls` reports `cargo-binstall 1.21.1 (missing)` and mise falls through to `cargo install cargo-machete@0.9.2 --locked --root …`, i.e. a from-source build.
- `mise install cargo-binstall cargo:cargo-machete` (this PR) → binstall is installed and `cargo-machete` arrives as a prebuilt download: `INFO Done in 1.37s`, with no Rust toolchain needed at all.

### Measured CI timings

Because `install_args_hash` is a new key component, this PR's own run was a guaranteed mise cache miss — a true Mode B run, directly comparable to the baseline. Measured on [run 30192910432](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30192910432) (commit `df2b2b4`, before the `cargo-binstall` fix), all 6 jobs green:

| job | mise step, Mode B before | this run | job total, Mode B before | this run |
|---|---|---|---|---|
| frontend | 4m21s | **8s** | 5m12s | **56s** |
| hygiene | 9m23s | **4m30s** | 10m43s | **5m42s** |
| app (windows) | 6m37s | 7m01s | 15m11s | **10m09s** |
| app (macos) | 5m50s | 5m22s | 11m37s | **7m31s** |
| loom | 4m30s | 4m08s | 6m36s | **4m29s** |
| core | 4m03s | 4m23s | 5m40s | **4m47s** |

The `frontend` (−4m13s) and `hygiene` (−4m53s) drops are the whole point of this change: those two jobs were building `cargo-nextest` / `cargo-llvm-cov` they never invoke. `core` and `app (windows)` still install the same tool set as before, so their mise steps land on the baseline ± runner variance. Wall-clock for the whole run fell from 15m11s to 10m12s.

### Measured after the `cargo-binstall` fix

The `cargo-binstall` commit changes `install_args` again, so [run 30193613740](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193613740) on `782dbb7` is another guaranteed Mode B run and is directly comparable to the one above. All 6 jobs green:

| job | job total, `df2b2b4` | job total, `782dbb7` | mise step, `df2b2b4` | mise step, `782dbb7` |
|---|---|---|---|---|
| core | 4m47s | **48s** | 4m23s | **19s** |
| loom | 4m29s | **36s** | 4m08s | **17s** |
| app (macos) | 7m31s | **2m35s** | 5m22s | **24s** |
| app (windows) | 10m09s | **3m35s** | 7m01s | **33s** |
| frontend | 56s | 51s | 8s | 2s |
| hygiene | 5m42s | 5m41s | 4m30s | 4m19s |

Wall-clock for the whole run: **10m09s -> 5m41s**. That delta is entirely #227's benefit, which this PR would have blocked without the `cargo-binstall` entries: `cargo-nextest` and `cargo-llvm-cov` stop being compiled and arrive as prebuilt downloads.

`hygiene` is the one job that does not move, and it is now the critical path: it still builds `cargo-modules` from source, which publishes no prebuilt binary for binstall to fetch. That is #233 / #250's job, and PR #250 measures it down to 86-99s.

A missing tool surfaces immediately as `command not found` / `no such subcommand`, so a green run is itself proof that every `install_args` list is complete — including that `core` still collected coverage and uploaded to Codecov, and that `hygiene` still ran `cargo machete` and `cargo modules orphans`.

Reproduce with:

```bash
gh api repos/{owner}/{repo}/actions/runs/<run-id>/jobs \
  --jq '.jobs[] | "=== \(.name) ===", (.steps[] | "  \(.completed_at) \(.name)")'
```

## Test plan

- [x] `actionlint .github/workflows/ci.yml` passes
- [x] Only `.github/workflows/ci.yml` is modified
- [x] All five mise-action pins unchanged (grep guard prints nothing)
- [x] All added comments are in English
- [x] Every `install_args` list containing a `cargo:` entry also names `cargo-binstall`; `frontend` (no `cargo:` entry) does not
- [x] Reproduced locally that omitting `cargo-binstall` forces a from-source `cargo install`, and that naming it yields a prebuilt download
- [x] Reproduced locally that naming `cargo-binstall` still exits 0 when it is absent from `mise.toml` — so this PR and #227 can merge in either order
- [x] All 6 CI jobs green on `df2b2b4` (`core`, `loom`, `hygiene`, `frontend`, `app (macos-latest)`, `app (windows-latest)`)
- [x] `frontend` job's mise step well under a minute in a Mode B run — 8s vs a 4m21s baseline
- [x] `core` job still collects coverage (`cargo llvm-cov nextest` ran, Codecov upload succeeded)
- [x] `hygiene` job still runs `cargo machete` and `cargo modules orphans` with `MISE_ENV=ci-hygiene`
- [x] All 6 CI jobs green on `782dbb7` (the `cargo-binstall` commit) — [run 30193613740](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193613740)
- [x] Measured: the `cargo-binstall` fix cuts the Mode B wall-clock from 10m09s to 5m41s; `core` 4m47s -> 48s, `loom` 4m29s -> 36s, `app (windows)` 10m09s -> 3m35s
- [ ] After merge: `main`'s next run is still green (first post-merge run repeats the cache miss under the `refs/heads/main` cache scope)

Closes #230
