### PR TITLE
perf(ci): skip CI for docs- and site-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,22 @@
 name: CI
 
+# Skipped for changes that no job in this workflow verifies: every gate here is scoped to
+# `src` (package.json), the Rust workspace, or the pinned toolchain. `site/**` is built and
+# checked by deploy-pages.yml instead, and `knip.json` already excludes it from the root knip
+# run. GitHub only skips when EVERY changed file matches, so a PR touching both `docs/` and
+# `src/` still runs the full workflow.
 on:
   push:
     branches: [main]
+    paths-ignore: &ci-irrelevant-paths
+      - "docs/**"
+      - "site/**"
+      - "**/*.md"
+      - "LICENSE"
+      - ".claude/**"
+      - ".superpowers/**"
   pull_request:
+    paths-ignore: *ci-irrelevant-paths
 
 # CI-only debuginfo trimming. `line-tables-only` keeps file:line in panic and test-failure
 # backtraces (all CI needs) and drops variable/type DWARF, which nothing in CI reads. This cuts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,20 @@
 name: CI
 
-# Skipped for changes that no job in this workflow verifies: every gate here is scoped to
-# `src` (package.json), the Rust workspace, or the pinned toolchain. `site/**` is built and
-# checked by deploy-pages.yml instead, and `knip.json` already excludes it from the root knip
-# run. GitHub only skips when EVERY changed file matches, so a PR touching both `docs/` and
-# `src/` still runs the full workflow.
+# Skipped only for changes that no job in this workflow verifies:
+# - `site/**` is already ignored by `knip.json` and is built and checked by deploy-pages.yml.
+# - `**/*.md` is safe because no CI gate reads or analyzes Markdown.
+# - `LICENSE` is safe because no CI gate reads it.
+# `pnpm knip` is the one repo-wide gate. Therefore `docs/**`, `.claude/**`, and
+# `.superpowers/**` are deliberately not ignored even though they contain no CI-relevant code
+# today: knip would gate a `.ts` or `.js` file added there. GitHub only skips when EVERY changed
+# file matches, so a PR touching both a `.md` file and `src/` still runs the full workflow.
 on:
   push:
     branches: [main]
     paths-ignore: &ci-irrelevant-paths
-      - "docs/**"
       - "site/**"
       - "**/*.md"
       - "LICENSE"
-      - ".claude/**"
-      - ".superpowers/**"
   pull_request:
     paths-ignore: *ci-irrelevant-paths
 


### PR DESCRIPTION
Stacked on #247 — base is `perf/ci-concurrency-cancel`, **retarget to `main` before merge**.

**This is the last item of the CI batch and must merge last.** It restructures the workflow's trigger semantics and sits against every other lane's edits, so #236 (#227), #238 (#228), #247 (#229), #237 (#230), #235 (#231), #248 (#232) and #250 (#233) should all be merged into `main` first.

Closes #234

## Summary

`.github/workflows/ci.yml` has no path filter, so a PR that touches only `README.md`, `CLAUDE.md`, a doc under `docs/` or `site/**` runs all six jobs — two Rust matrix jobs and a Tauri smoke build included — to verify nothing that any of those jobs actually reads. This adds a shared `paths-ignore` list to both the `push` and `pull_request` triggers, so a change whose every file is CI-irrelevant produces no run at all. The list is deliberately narrower than the one in the issue: `pnpm knip` turns out to gate the whole repository, so `docs/**`, `.claude/**` and `.superpowers/**` are **not** ignorable.

## Background / Motivation

- Most of `ci.yml` verifies nothing outside `src`, the Rust workspace and the pinned toolchain: the root `fmt:check` / `lint:ci` / `test` / `build` scripts in `package.json` are all scoped to `src vite.config.ts vitest.config.ts`. `site/**` is built and checked by `deploy-pages.yml`, which is itself already path-filtered on `paths: ["site/**", ".github/workflows/deploy-pages.yml"]` and already uses a `concurrency` group — the in-repo precedent for this change.
- Measured baseline, mise cache HIT ([run 30181255776](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30181255776)): `app (windows)` 7m20s (critical path), `app (macos)` 4m08s, `loom` 2m23s, `core` 2m06s, `hygiene` 1m31s, `frontend` 1m01s — roughly 19 minutes of billed runner time behind a 7m20s wall-clock wait.
- Measured baseline, mise cache MISS ([run 30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615)): `app (windows)` 15m11s, `app (macos)` 11m37s, `hygiene` 10m43s, `loom` 6m36s, `core` 5m40s, `frontend` 5m12s — about 55 minutes of runner time for a markdown-only diff.
- Cache-miss mode is not rare: `gh api repos/{owner}/{repo}/actions/cache/usage` reports `active_caches_size_in_bytes: 12485528599` (12.49 GB) across 53 caches against GitHub's 10 GB per-repo limit, so LRU eviction keeps pulling runs back into Mode B.
- Expected effect: markdown-only and site-only PRs go from 7m20s (Mode A) or ~15m (Mode B) to **0s, no run**. No effect on any PR that touches code.

