### PR TITLE
perf(ci): cache cargo-modules on its own version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,16 +59,30 @@ jobs:
   hygiene:
     name: hygiene (deps + orphan files)
     runs-on: ubuntu-latest
-    # Load mise.ci-hygiene.toml so mise-action installs cargo-modules here only — it compiles
-    # rust-analyzer from source (~16 min on Windows), and this is the sole job that runs it.
+    # Load mise.ci-hygiene.toml so mise-action installs cargo-machete here only.
     env:
       MISE_ENV: ci-hygiene
+      # Single source of truth for the pin; also the cache key below. Tracked by the Renovate
+      # custom manager in renovate.json.
+      CARGO_MODULES_VERSION: "0.26.0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
         with:
-          # `rust` is required because both tools are cargo subcommands invoked as `cargo <sub>`.
-          install_args: rust cargo:cargo-machete cargo:cargo-modules
+          # `rust` is required because cargo-machete is a cargo subcommand invoked as `cargo machete`.
+          install_args: rust cargo:cargo-machete
+      # cargo-modules ships no prebuilt binary, so it is a ~9 min source build. Cache it keyed on
+      # its own version alone: mise-action's cache key hashes every `mise*.toml`, so leaving it
+      # under mise meant any `rust`/`node`/`pnpm`/`cargo-nextest` bump rebuilt it from scratch.
+      # `--root` pins the install location so the cache path does not depend on CARGO_HOME.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: cargo-modules-cache
+        with:
+          path: ~/.cargo-tools
+          key: cargo-modules-${{ runner.os }}-${{ env.CARGO_MODULES_VERSION }}
+      - if: steps.cargo-modules-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-modules@${{ env.CARGO_MODULES_VERSION }} --locked --root ~/.cargo-tools
+      - run: echo "$HOME/.cargo-tools/bin" >> "$GITHUB_PATH"
       # Unused Cargo.toml dependencies across the whole workspace (no compilation needed).
       # Intentional declarations (transitive version pins, PR5 pre-declarations) are
       # allow-listed via `[package.metadata.cargo-machete]` in each crate's Cargo.toml.

--- a/mise.ci-hygiene.toml
+++ b/mise.ci-hygiene.toml
@@ -1,12 +1,13 @@
 # mise config environment, loaded only when MISE_ENV=ci-hygiene (set on the `hygiene` CI job).
 #
-# Both hygiene tools compile from source (no prebuilt binary fetched via binstall); cargo-modules
-# additionally pulls in the whole rust-analyzer crate graph (~16 min on a Windows runner, which
-# also does not cache it reliably). They are used ONLY by the `hygiene` job (`cargo machete` /
-# `cargo modules orphans`), so they are kept out of the shared `mise.toml`: otherwise every job
-# (core / frontend / app on macOS+Windows) would compile them via mise-action despite never running
-# them. Renovate's mise manager matches this file by default (`mise.<env>.toml`), so the pins stay
-# tracked.
+# cargo-machete is kept out of the shared `mise.toml` because it is used ONLY by the `hygiene`
+# job (`cargo machete`); otherwise every job (core / frontend / app on macOS+Windows) would
+# install it despite never running it. Renovate's mise manager matches this file by default
+# (`mise.<env>.toml`), so the pin stays tracked.
+#
+# cargo-modules is deliberately NOT here: it publishes no prebuilt binaries, so it is always a
+# ~9 min source build (it pulls in the whole rust-analyzer crate graph), and mise-action's cache
+# key hashes every `mise*.toml`, which meant an unrelated `mise.toml` bump forced that rebuild.
+# It is installed and cached by version in the `hygiene` job instead — see .github/workflows/ci.yml.
 [tools]
-"cargo:cargo-modules" = "0.26.0"
 "cargo:cargo-machete" = "0.9.2"

--- a/mise.toml
+++ b/mise.toml
@@ -7,9 +7,10 @@ node = "24.18.0"
 pnpm = "11.16.0"
 "cargo:cargo-nextest" = "0.9.137"
 "cargo:cargo-llvm-cov" = "0.8.7"
-# The dependency-hygiene tools (cargo-modules, cargo-machete) live in mise.ci-hygiene.toml: both
-# compile from source and are only used by the `hygiene` CI job (MISE_ENV=ci-hygiene), so keeping
-# them out of this shared config avoids that compile in the core / frontend / app jobs.
+# cargo-machete lives in mise.ci-hygiene.toml because only the `hygiene` CI job uses it
+# (MISE_ENV=ci-hygiene). cargo-modules is not managed by mise: the job installs it with
+# `cargo install` and caches it keyed on its own version because it publishes no prebuilt binary,
+# while mise-action's cache key hashes every mise*.toml.
 
 [settings]
 # Prefer binary fetch via cargo-binstall when available (faster installs)

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,16 @@
   "internalChecksFilter": "strict",
   "prConcurrentLimit": 10,
   "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the cargo-modules pin in the CI hygiene job",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": ["CARGO_MODULES_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "crate",
