### PR TITLE
perf(ci): cancel superseded runs with a concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ env:
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
+# One in-flight run per PR: Renovate force-pushes its branches repeatedly (17 runs on
+# `renovate/frontend-(npm)` in the last 100 PR runs), and without this every superseded push
+# keeps six jobs running to completion on a commit that will never merge, holding concurrency
+# slots that the current run needs. `push` events on main are keyed by ref and never cancelled,
+# so main's history keeps a complete CI record and the rust-cache save step always runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   core:
     name: core (rust, pure)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,13 @@ env:
 # One in-flight run per PR: Renovate force-pushes its branches repeatedly (17 runs on
 # `renovate/frontend-(npm)` in the last 100 PR runs), and without this every superseded push
 # keeps six jobs running to completion on a commit that will never merge, holding concurrency
-# slots that the current run needs. `push` events on main are keyed by ref and never cancelled,
-# so main's history keeps a complete CI record and the rust-cache save step always runs.
+# slots that the current run needs. Pull-request runs are grouped by PR number, so a new push
+# cancels the previous run. `push` events fall back to `github.run_id`, which is unique per run,
+# so pushes to main never share a group. GitHub cancels a pending run in a group when a newer one
+# is queued regardless of `cancel-in-progress`; sharing a group would silently drop CI for the
+# intermediate commits in a merge burst and skip their rust-cache save.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Stacked on #238 — base is `perf/ci-thin-debuginfo`, **retarget to `main` once #238 merges**.

Closes #229

## Summary

`.github/workflows/ci.yml` has no `concurrency:` block, so a force-push leaves its predecessor's six jobs running to completion on a commit that will never merge. This adds a workflow-level concurrency group keyed per PR, with `cancel-in-progress` gated on `github.event_name == 'pull_request'`. `push` events fall back to `github.run_id` rather than `github.ref`, so pushes to `main` each get their own group and are never queued behind — or cancelled by — one another.

## Background / Motivation

- Renovate force-pushes its branches aggressively. Of the last 100 `pull_request` CI runs: 17 on `renovate/frontend-(npm)`, 15 on `renovate/github-actions`, 13 on `renovate/site-(npm)`, 6 on `renovate/mise`, 5 on `renovate/backend-(cargo)` — every superseded push keeps six jobs alive on a dead commit.
- Each obsolete run burns roughly 35 minutes of billed runner time (6 jobs, mise cache-hit mode) and holds concurrent-job slots, so the run a human is actually waiting on sits queued instead of starting. `renovate.json` sets `prConcurrentLimit: 10`, so several PRs in flight is the normal state, not the exception.
- Measured baseline, mise cache HIT ([run 30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776)): `app (windows)` 7m20s (critical path), `app (macos)` 4m08s, `loom` 2m23s, `core` 2m06s, `hygiene` 1m31s, `frontend` 1m01s.
- Measured baseline, mise cache MISS ([run 30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)): `app (windows)` 15m11s, `app (macos)` 11m37s, `hygiene` 10m43s, `loom` 6m36s, `core` 5m40s, `frontend` 5m12s — a superseded run in this mode wastes over 55 minutes of runner time.
- `Swatinem/rust-cache` is configured with `save-if: github.ref == 'refs/heads/main'`, so losing a `main` run would discard the cache save and make the next run a cold rebuild. That is why the cancel flag is conditional rather than a bare `true` — **and why the group key for pushes had to change too, see below.**

### Why `github.ref` is the wrong fallback for the group key

The obvious expression is `${{ github.event.pull_request.number || github.ref }}`, and the first revision of this PR shipped it. It is wrong. `github.event.pull_request.number` is empty on a `push`, so **every** push to `main` lands in the single group `CI-refs/heads/main`, and GitHub's documented behaviour is:

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`. By default, any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place.

— [Workflow syntax: `concurrency`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency). The `queue` property confirms it: `single` (the default) means "at most one job or workflow run can be `pending` in the concurrency group".

`cancel-in-progress: false` only spares the **running** run; it does not make pending runs queue. So a burst of merges — this repo's normal pattern — would leave all but the newest `main` commit with a `cancelled` run and **zero jobs executed**: no `core` / `loom` / `hygiene` / `frontend` / `app` verification, and no `Swatinem/rust-cache` post-save.

That burst pattern is real, from `gh run list --workflow=ci.yml --event push --branch main`:

| date | pushes to `main` | window | first run duration |
|---|---|---|---|
| 2026-07-04 12:00:54Z | 7 | 71 s | 5m04s |
| 2026-07-26 06:32:37Z | 5 | 61 s | 9m00s |
| 2026-07-26 06:56:30Z | 4 | 3m03s | 6m00s |

The 06:56 burst is merge commits `022655a` / `2d2b600` / `f0a5bc6` / `8f96019` — the weekly Renovate batch. Under a shared group, three of those four commits would have carried no CI at all, including `app (windows-latest)`, which this repo's notes call the only job that catches `\` vs `/` path regressions.

## Changes

### Workflow-level `concurrency` block (`.github/workflows/ci.yml`)

- `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}` — one group per PR for `pull_request` events; `github.run_id` is unique per run and always defined, so every `push` gets its own group and pushes to `main` behave exactly as they do today. `github.ref` alone would be `refs/pull/<n>/merge` on PRs; the PR number is the explicit, readable key.
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — PR runs are cancelled when superseded; `push` runs are not.
- Placed immediately after the `env:` block from #238, at workflow level where `github.event_name` and `github.event.pull_request` are both available — no `needs:` or job-level plumbing.
- The English comment above the block records both the motivation and the pending-cancellation mechanism, so neither the conditional flag nor the `run_id` fallback is "simplified" away in a future edit.

### Not changed

- No job body, `runs-on`, step, or action SHA is touched. The diff is +12 lines in one file.
- Path-based job skipping stays out of scope (tracked in #234); Renovate's schedule and `prConcurrentLimit` are unchanged.

## Verification

- `actionlint .github/workflows/ci.yml` — clean, the workflow still parses.
- `git diff perf/ci-thin-debuginfo...HEAD --stat` — `.github/workflows/ci.yml`, one file.
- Confirm the flag is the conditional expression, not `true`, and the fallback is `run_id`, not `ref`:
  `grep -n 'group:\|cancel-in-progress' .github/workflows/ci.yml`
- Behaviour once running: push a trivial second commit to this branch, then
  `gh run list --workflow=ci.yml --branch perf/ci-concurrency-cancel --json databaseId,status,conclusion,createdAt`
  — the older run must report `conclusion: cancelled` and the newer one must run to completion.
- Regression to watch on `main`: after this merges, `gh run list --workflow=ci.yml --event push --branch main --json conclusion` must never show `cancelled`, otherwise the rust-cache save was skipped. The next Renovate batch merge is the natural test — several merges land inside a minute and every one of them must produce a completed run.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` exits 0
- [x] `.github/workflows/ci.yml` is the only file changed; the diff adds only the `concurrency:` block
- [x] `cancel-in-progress` is the conditional expression, not a bare `true`
- [x] The group's non-PR fallback is `github.run_id`, not `github.ref`, so concurrent pushes to `main` never share a group
- [x] Every comment in the added block is in English
- [ ] #238 (C2) is merged into `main` and this PR is retargeted to `main` before merge
- [ ] All 6 CI jobs green on this PR
- [ ] Push a trivial second commit here; the first run reports `conclusion: cancelled` and the second completes
- [ ] After merge, the next multi-merge burst on `main` produces one completed run per merge commit — none `cancelled` — and each runs the rust-cache save step