### `pnpm knip` is repo-wide, so the issue's six-entry list was unsafe

The issue specifies `docs/**`, `site/**`, `**/*.md`, `LICENSE`, `.claude/**`, `.superpowers/**`. Three of those cannot be ignored. `pnpm knip` in the `frontend` job scans the **entire repository** for unused files; the only reason `site/**` does not trip it is that `knip.json` already lists `site/**` under `ignore`.

Reproduced on this branch — drop a probe file and run knip with the repo's current `knip.json`:

```console
$ printf 'export const probe = 1\n' > docs/probe.ts
$ node node_modules/knip/bin/knip.js
Unused files (1)
docs/probe.ts
$ echo $?
1
```

So `docs/**` **is** gated today. Ignoring it would let a PR that adds a `.ts`/`.js` file there skip CI entirely and merge unchecked — and the failure would then surface on the next unrelated PR that touches `src/` or `crates/`, blamed on an innocent author. The same argument applies to `.claude/**` and to `.superpowers/**` (which is not in `.gitignore`, only in a local `.git/info/exclude`, so it can be committed).

Adding those directories to `knip.json`'s `ignore` was the other option, and was rejected: knip reports an ignore pattern that matches nothing as a configuration hint —

```console
Configuration hints (2)
docs/**       knip.json  Remove from ignore
.claude/**    knip.json  Remove from ignore
```

— so every future CI run would print advice that, if followed, silently reopens the hole. Keeping the paths-ignore list minimal is the version with no trap in it.

Little is lost. `**/*.md` already matches Markdown anywhere in the tree, and every tracked file under `.claude/` is Markdown; under `docs/` only `docs/images/*.png`, `docs/images/diagram.py` and `docs/how-it-works/index.html` are not, and those now correctly run CI.

## Changes

### `paths-ignore` on both triggers (`.github/workflows/ci.yml`)

- The three-entry list — `site/**`, `**/*.md`, `LICENSE` — is defined once as the YAML anchor `&ci-irrelevant-paths` on `push.paths-ignore` and reused on `pull_request.paths-ignore` via `*ci-irrelevant-paths`, so the two triggers cannot drift apart. (GitHub Actions does resolve anchors in workflow files: [run 30193146114](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193146114) on this branch parsed and ran all six jobs.)
- `push.branches: [main]` is unchanged, so the push-side filter only ever affects direct pushes to `main`; every other branch already produced no `push` run.
- An English comment above `on:` justifies each entry individually and records that `pnpm knip` is the one repo-wide gate — which is exactly why `docs/**`, `.claude/**` and `.superpowers/**` are absent.

### Deliberately excluded from the list

- `docs/**`, `.claude/**`, `.superpowers/**` — gated by `pnpm knip`, see above.
- `.github/workflows/**` — a change to `ci.yml` itself must run `ci.yml` (which is why this PR triggers a full run).
- `public/**` — consumed by `pnpm build` / `pnpm tauri build`.
- `src/**`, `src-tauri/**`, `crates/**`, `scripts/**`, and every root config file (`*.json`, `*.ts`, `Cargo.*`, `mise*.toml`, `pnpm-lock.yaml`).
- Per-job path filtering stays rejected: `ts-rs` generates `src/bindings/*.ts` from the Rust DTOs, so a Rust-only change routinely breaks the TypeScript build and the `frontend` job is the gate that catches it; conversely `pnpm tauri build --no-bundle --debug` in the `app` job runs `beforeBuildCommand: pnpm build`. The two sides are coupled in both directions, so only "neither side is touched at all" is safe to skip.

### Not changed

- No job body, `runs-on`, step, action SHA, `knip.json`, the `env:` block from #228, or the `concurrency:` block from #229 is touched.
- The pre-existing gap that no workflow runs `site/package.json`'s own lint/fmt/test/knip scripts on pull requests is out of scope — this change makes it more visible but does not create it, and it deserves its own issue.