+      "depNameTemplate": "cargo-modules"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Stacked on #237 — base is `perf/ci-scope-mise-per-job`, not `main`. Retarget to `main` once #237 merges.

Closes #233

## Summary

`cargo-modules` publishes no prebuilt binary, so it is always a ~9 minute source build, and `jdx/mise-action`'s cache key hashes every `mise*.toml` — which meant an unrelated `rust` / `node` / `pnpm` / `cargo-nextest` bump in `mise.toml` invalidated the `hygiene` job's cache and forced that rebuild. The pin moves out of `mise.ci-hygiene.toml` into a `CARGO_MODULES_VERSION` env var on the `hygiene` job, cached by `actions/cache` on a key of `runner.os` + that version alone, so nothing but a genuine `cargo-modules` bump can trigger the rebuild.

## Background / Motivation

- `hygiene` is the second-longest job when the mise cache misses — **10m43s** in [run 30191258615](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30191258615) — and **9m23s of that is a single tool build**. Its log reads `Installing cargo-modules v0.26.0` → `Compiling cargo-modules v0.26.0` → ``Finished `release` profile [optimized] target(s) in 9m 08s``.
- `cargo-binstall` (#227) cannot fix this one. `gh api repos/regexident/cargo-modules/releases/latest` returns **404 — the repo publishes no releases at all**, so binstall logs `Fallback to cargo-install is disabled` and mise falls back to a source build that pulls in the whole rust-analyzer crate graph.
- The invalidation is structural, not incidental. `jdx/mise-action`'s `file_hash` globs (`src/index.ts:14-38` at SHA `9e7f7633`) cover `**/mise.toml` **and** `**/mise.*.toml`, and `file_hash` feeds the default cache key (`src/index.ts:43`). `mise.toml` took **12 commits in the last 60 days** on a weekly Renovate schedule; each one rebuilt `cargo-modules` from scratch for no reason.
- With cache-eviction pressure removed by #228, `hygiene` becomes the workflow's critical path every time this fires.

Expected effect on the `hygiene` job total:

| scenario | before | after |
|---|---|---|
| warm cache | 1m31s | ~1m35s (one extra cache-restore step) |
| after a `mise.toml` bump | 10m43s | **~1m40s** |
| after a `cargo-modules` bump | 10m43s | ~10m43s (correct — the tool genuinely changed) |

## Changes

### Version pin moved onto the job (`.github/workflows/ci.yml`)

- `CARGO_MODULES_VERSION: "0.26.0"` is added to the `hygiene` job's `env:` block as the single source of truth for both the install and the cache key.
- `install_args` drops `cargo:cargo-modules` and keeps `rust cargo-binstall cargo:cargo-machete` — `rust` is still required because `cargo machete` is a cargo subcommand, and `cargo-binstall` has to stay named or `cargo:cargo-machete` falls back to a from-source build (see #237).

### Independent cache for `cargo-modules` (`.github/workflows/ci.yml`)

- `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` (SHA-pinned, matching the repo's convention for every other action) restores `~/.cargo-tools` on key `cargo-modules-${{ runner.os }}-${{ env.CARGO_MODULES_VERSION }}`. Nothing else enters that key — that is the whole point of the change.
- `cargo install cargo-modules@${{ env.CARGO_MODULES_VERSION }} --locked --root ~/.cargo-tools` runs only on `cache-hit != 'true'`. `--locked` keeps the build reproducible from the cache key; `--root` pins the install location so the cached path does not depend on `CARGO_HOME`.
- The whole root is cached, not just `bin/`, so `.crates.toml` / `.crates2.json` come back with it.
- `echo "$HOME/.cargo-tools/bin" >> "$GITHUB_PATH"` runs **unconditionally**, on both the hit and miss paths, rather than relying on `cargo install`'s default `~/.cargo/bin` winning against the runner's mise shims and preinstalled Rust.
- `cargo machete` and `cargo modules orphans -p simple-archiver-core --lib --deny` are unchanged.

### Tooling config (`mise.toml`, `mise.ci-hygiene.toml`, `renovate.json`)

- `mise.ci-hygiene.toml` drops the `"cargo:cargo-modules"` pin and keeps `"cargo:cargo-machete" = "0.9.2"`. The header comment now records why `cargo-modules` is deliberately absent and where it lives instead.
- `mise.toml`'s trailing `[tools]` comment still claimed that *both* hygiene tools live in `mise.ci-hygiene.toml`. That is false once this PR lands, so it is rewritten to describe `cargo-machete` only and to point at the `hygiene` job for `cargo-modules`. Comment-only edit — no tool entry or setting changes.
- `renovate.json` gains a top-level `customManagers` entry (regex, datasource `crate`, dep `cargo-modules`) matching `CARGO_MODULES_VERSION:\s*"(?<currentValue>[^"]+)"` in `.github/workflows/ci.yml`, so the pin stays tracked after leaving Renovate's `mise` manager. `packageRules` is untouched.

## Verification

Local gates run on this branch:

- `actionlint .github/workflows/ci.yml` — exit 0
- `renovate-config-validator renovate.json` — `Config validated successfully against 1 file(s)`, exit 0. Also exit 0 in auto-discovery (repository-config) mode, so `managerFilePatterns` is accepted by the current Renovate and the older `fileMatch` fallback is not needed.
- `node -e "JSON.parse(...)"` on `renovate.json` — parses
- `mise ls` with `MISE_ENV=ci-hygiene` — resolves `cargo:cargo-machete 0.9.2` from this worktree's `mise.ci-hygiene.toml`; `cargo-modules` no longer comes from it
- `git diff --stat` — 4 files; every `ci.yml` hunk this PR adds is inside the `hygiene` job (the `install_args` hunks in the other jobs come from the #237 base, merged in)
- `python3 -c "import tomllib; tomllib.load(open('mise.toml','rb'))"` — parses; the `[tools]` table is unchanged (`rust`, `node`, `pnpm`, `cargo:cargo-nextest`, `cargo:cargo-llvm-cov`)
- `actions/cache` SHA checked against upstream: `gh api repos/actions/cache/git/ref/tags/v6.1.0` → `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`, matching the pin and its `# v6.1.0` comment

Once CI has run, confirm the cache wiring from the `hygiene` job log:

```bash
gh run view <run-id> --json jobs \
  --jq '.jobs[] | select(.name | startswith("hygiene")) | "\(.name): \(.startedAt) -> \(.completedAt)"'
gh api repos/{owner}/{repo}/actions/jobs/<hygiene-job-id>/logs | grep -iE "Cache restored|cargo-modules"
```

First run: cache miss, `cargo install` runs. Second run on the same branch: `Cache restored`, the `cargo install` step shows as skipped, and `cargo modules orphans` still passes — which is what proves the `--root` + `$GITHUB_PATH` wiring works.

### Measured on CI — the full miss -> hit cycle

Three runs on this branch, all 6 jobs green in each:

| run | commit | `actions/cache` | `cargo install cargo-modules` | `cargo modules orphans` | `hygiene` total |
|---|---|---|---|---|---|
| [30193409542](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193409542) | `b46a18b` | miss | **243s** | 77s, pass | **389s** |
| [30193633372](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193633372) | `008262c` | hit (1s) | *skipped* | 75s, pass | **99s** |
| [30193670609](https://github.com/yasuflatland-lf/simple-archiver/actions/runs/30193670609) | `c44c48f` | hit (2s) | *skipped* | 61s, pass | **86s** |

`cargo modules orphans` passing while the install step is skipped is the proof that `--root ~/.cargo-tools` plus the unconditional `$GITHUB_PATH` append actually resolves the cached binary — nothing else on the runner provides `cargo-modules` any more.

The saved entry is `cargo-modules-Linux-0.26.0`, 6 MB (`gh api repos/{owner}/{repo}/actions/caches`), versus the ~700 MB `v0-rust-*` entries that dominate the 12.49 GB total.

One scoping note for the reviewer: the entry above is currently scoped to `refs/pull/250/merge`. GitHub scopes a cache created on a PR to that PR's ref, so the **first run on `main` after merge is still a miss** and is what creates the `refs/heads/main`-scoped entry that every later PR restores from. Expect one more ~4 minute `hygiene` run immediately after merge, then ~1m30s steady state.

For comparison, PR #237's run on `782dbb7` — same `hygiene` job but with `cargo-modules` still installed through mise — took **341s**, of which 259s was the mise step compiling it. This PR removes that.

## Test plan

- [x] Exactly four files changed: `.github/workflows/ci.yml`, `mise.toml`, `mise.ci-hygiene.toml`, `renovate.json`
- [x] The `mise.toml` edit is comment-only — `tomllib` reports an unchanged `[tools]` table
- [x] `mise.ci-hygiene.toml` no longer contains `cargo-modules`; still contains the `cargo-machete` pin
- [x] `actions/cache` pinned by SHA with a `# v6.1.0` comment
- [x] `renovate-config-validator renovate.json` exits 0 with `managerFilePatterns` (no `fileMatch` fallback needed)
- [x] `actionlint .github/workflows/ci.yml` exits 0
- [x] All added comments are in English
- [x] `hygiene`'s `install_args` still names `cargo-binstall` after merging the updated #237 base
- [ ] #237 merges and this PR is retargeted to `main` before merge
- [x] All 6 CI jobs green; `cargo modules orphans -p simple-archiver-core --lib --deny` still runs and passes, proving the `--root` + `$GITHUB_PATH` wiring
- [x] Cache-hit path verified: runs `008262c` and `c44c48f` both report a cache hit and show the `cargo install` step as skipped
- [x] Measured: `hygiene` total 389s on the miss run, **99s / 86s** on the two hit runs — comfortably under the ≈1m40s success criterion
- [ ] After merge: `main`'s first run is a miss (PR-scoped caches are not visible to `main`); confirm the second `main` run restores `cargo-modules-Linux-0.26.0` and `hygiene` settles at ~1m30s
- [ ] After the next `mise.toml` bump: confirm `hygiene` does **not** rebuild `cargo-modules`

