### PR TITLE
perf(ci): run both Windows test suites in one nextest invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,17 +107,20 @@ jobs:
       # Belt and suspenders: mise.toml requests clippy components, but
       # ensure they exist on the active toolchain even if a cached install lacks them.
       - run: rustup component add clippy
-      # Core tests on Windows only: the `core` job already covers them on Linux,
-      # and macOS shares Linux's `/` path separator, so a macOS rerun adds nothing.
-      # Windows is kept because it is the sole job that catches `\` vs `/` regressions.
-      - if: matrix.os == 'windows-latest'
-        run: cargo nextest run -p simple-archiver-core --profile ci
       # PR6: the presentation crate's tests (Tauri command surface, progress
       # event sink, run_job integration) only build on runners with the Tauri
       # toolchain, which the app job has. Run them here so they are covered in CI.
       - if: matrix.os == 'macos-latest'
         run: cargo clippy -p simple-archiver --all-targets -- -D warnings
-      - run: cargo nextest run -p simple-archiver --profile ci
+      # Windows additionally runs the core suite: the `core` job already covers it on Linux, and
+      # macOS shares Linux's `/` path separator, so Windows is the sole job that catches `\` vs
+      # `/` regressions. Both crates go through ONE nextest invocation so cargo resolves the
+      # workspace and walks the fingerprint tree once instead of twice — on the Windows runner
+      # that scan is the bulk of the second invocation's non-compile time.
+      - if: matrix.os == 'windows-latest'
+        run: cargo nextest run -p simple-archiver-core -p simple-archiver --profile ci
+      - if: matrix.os == 'macos-latest'
+        run: cargo nextest run -p simple-archiver --profile ci
       # node_modules is installed for `pnpm tauri build` below (beforeBuildCommand: pnpm build),
       # not for tests: the vitest suite is jsdom-only with no OS-dependent behaviour, so it runs
       # once in the `frontend` job rather than a third time here on each OS.

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,7 +101,7 @@ This project is designed around TDD. **Write tests before implementation.**
 | `loom` | ubuntu | loom-clippy + loom-nextest for `simple-archiver-core` (concurrency model verification) |
 | `hygiene` | ubuntu | cargo-machete (unused deps) + cargo-modules orphan check on the core crate |
 | `frontend` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm run test:coverage`, Codecov upload (`frontend` flag), `pnpm build` |
-| `app` | macos + windows (matrix) | nextest for `simple-archiver-core`; clippy (macOS only) + nextest for the presentation crate `simple-archiver`; `pnpm install --frozen-lockfile`, then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend; Vitest runs once in the `frontend` job (jsdom-only, with no OS-dependent behaviour) |
+| `app` | macos + windows (matrix) | Windows: one nextest invocation for `simple-archiver-core` + `simple-archiver`; macOS: clippy + nextest for `simple-archiver` only; `pnpm install --frozen-lockfile`, then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend; Vitest runs once in the `frontend` job (jsdom-only, with no OS-dependent behaviour) |
 
 The presentation-crate clippy + nextest steps in the `app` job were added in PR6; the Tauri toolchain (gtk/webkit headers on Linux) is unavailable on ubuntu, so those steps run only on the mac/windows runners.
 


### PR DESCRIPTION
Stacked on #235 — base is `perf/ci-drop-duplicate-vitest`, not `main`. Retarget this PR to `main` once #235 merges.

## Summary

On Windows the `app` job invoked cargo twice back to back over the same workspace, once per crate, paying cargo's workspace resolution and fingerprint walk plus nextest's binary-list phase twice. The two steps become a single `cargo nextest run -p simple-archiver-core -p simple-archiver --profile ci`, and macOS keeps its own unchanged `-p simple-archiver` step. CI-only change; identical test coverage on both runners.

## Background / Motivation

- `app (windows)` is the critical path of the whole workflow: 7m20s with a mise cache hit (run [30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776)) and 15m11s on a cache miss (run [30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)). Everything on that job is on the critical path.
- Inside the cache-hit run, the two cargo steps are `cargo nextest run -p simple-archiver-core --profile ci` at 1m42s and `cargo nextest run -p simple-archiver --profile ci` at 2m41s, against a Rust compile/link total of ~5m57s out of the job's 7m20s.
- The compilation is not duplicated — the second invocation reuses `target/debug` — but the per-invocation overhead is: cargo re-resolves the workspace and re-walks/re-verifies the fingerprint tree (notably slow on the Windows runner's filesystem), and nextest re-runs its binary-list phase. Merging the two invocations pays that once instead of twice.
- Expected effect is −15s to −40s on `app (windows)`, and it is genuinely uncertain because the saving is startup overhead rather than compilation. The issue therefore attaches a decision gate: under ~15s, revert instead of merging (see Test plan).

## Changes

### Windows: one nextest invocation for both crates (`.github/workflows/ci.yml`, `app` job)

- Replaced the Windows-only `cargo nextest run -p simple-archiver-core --profile ci` step and the shared `cargo nextest run -p simple-archiver --profile ci` step with a single Windows-only `cargo nextest run -p simple-archiver-core -p simple-archiver --profile ci`.
- `--profile ci` sets `fail-fast = false` in `.config/nextest.toml`, so combining the two crates into one invocation cannot let a `simple-archiver-core` failure hide `simple-archiver` failures — both crates still report in full.

### macOS: behaviour preserved

- macOS now has its own explicit `if: matrix.os == 'macos-latest'` guard on `cargo nextest run -p simple-archiver --profile ci`, replacing the previously unconditional step. Same command, same crate, still ordered after `cargo clippy -p simple-archiver --all-targets -- -D warnings`.
- macOS still does not run the core suite — the `core` job covers it on Linux, and macOS shares Linux's `/` path separator. Windows remains the sole runner that catches `\` vs `/` regressions.

### Comments

- The comment block explaining the Windows-only core suite moved with the merged step and now also records *why* both crates share one invocation, so a later reader does not split them back apart.

### CI documentation (`docs/development.md`)

- The CI-jobs table's `app` row described the Rust tests as if the core suite ran on both matrix legs. It now says: Windows runs `simple-archiver-core` + `simple-archiver` in one nextest invocation; macOS runs clippy + nextest for `simple-archiver` only. (The pnpm/tauri clause of that row was corrected by #235, this PR's base.)

### Not touched

- No `pnpm` steps, no `rustup component add`, no `jdx/mise-action` steps, no workflow header — those are #230 and #228 / #229, and they edit disjoint regions so the lanes merge independently.

## Verification

- `actionlint .github/workflows/ci.yml` → exit 0, workflow still parses.
- `git diff origin/perf/ci-drop-duplicate-vitest --stat` → `.github/workflows/ci.yml`, one file, 9 insertions / 6 deletions.
- `grep -n "nextest run" .github/workflows/ci.yml` → three hits: the `loom` job's line, plus exactly two in the `app` job — one guarded by `windows-latest` naming both crates, one guarded by `macos-latest` naming only `simple-archiver`. The `core` job's `cargo llvm-cov nextest -p simple-archiver-core` is untouched.
- Coverage is unchanged and must be read out of the logs — the merged Windows step's nextest output has to list tests from both crates:
  `gh api repos/{owner}/{repo}/actions/jobs/<job-id>/logs | grep -E "Starting [0-9]+ tests|Summary"`
- Timing, against the cache-hit baseline of `app (windows)` 7m20s (minus whatever #235 already removed — state which baseline you compared against):
  `gh run view <run-id> --json jobs --jq '.jobs[] | "\(.name): \(.startedAt) -> \(.completedAt)"'`

## Test plan

- [x] `actionlint .github/workflows/ci.yml` passes
- [x] Two files changed: `.github/workflows/ci.yml` and `docs/development.md` (one table row corrected)
- [x] Windows runs both `simple-archiver-core` and `simple-archiver` in one invocation; macOS runs only `simple-archiver`, still after its clippy step
- [x] `--profile ci` keeps `fail-fast = false`, so a core failure cannot mask presentation failures
- [x] Every added comment is in English
- [x] `docs/development.md`'s CI-jobs table now describes the Windows-only combined nextest run
- [ ] #235 merges first, then this PR is retargeted from `perf/ci-drop-duplicate-vitest` to `main`
- [ ] All 6 CI jobs green on this PR
- [ ] Coverage unchanged, verified from the Windows step's nextest summary listing tests from both crates
- [ ] Measured: `app (windows)` total recorded and compared against the stated baseline
- [ ] **Decision gate** — if the improvement is under ~15s, revert this change and close #232 instead of merging

Closes #232