## Verification

**Preconditions re-verified at implementation time** (both still hold, so `paths-ignore` is safe here):

- `gh api repos/yasuflatland-lf/simple-archiver/branches/main/protection` → HTTP 404 `"Branch not protected"`
- `gh api repos/yasuflatland-lf/simple-archiver/rulesets --jq '.[] | "\(.name) \(.enforcement)"'` → `main disabled`

This matters because `paths-ignore` skips the workflow entirely, so **no check is reported at all** on an ignored PR. A job skipped by a job-level `if:` still reports and counts as passing; a workflow that never triggers reports nothing, so a required status check would leave such a PR permanently stuck on "Expected — Waiting for status to be reported". Re-run both commands before merging; if either has changed, **stop and escalate rather than merging**.

**Migration path if required status checks are ever enabled:** replace `paths-ignore` with a `changes` gate job using `dorny/paths-filter` and put `if: needs.changes.outputs.code == 'true'` on each job. That form always reports a conclusion, so required checks stay satisfiable.

**Correction to the issue's Definition of Done.** The issue proposes verifying by pushing a docs-only commit to this PR branch and expecting no run. **That test is invalid for `pull_request` events.** GitHub evaluates `paths` / `paths-ignore` filters against the PR's full `base...head` diff, not against the newest commit alone, and this PR already changes `.github/workflows/ci.yml` — which is deliberately not in the ignore list — so a run will always trigger here no matter what a later commit touches. The valid manual check is **a separate PR whose entire `base...head` diff is markdown-only**; no probe PR or probe branch was created for this one. Likewise, the push-side filter cannot be exercised from this branch at all, because `on.push.branches` is restricted to `[main]`.

Local checks:

- `actionlint .github/workflows/ci.yml` — exit 0, the workflow still parses (YAML anchors and aliases included).
- The alias resolves identically on both triggers:
  `python3 -c "import yaml,json;d=yaml.safe_load(open('.github/workflows/ci.yml'));print(json.dumps(d[True],indent=2))"`
  → `push.paths-ignore` and `pull_request.paths-ignore` are the same three entries, and `push.branches` is still `["main"]`.
- knip probe, both directions: with `docs/probe.ts` present, `node node_modules/knip/bin/knip.js` exits 1 with `Unused files (1) docs/probe.ts`; with the probe removed it exits 0 clean. That is the evidence behind dropping `docs/**` from the list.
- No `.md` file is read by any gate: `grep -rn --include='*.rs' include_str! crates src-tauri` finds only a JSON capability file, there is no `#![doc = include_str!]`, no `readme` key in any `Cargo.toml` (so no README doctests), and nothing in `package.json` / `knip.json` / `vite.config.ts` / `vitest.config.ts` / `.oxfmtrc.json` / `.oxlintrc.json` references `.md`.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` exits 0
- [x] `.github/workflows/ci.yml` is the only file changed; the diff adds `paths-ignore` to both `push` and `pull_request` and changes nothing else
- [x] `.github/workflows/**`, `public/**`, `src/**`, `src-tauri/**`, `crates/**`, `scripts/**` and every root config file are absent from the ignore list
- [x] `docs/**`, `.claude/**` and `.superpowers/**` are absent from the ignore list, because `pnpm knip` gates them — verified with a `docs/probe.ts` probe (knip exit 1)
- [x] `push.branches: [main]`, the `env:` block (#228) and the `concurrency:` block (#229) are byte-for-byte unchanged
- [x] `knip.json` is unchanged
- [x] The added comment is in English
- [x] Branch protection is still 404 and the `main` ruleset is still `disabled`
- [ ] #227, #228, #229, #230, #231, #232 and #233 are all merged into `main`, and this PR is retargeted to `main` before merge
- [ ] Re-run both precondition commands immediately before merging; escalate instead of merging if either has changed
- [ ] All 6 CI jobs run and are green on **this** PR — a skipped run here would itself be the bug, since it edits `.github/workflows/ci.yml`
- [ ] Manual behaviour check on a **separate** PR whose entire `base...head` diff is markdown-only: `gh run list --workflow=ci.yml --branch <that-branch>` shows no run, and the PR page shows no checks at all
- [ ] Regression check: the next PR touching `src/` or `crates/` still runs all 6 jobs
