### PR TITLE
perf(ci): build CI with line-tables-only debuginfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+# CI-only debuginfo trimming. `line-tables-only` keeps file:line in panic and test-failure
+# backtraces (all CI needs) and drops variable/type DWARF, which nothing in CI reads. This cuts
+# codegen + link time on the `app` jobs and shrinks `target/debug`, which in turn shrinks the
+# Swatinem/rust-cache entries — the repo is currently 12.49 GB against GitHub's 10 GB cache
+# limit, so entries are being evicted and every eviction costs a full cold rebuild.
+# Set as workflow env rather than `[profile.dev]` in Cargo.toml so local development keeps
+# full debug info for step-debugging.
+env:
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
 jobs:
   core:
     name: core (rust, pure)


### PR DESCRIPTION
## Summary

CI compiles the whole Rust dependency tree with full DWARF debug info, which nothing in CI ever reads — no job step-debugs. This adds a workflow-level `env:` block setting `CARGO_PROFILE_DEV_DEBUG` and `CARGO_PROFILE_TEST_DEBUG` to `line-tables-only`, which keeps `file:line` in panic and test-failure backtraces while dropping variable/type DWARF, cutting codegen + link time on the `app` jobs and shrinking `target/debug` — and with it the `Swatinem/rust-cache` entries that currently push the repo over GitHub's cache limit. One file, 11 added lines, no job body touched.

## Background / Motivation

- **Rust compile/link dominates the critical path.** On a warm-cache run ([30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776)) `app (windows)` takes **7m20s**, of which **5m57s** is Rust: `cargo nextest -p simple-archiver-core` 1m42s, `cargo nextest -p simple-archiver` 2m41s, `pnpm tauri build --no-bundle --debug` 1m34s. Most of that tail is codegen and link of debug info for the entire dependency tree.
- **The repo is over the Actions cache limit, so the slow mode keeps recurring.** `gh api repos/{owner}/{repo}/actions/cache/usage` reports `active_caches_size_in_bytes: 12485528599` (**12.49 GB**) across 53 caches against the **10 GB** per-repo limit. GitHub evicts LRU, so cache-miss runs come back continuously rather than only after a Renovate bump.
- **`Swatinem/rust-cache` entries are the bulk of that 12.49 GB**, and debug info is the dominant contributor to what they archive: `v0-rust-app-Darwin-arm64-*` entries are 720–728 MB each and `v0-rust-app-Windows_NT-x64-*` are 676–681 MB each. Locally this repo's `target/debug/deps` is 16 GB.
- **Cache misses are expensive**: the same workflow on a cold cache ([30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)) runs `app (windows)` in **15m11s** instead of 7m20s. Every eviction buys one of those.
- CI has no interactive debugger attached at any point, so full DWARF buys nothing there — but a `[profile.dev]` entry in `Cargo.toml` would degrade local step-debugging for everyone, hence the CI-scoped `env:` instead.

## Changes

### Workflow-level debuginfo trimming (`.github/workflows/ci.yml`)

- New top-level `env:` block between `on:` and `jobs:` setting `CARGO_PROFILE_DEV_DEBUG: line-tables-only` and `CARGO_PROFILE_TEST_DEBUG: line-tables-only`.
- Workflow-level `env:` is inherited by every job and every `run:` step, so one block covers all six jobs (`core`, `app` on both matrix legs, `loom`, `hygiene`, `frontend`) without touching any job body.
- `[profile.test]` inherits `[profile.dev]`, so `CARGO_PROFILE_DEV_DEBUG` alone would very likely suffice; `CARGO_PROFILE_TEST_DEBUG` is set explicitly as belt-and-suspenders. `pnpm tauri build --no-bundle --debug` uses the `dev` profile and is covered by the first variable.
- An English comment block above the `env:` records why it is CI-scoped rather than a `Cargo.toml` profile change, so a future reader does not "tidy" it into the manifest.

### Deliberately unchanged

- No job bodies, no steps, no action SHAs, no `concurrency` block (that is #229, which edits this same region of the file and is stacked behind this PR).
- No `Cargo.toml` change — local `cargo build`/`cargo test` keep full debug info.

## Verification

Confirm the env block parses and is actually consumed by Cargo:

```bash
actionlint .github/workflows/ci.yml            # exits 0
git diff --stat origin/main                    # 1 file changed, 11 insertions(+)

# Cargo accepts the value (run in any crate):
CARGO_PROFILE_DEV_DEBUG=line-tables-only CARGO_PROFILE_TEST_DEBUG=line-tables-only \
  cargo test --no-run                          # exits 0, "Finished `test` profile [unoptimized + debuginfo]"
# negative control — Cargo really reads the variable:
CARGO_PROFILE_DEV_DEBUG=bogus-value cargo test --no-run
#   error in environment variable `CARGO_PROFILE_DEV_DEBUG`: could not load config key `profile.dev.debug`
#   invalid value: string "bogus-value", expected ... "line-tables-only" ...
```

**This PR's own CI run is a guaranteed `rust-cache` miss and will be SLOWER than the 7m20s baseline — that is expected, not a regression.** `Swatinem/rust-cache` folds every environment variable whose name starts with `CARGO`, `CC`, `CFLAGS`, `CXX`, `CMAKE` or `RUST` into its cache key (`src/config.ts:117`), so adding these two variables changes the key by construction. The first `push: main` run after merge is also a miss and is the run that *saves* the new, smaller cache (`save-if: github.ref == 'refs/heads/main'`). **The second `main` run after merge is the first valid measurement.**

Measure it there:

```bash
gh run list --workflow=ci.yml --branch main --limit 3 --json databaseId,createdAt
gh run view <id> --json jobs --jq '.jobs[] | "\(.name): \(.startedAt) -> \(.completedAt)"'
gh api repos/{owner}/{repo}/actions/cache/usage
```

Success criteria: `app (windows)` total below the 7m20s baseline, and cache usage well under 10 GB with the `v0-rust-app-*` entries roughly halved from ~700 MB.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` exits 0
- [x] `git diff --stat origin/main` shows `.github/workflows/ci.yml` as the only file, 11 insertions
- [x] Cargo accepts both overrides (`cargo test --no-run` exits 0; an invalid value is rejected, proving the variable is read)
- [x] Every comment in the added block is in English
- [ ] All 6 CI jobs green on this PR (expected to be slower than baseline — cold `rust-cache` by construction)
- [ ] After merge, the *second* `push: main` run shows `app (windows)` under the 7m20s baseline
- [ ] After merge, `gh api repos/{owner}/{repo}/actions/cache/usage` reports well under 10 GB, with `v0-rust-app-*` entries roughly halved from ~700 MB
- [ ] **Human follow-up after merge** — purge the stale full-debuginfo Rust caches so the old entries stop crowding out the new small ones (destructive, outward-facing; not executed by this PR):

      gh api "repos/{owner}/{repo}/actions/caches?per_page=100" \
        --jq '.actions_caches[] | select(.key | startswith("v0-rust-")) | .id' \
        | xargs -I{} gh api -X DELETE "repos/{owner}/{repo}/actions/caches/{}"
      gh api repos/{owner}/{repo}/actions/cache/usage

      Consequence: the next `main` run rebuilds Rust from scratch once, then repopulates with the smaller entries. That is the intended reset.

Closes #228
