### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-archiver"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags 2.13.1",
  "serde",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async_zip",
  "chardetng",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.11.0"
+version = "0.12.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release version bump `0.11.0` → `0.12.0` ahead of cutting the `v0.12.0` release.

Bumps the version in all six tracked locations:

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `crates/core/Cargo.toml`
- `Cargo.lock` (`simple-archiver` + `simple-archiver-core`)

## What ships in v0.12.0 (since v0.11.0)

Correctness

- Claim each output destination atomically instead of probing, so parallel jobs cannot race onto the same path (#252)
- Fold output names the way the filesystem does, and fail only the one bad source instead of the whole run (#255)
- Report the path actually written in the terminal event, not the planned one (#256)
- Treat a skipped item as a terminal state rather than reporting it as success (#257)
- Remove the partial zip when compression fails, and clean up the partially copied tree when folder placement fails (#206, #208)
- Report a panicking worker's task as failed, and extract archives with an oversized extra-field subfield (#226)
- Ignore file drops while a job is running, clear prior run progress when a new run starts, and guard `runJob` against re-entrancy (#204, #205, #211)

Performance

- Throttle progress emits in the aggregation loop and coalesce them with `requestAnimationFrame` (#207, #209)
- Widen the zip extraction read buffer to cut blocking-pool round trips (#210)

Internals

- Add an `OutputStrategy` port so the engine stops branching on output mode (#258)
- Split `OutputName` into a sum type per output mode (#254)
- Freeze the draft mid-run and unify the run gate (#253)

Also included: CI runtime improvements (#235–#238, #247–#250), dependency updates, and refreshed architecture/domain docs (#251).

## Verification

- `cargo metadata --locked` exits 0 (lockfile consistent)
- Diff is exactly the six version lines, nothing else
