### PR TITLE
feat(presentation): keep the focused queue row scrolled into view

### DIFF
--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -1449,3 +1449,238 @@ describe("TaskList reorder feedback", () => {
     expect(animate).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Focused-row visibility
+// ---------------------------------------------------------------------------
+
+describe("TaskList focused row visibility", () => {
+  // jsdom keeps `scrollTop` pinned at 0 on real elements (no layout box), so the
+  // scroller is faked as a plain object with a writable scrollTop, matching
+  // edge-autoscroll.test.ts.
+  function fakeScroller(top: number, bottom: number): HTMLElement {
+    return {
+      scrollTop: 0,
+      getBoundingClientRect: () =>
+        ({
+          top,
+          bottom,
+          height: bottom - top,
+          left: 0,
+          right: 0,
+          width: 0,
+          x: 0,
+          y: top,
+          toJSON() {},
+        }) as DOMRect,
+    } as unknown as HTMLElement;
+  }
+
+  // Prescribe a uniform row grid on the rendered rows. React reuses these <tr>
+  // nodes across a reorder (index keys, unchanged count), so the stubs survive.
+  function stubRowGrid(rowHeight: number): void {
+    document
+      .querySelectorAll<HTMLElement>("tr[data-row-index]")
+      .forEach((tr) => {
+        const top = Number(tr.dataset.rowIndex) * rowHeight;
+        tr.getBoundingClientRect = () =>
+          ({
+            top,
+            bottom: top + rowHeight,
+            height: rowHeight,
+            left: 0,
+            right: 0,
+            width: 0,
+            x: 0,
+            y: top,
+            toJSON() {},
+          }) as DOMRect;
+      });
+  }
+
+  it("scrolls the work area when a row moves below the fold", async () => {
+    // A store `reorder` that commits a genuinely new draft: animateMove compares
+    // draft references to decide whether the move landed.
+    const reorder = vi
+      .fn()
+      .mockImplementation(async (from: number, to: number) => {
+        const next = [...useJobStore.getState().draft.items];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved);
+        useJobStore.setState((s) => ({ draft: { ...s.draft, items: next } }));
+      });
+    useJobStore.setState({
+      draft: {
+        items: makeItems(10),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      reorder,
+    });
+
+    const scroller = fakeScroller(0, 300);
+    const user = userEvent.setup();
+    render(<TaskList scrollContainerRef={{ current: scroller }} />);
+    // Rows sit on a 40px grid, so row 8 (320..360) is past the 300px fold.
+    stubRowGrid(40);
+
+    const downButtons = screen.getAllByRole("button", { name: /move down/i });
+    await user.click(downButtons[7]);
+
+    await waitFor(() => {
+      expect(scroller.scrollTop).toBeGreaterThan(0);
+    });
+  });
+
+  // Seed a 10-row queue plus whatever store overrides the test needs.
+  function seedRows(extra: Record<string, unknown> = {}) {
+    useJobStore.setState({
+      draft: {
+        items: makeItems(10),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      ...extra,
+    });
+  }
+
+  // The item rows (the first <tr> is the header).
+  function itemRows() {
+    return screen.getAllByRole("row").slice(1) as HTMLTableRowElement[];
+  }
+
+  it("scrolls the work area when the selection alone moves off screen", () => {
+    seedRows();
+
+    const scroller = fakeScroller(0, 300);
+    render(<TaskList scrollContainerRef={{ current: scroller }} />);
+    // Rows sit on a 40px grid, so row 8 (320..360) is past the 300px fold.
+    stubRowGrid(40);
+
+    act(() => {
+      // A PURE selection change: the queue contents are untouched, so no
+      // reorder path is involved and this watcher owns the scroll.
+      useJobStore.setState({ selectedIndices: [8], selectionAnchor: 8 });
+    });
+
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("does not scroll the work area when a single row is dropped by drag", async () => {
+    // Mimic the real store's reorder: a fresh draft, and the selection dropped
+    // by the structural edit (draftEdit).
+    const reorder = vi
+      .fn()
+      .mockImplementation(async (from: number, to: number) => {
+        const next = [...useJobStore.getState().draft.items];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved);
+        useJobStore.setState((s) => ({
+          draft: { ...s.draft, items: next },
+          selectedIndices: [],
+          selectionAnchor: null,
+        }));
+      });
+    seedRows({ reorder });
+
+    const scroller = fakeScroller(0, 300);
+    render(<TaskList scrollContainerRef={{ current: scroller }} />);
+    stubRowGrid(40);
+
+    const rows = itemRows();
+    // Drag row 0 down onto the bottom half of row 9 (360..400) — deep inside the
+    // bottom edge zone, i.e. the normal end of any long downward drag.
+    fireEvent.pointerDown(screen.getByTestId("reorder-handle-0"));
+    fireEvent.pointerMove(rows[9], { clientY: 396 });
+    // Baseline taken after the last move so any edge auto-scroll already applied
+    // is excluded; only the drop's own effect is under test.
+    const beforeDrop = scroller.scrollTop;
+    await act(async () => {
+      fireEvent.pointerUp(rows[9], { clientY: 396 });
+    });
+
+    expect(reorder).toHaveBeenCalledWith(0, 9);
+    // Drag landing is out of scope: releasing must not yank the list out from
+    // under the pointer.
+    expect(scroller.scrollTop).toBe(beforeDrop);
+  });
+
+  it("does not scroll the work area when a selected block is dropped by drag", async () => {
+    // Mimic applyMovePlan: a fresh draft committed together with the block's new
+    // positions re-applied as the selection.
+    const moveSelectedTo = vi.fn().mockImplementation(async () => {
+      useJobStore.setState((s) => ({
+        draft: { ...s.draft, items: [...s.draft.items] },
+        selectedIndices: [8, 9],
+        selectionAnchor: 8,
+      }));
+    });
+    seedRows({
+      moveSelectedTo,
+      selectedIndices: [0, 1],
+      selectionAnchor: 0,
+    });
+
+    const scroller = fakeScroller(0, 300);
+    render(<TaskList scrollContainerRef={{ current: scroller }} />);
+    stubRowGrid(40);
+
+    const rows = itemRows();
+    fireEvent.pointerDown(screen.getByTestId("reorder-handle-0"));
+    fireEvent.pointerMove(rows[9], { clientY: 396 });
+    const beforeDrop = scroller.scrollTop;
+    await act(async () => {
+      fireEvent.pointerUp(rows[9], { clientY: 396 });
+    });
+
+    expect(moveSelectedTo).toHaveBeenCalledWith(10);
+    // The commit rewrites selectedIndices, but the selection watcher must not
+    // treat that as a plain selection change and chase the block's trailing row.
+    expect(scroller.scrollTop).toBe(beforeDrop);
+  });
+
+  it("leaves the scroller alone when the landing row is already visible", async () => {
+    const reorder = vi
+      .fn()
+      .mockImplementation(async (from: number, to: number) => {
+        const next = [...useJobStore.getState().draft.items];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved);
+        useJobStore.setState((s) => ({ draft: { ...s.draft, items: next } }));
+      });
+    useJobStore.setState({
+      draft: {
+        items: makeItems(10),
+        namingTemplate: null,
+        startNumber: 1,
+        outputDir: null,
+        outputMode: "zip",
+        conflictPolicy: "autoRename",
+      },
+      previewNames: [],
+      reorder,
+    });
+
+    const scroller = fakeScroller(0, 300);
+    const user = userEvent.setup();
+    render(<TaskList scrollContainerRef={{ current: scroller }} />);
+    stubRowGrid(40);
+
+    // Row 0 moves to row 1 (40..80), well inside the visible 0..300 band.
+    const downButtons = screen.getAllByRole("button", { name: /move down/i });
+    await user.click(downButtons[0]);
+
+    await waitFor(() => {
+      expect(reorder).toHaveBeenCalled();
+    });
+    expect(scroller.scrollTop).toBe(0);
+  });
+});

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -19,6 +19,8 @@ import { TaskRow } from "@/components/TaskRow";
 import { useColumnResize } from "@/hooks/useColumnResize";
 import { useQueueReorderKeys } from "@/hooks/useQueueReorderKeys";
 import { useQueueSelectionKeys } from "@/hooks/useQueueSelectionKeys";
+import { useScrollRowIntoView } from "@/hooks/useScrollRowIntoView";
+import { useSelectedRowVisibility } from "@/hooks/useSelectedRowVisibility";
 import { cn } from "@/lib/utils";
 import { useJobStore } from "@/store/jobStore";
 
@@ -58,13 +60,27 @@ export function TaskList({
   // Queue-scoped keyboard shortcuts (select all / delete / clear). Stable across
   // renders, so it is safe to call before the early return below.
   const onSelectionKeys = useQueueSelectionKeys();
+  // Scrolls a given row into view. Declared before the two hooks below so both
+  // can take it, and stable for stable refs so neither effect re-fires.
+  const scrollRowIntoView = useScrollRowIntoView({
+    tableRef,
+    scrollContainerRef,
+  });
   const {
     animatedReorder,
     animatedMoveSelected,
     animatedMoveSelectedTo,
     justMovedIndex,
     liveMessage,
-  } = useReorderAnimation(tableRef);
+  } = useReorderAnimation(tableRef, scrollRowIntoView);
+  // Kept after useReorderAnimation, which React runs first because it runs
+  // layout effects in declaration order. The two no longer compete: this hook
+  // ignores every change that also swapped draft.items, which is exactly what a
+  // move does, so a move's landing scroll is the only one that happens. The
+  // order stays as the defensive arrangement — should both ever fire for one
+  // render, the move's landing row (measured against the settled layout) is the
+  // one that should win, and minimum-distance scrolling makes the loser a no-op.
+  useSelectedRowVisibility(scrollRowIntoView);
   // Arrow keys move the selected row(s): a single selection routes through the
   // single animated reorder, a multi-row selection through the grouped shift, so
   // the slide/settle/announce match drag and the buttons either way.

--- a/src/components/reorder-animation.test.tsx
+++ b/src/components/reorder-animation.test.tsx
@@ -160,3 +160,200 @@ describe("useReorderAnimation single-row reorder", () => {
     expect(result.current.liveMessage).toBe("");
   });
 });
+
+// A container holding real <tr> nodes on a uniform grid whose rect reads, slide
+// starts, and the scroll callback all append to one log, so their relative order
+// can be asserted. Distinct tops matter: equal tops would make every FLIP delta
+// zero and no slide would start at all.
+const LOGGED_ROW_HEIGHT = 20;
+function loggingContainer(rowCount: number, log: string[]): HTMLElement {
+  const container = document.createElement("div");
+  const table = document.createElement("table");
+  const tbody = document.createElement("tbody");
+  for (let i = 0; i < rowCount; i++) {
+    const tr = document.createElement("tr");
+    tr.dataset.rowIndex = String(i);
+    const top = i * LOGGED_ROW_HEIGHT;
+    tr.getBoundingClientRect = () => {
+      log.push("measure");
+      return {
+        top,
+        bottom: top + LOGGED_ROW_HEIGHT,
+        height: LOGGED_ROW_HEIGHT,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: top,
+        toJSON() {},
+      } as DOMRect;
+    };
+    tr.animate = () => {
+      log.push("animate");
+      return {
+        finished: Promise.resolve(),
+        cancel: () => {},
+      } as unknown as Animation;
+    };
+    tbody.append(tr);
+  }
+  table.append(tbody);
+  container.append(table);
+  return container;
+}
+
+function renderWithScroll(scrollRowIntoView: (index: number) => void) {
+  const containerRef = { current: document.createElement("div") };
+  return renderHook(() => useReorderAnimation(containerRef, scrollRowIntoView));
+}
+
+describe("useReorderAnimation row visibility", () => {
+  it("shows the landing row after a single-row move", async () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+    mockArchive.reorder.mockImplementation(() => Promise.resolve(makeDraft(3)));
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedReorder(0, 2);
+    });
+
+    expect(scrollRowIntoView).toHaveBeenCalledWith(2);
+  });
+
+  it("shows the trailing row of a grouped move down", async () => {
+    useJobStore.setState({
+      draft: makeDraft(4),
+      selectedIndices: [0, 1],
+      selectionAnchor: 0,
+    });
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedMoveSelected("down");
+    });
+
+    // The block lands on [1, 2]; moving down, the bottom row is the one to keep
+    // in sight.
+    expect(scrollRowIntoView).toHaveBeenCalledWith(2);
+  });
+
+  it("shows the leading row of a grouped move up", async () => {
+    useJobStore.setState({
+      draft: makeDraft(4),
+      selectedIndices: [2, 3],
+      selectionAnchor: 2,
+    });
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedMoveSelected("up");
+    });
+
+    expect(scrollRowIntoView).toHaveBeenCalledWith(1);
+  });
+
+  it("does not scroll on a drag relocate (out of scope)", async () => {
+    useJobStore.setState({
+      draft: makeDraft(5),
+      selectedIndices: [1, 3],
+      selectionAnchor: 1,
+    });
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedMoveSelectedTo(5);
+    });
+
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when the move clamps to a no-op", async () => {
+    useJobStore.setState({
+      draft: makeDraft(4),
+      selectedIndices: [0, 1],
+      selectionAnchor: 0,
+    });
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedMoveSelected("up");
+    });
+
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("scrolls after the FLIP measurement but before the slides start", async () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+    mockArchive.reorder.mockImplementation(() => Promise.resolve(makeDraft(3)));
+    const log: string[] = [];
+    const containerRef = { current: loggingContainer(3, log) };
+    const { result } = renderHook(() =>
+      useReorderAnimation(containerRef, () => {
+        log.push("scroll");
+      }),
+    );
+
+    await act(async () => {
+      await result.current.animatedReorder(0, 2);
+    });
+
+    const scroll = log.indexOf("scroll");
+    const firstAnimate = log.indexOf("animate");
+    expect(scroll).toBeGreaterThan(-1);
+    expect(firstAnimate).toBeGreaterThan(-1);
+    // Scrolling between FLIP's before/after measurements would corrupt its
+    // deltas, so every rect read must already be done.
+    expect(log.lastIndexOf("measure")).toBeLessThan(scroll);
+    // ...and no slide may have started yet: el.animate() composes its first
+    // keyframe at the next style flush, which the scroll's own
+    // getBoundingClientRect() forces, so a scroll taken after the slides start
+    // reads each row's PRE-move position and lands one delta short.
+    expect(scroll).toBeLessThan(firstAnimate);
+  });
+
+  it("still shows the landing row under reduced motion (no FLIP captured)", async () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({ matches: true } as MediaQueryList),
+    );
+    try {
+      useJobStore.setState({ draft: makeDraft(3) });
+      mockArchive.reorder.mockImplementation(() =>
+        Promise.resolve(makeDraft(3)),
+      );
+      const scrollRowIntoView = vi.fn();
+      const { result } = renderWithScroll(scrollRowIntoView);
+
+      await act(async () => {
+        await result.current.animatedReorder(0, 2);
+      });
+
+      // No slide was captured, so no row carries a transform — the scroll still
+      // has to happen, from the (already true) layout positions.
+      expect(scrollRowIntoView).toHaveBeenCalledWith(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not scroll a single-row move when the caller opts out", async () => {
+    useJobStore.setState({ draft: makeDraft(3) });
+    mockArchive.reorder.mockImplementation(() => Promise.resolve(makeDraft(3)));
+    const scrollRowIntoView = vi.fn();
+    const { result } = renderWithScroll(scrollRowIntoView);
+
+    await act(async () => {
+      await result.current.animatedReorder(0, 2, { showLandingRow: false });
+    });
+
+    // The move still lands (and still announces); only the landing scroll is
+    // suppressed — this is what the drag path asks for.
+    expect(mockArchive.reorder).toHaveBeenCalledWith(0, 2);
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/reorder-animation.tsx
+++ b/src/components/reorder-animation.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 
 import { computeFlipDeltas, reorderPermutation } from "@/components/flip";
+import type { ScrollRowIntoView } from "@/hooks/useScrollRowIntoView";
 import { basename } from "@/lib/path";
 import { planRelocateSelection, planShiftSelection } from "@/lib/queue-move";
 import { useJobStore } from "@/store/jobStore";
@@ -23,7 +24,21 @@ const SLIDE_MS = 200;
  * settle keyframe so the fade completes before the flag clears. */
 const HIGHLIGHT_CLEAR_MS = 800;
 
-type AnimatedReorder = (from: number, to: number) => Promise<void>;
+/** Per-call tweaks for a single-row animated reorder. */
+interface ReorderOptions {
+  /**
+   * Bring the landing row into view once the move has rendered. Defaults to
+   * true, which is what the keyboard and the move buttons want; the drag path
+   * opts out because drag landing is deliberately out of scope.
+   */
+  showLandingRow?: boolean;
+}
+
+type AnimatedReorder = (
+  from: number,
+  to: number,
+  options?: ReorderOptions,
+) => Promise<void>;
 /** Shift the whole selection one slot up/down (keyboard / move buttons). */
 type AnimatedMoveSelected = (direction: "up" | "down") => Promise<void>;
 /** Relocate the whole selection to a drop gap (drag). */
@@ -84,6 +99,7 @@ interface PendingFlip {
  */
 export function useReorderAnimation(
   containerRef: RefObject<HTMLElement | null>,
+  scrollRowIntoView?: ScrollRowIntoView,
 ): {
   animatedReorder: AnimatedReorder;
   animatedMoveSelected: AnimatedMoveSelected;
@@ -97,6 +113,11 @@ export function useReorderAnimation(
   // Pre-commit measurement + the move, stashed by animatedReorder and consumed
   // by the layout effect after the re-render.
   const pendingRef = useRef<PendingFlip | null>(null);
+  // Which row to bring into view once the move has rendered. Captured BEFORE the
+  // store mutation for the same reason as the FLIP capture above: the commit can
+  // resolve and flush React's effects before the awaiting code resumes, so a
+  // stash written afterwards would arrive too late to be consumed.
+  const pendingFocusRef = useRef<number | null>(null);
   // WAAP animations we started, tracked so a rapid second move can cancel them
   // (settling rows to their final layout) before measuring again.
   const activeRef = useRef<Set<Animation>>(new Set());
@@ -127,13 +148,24 @@ export function useReorderAnimation(
   }, []);
 
   // Play the captured FLIP: measure the settled tops, invert each row by its
-  // delta, then animate the transform back to zero so it glides into place.
+  // delta, then animate the transform back to zero so it glides into place. The
+  // pending focus row is scrolled into view from this same effect, wedged
+  // between the measurement and the slides — see the comment below for why the
+  // two cannot be separate effects.
   useLayoutEffect(() => {
     const pending = pendingRef.current;
     pendingRef.current = null;
-    if (!pending) return;
+    const focus = pendingFocusRef.current;
+    pendingFocusRef.current = null;
     const container = containerRef.current;
     if (!container) return;
+    if (!pending) {
+      // Reduced motion: no slide was captured, so no row carries a transform and
+      // every rect already reads a true layout position. The row still has to
+      // end up on screen.
+      if (focus !== null) scrollRowIntoView?.(focus);
+      return;
+    }
     const afterTops: number[] = [];
     const elByIndex: HTMLElement[] = [];
     container
@@ -148,6 +180,19 @@ export function useReorderAnimation(
       pending.beforeTops,
       afterTops,
     );
+    // Scroll here — after the "after" measurement, before the first slide
+    // starts. `el.animate()` leaves the animation play-pending with hold time 0,
+    // so its first keyframe is composed into style at the next style flush, and
+    // a `getBoundingClientRect()` forces exactly that flush. A scroll measured
+    // once the slides are running would therefore read each row's PRE-move
+    // position and land one FLIP delta short.
+    //
+    // Scrolling here cannot corrupt the slide: `deltas` were computed from the
+    // pre-scroll before/after tops, and a transform is a relative displacement,
+    // so both endpoints shift by the same scroll amount and the row still glides
+    // to the right place. It all happens inside one layout-effect flush, so
+    // nothing paints in between.
+    if (focus !== null) scrollRowIntoView?.(focus);
     deltas.forEach((dy, newIndex) => {
       const el = elByIndex[newIndex];
       if (!dy || !el || typeof el.animate !== "function") return;
@@ -160,7 +205,7 @@ export function useReorderAnimation(
         .then(() => activeRef.current.delete(anim))
         .catch(() => activeRef.current.delete(anim));
     });
-  }, [items, containerRef]);
+  }, [items, containerRef, scrollRowIntoView]);
 
   useEffect(
     () => () => {
@@ -178,6 +223,8 @@ export function useReorderAnimation(
       perm: number[],
       apply: () => Promise<void>,
       describe: () => { justMoved: number | null; message: string },
+      /** Row to bring into view once rendered; `null` leaves the scroller alone. */
+      focusIndex: number | null,
     ): Promise<void> => {
       // An identity permutation means nothing moves (a clamped / in-place drop).
       if (perm.every((oldIndex, newIndex) => oldIndex === newIndex)) return;
@@ -187,11 +234,15 @@ export function useReorderAnimation(
         settleActive();
         pendingRef.current = { beforeTops: measureTops(), perm };
       }
+      // Stashed even under reduced motion, where there is no FLIP capture: the
+      // row still has to end up on screen.
+      pendingFocusRef.current = focusIndex;
       const before = useJobStore.getState().draft;
       await apply();
       if (useJobStore.getState().draft === before) {
         // Failed/no-op move: drop the capture, leave no feedback.
         pendingRef.current = null;
+        pendingFocusRef.current = null;
         return;
       }
       const info = describe();
@@ -213,7 +264,7 @@ export function useReorderAnimation(
   );
 
   const animatedReorder = useCallback<AnimatedReorder>(
-    (from, to) => {
+    (from, to, options) => {
       if (from === to) return Promise.resolve();
       const { draft } = useJobStore.getState();
       const name = basename(draft.items[from]?.path ?? "");
@@ -225,6 +276,9 @@ export function useReorderAnimation(
           justMoved: to,
           message: `Moved ${name} to position ${to + 1}`,
         }),
+        // The row landed at `to`; that is what the user is following — unless
+        // the caller opted out (the drag path).
+        options?.showLandingRow === false ? null : to,
       );
     },
     [animateMove],
@@ -238,10 +292,19 @@ export function useReorderAnimation(
         selectedIndices,
         direction,
       );
+      // Follow the edge of the block in the direction of travel: the bottom row
+      // going down, the top row going up.
+      const focusIndex =
+        plan.selected.length === 0
+          ? null
+          : direction === "down"
+            ? plan.selected[plan.selected.length - 1]
+            : plan.selected[0];
       return animateMove(
         plan.order,
         () => useJobStore.getState().moveSelected(direction),
         () => groupedAnnounce(plan.selected.length),
+        focusIndex,
       );
     },
     [animateMove],
@@ -259,6 +322,9 @@ export function useReorderAnimation(
         plan.order,
         () => useJobStore.getState().moveSelectedTo(gap),
         () => groupedAnnounce(plan.selected.length),
+        // Drag drops land under the pointer, which the edge auto-scroll has
+        // already kept on screen; scrolling again would fight the user.
+        null,
       );
     },
     [animateMove],

--- a/src/components/reorder-dnd.tsx
+++ b/src/components/reorder-dnd.tsx
@@ -199,7 +199,11 @@ export function ReorderDndProvider({
         // shifts every gap after it left by one — a gap past `from` maps to
         // `gap - 1`.
         const to = gap <= from ? gap : gap - 1;
-        if (to !== from) void animatedReorder(from, to);
+        // No landing scroll, matching the grouped drag above: the drop lands
+        // under the pointer, which the edge auto-scroll has already kept on
+        // screen, so scrolling on release would yank the list out from under it.
+        if (to !== from)
+          void animatedReorder(from, to, { showLandingRow: false });
       }
     }
     reset();

--- a/src/hooks/useScrollRowIntoView.test.ts
+++ b/src/hooks/useScrollRowIntoView.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useScrollRowIntoView } from "./useScrollRowIntoView";
+
+// jsdom has no layout, so every rect in this file is prescribed by the test.
+function rect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 0,
+    width: 0,
+    x: 0,
+    y: top,
+    toJSON() {},
+  } as DOMRect;
+}
+
+// A stand-in scroller: a plain object with a real, writable `scrollTop`. jsdom
+// treats `scrollTop` on a real element as permanently 0 (no layout box), so the
+// codebase fakes scrollers this way — see edge-autoscroll.test.ts.
+function fakeScroller(top: number, bottom: number): HTMLElement {
+  return {
+    scrollTop: 0,
+    getBoundingClientRect: () => rect(top, bottom - top),
+  } as unknown as HTMLElement;
+}
+
+// A real <table> so the hook's `tr[data-row-index]` lookup is genuinely
+// exercised; only the rects are stubbed. Rows are laid out on a uniform grid of
+// `rowHeight` px starting at viewport y = 0.
+function tableWithRows(count: number, rowHeight: number): HTMLTableElement {
+  const table = document.createElement("table");
+  const tbody = document.createElement("tbody");
+  for (let i = 0; i < count; i++) {
+    const tr = document.createElement("tr");
+    tr.dataset.rowIndex = String(i);
+    tr.getBoundingClientRect = () => rect(i * rowHeight, rowHeight);
+    tbody.append(tr);
+  }
+  table.append(tbody);
+  return table;
+}
+
+function setup(rowCount = 10, rowHeight = 40) {
+  const scroller = fakeScroller(0, 300);
+  const table = tableWithRows(rowCount, rowHeight);
+  const { result } = renderHook(() =>
+    useScrollRowIntoView({
+      tableRef: { current: table },
+      scrollContainerRef: { current: scroller },
+    }),
+  );
+  return { scroller, scrollRowIntoView: result.current };
+}
+
+describe("useScrollRowIntoView", () => {
+  it("scrolls a row below the fold in, leaving one row of margin", () => {
+    const { scroller, scrollRowIntoView } = setup();
+    // Row 8 spans 320..360; its bottom plus a 40px margin must reach 300.
+    scrollRowIntoView(8);
+    expect(scroller.scrollTop).toBe(100);
+  });
+
+  it("leaves the scroll position alone for an already-visible row", () => {
+    const { scroller, scrollRowIntoView } = setup();
+    // Row 2 spans 80..120, comfortably inside 0..300 with its margin.
+    scrollRowIntoView(2);
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it("is a no-op when the row is not rendered", () => {
+    const { scroller, scrollRowIntoView } = setup(3);
+    scrollRowIntoView(9);
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it("is a no-op without a scroll container", () => {
+    const table = tableWithRows(3, 40);
+    const { result } = renderHook(() =>
+      useScrollRowIntoView({ tableRef: { current: table } }),
+    );
+    expect(() => result.current(2)).not.toThrow();
+  });
+
+  it("is a no-op when the table ref is null", () => {
+    const scroller = fakeScroller(0, 300);
+    const { result } = renderHook(() =>
+      useScrollRowIntoView({
+        tableRef: { current: null },
+        scrollContainerRef: { current: scroller },
+      }),
+    );
+    expect(() => result.current(2)).not.toThrow();
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it("stays referentially stable across re-renders", () => {
+    const scroller = fakeScroller(0, 300);
+    const table = tableWithRows(3, 40);
+    const tableRef = { current: table };
+    const scrollContainerRef = { current: scroller };
+    const { result, rerender } = renderHook(() =>
+      useScrollRowIntoView({ tableRef, scrollContainerRef }),
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/hooks/useScrollRowIntoView.ts
+++ b/src/hooks/useScrollRowIntoView.ts
@@ -1,0 +1,56 @@
+import { useCallback, type RefObject } from "react";
+
+import { scrollDeltaToShowRow } from "@/lib/row-visibility";
+
+/** Bring the queue row at `index` into the scroller's visible area. */
+export type ScrollRowIntoView = (index: number) => void;
+
+interface ScrollRowIntoViewRefs {
+  /** The element wrapping the rows (the <table>); rows carry `data-row-index`. */
+  tableRef: RefObject<HTMLElement | null>;
+  /** The vertical scroller. Omitted (or null) makes the returned callback inert. */
+  scrollContainerRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Returns a callback that scrolls the queue's vertical scroller by the minimum
+ * distance needed to show the row at `index`, keeping one row of clearance at
+ * the edge it was crowding. A row already fully visible does not move the
+ * scroller, so repeat calls are idempotent and two callers asking for the same
+ * row cost nothing.
+ *
+ * The scroll is instant by design: the row itself is already sliding through the
+ * FLIP animation, and a competing smooth scroll would lag behind a held-down
+ * arrow key.
+ *
+ * Every lookup is guarded, so the callback is a no-op before mount, without a
+ * scroller (a standalone TaskList in a unit test), and for an index that is not
+ * rendered. In an environment without layout the rects are zero-sized, the delta
+ * is 0, and nothing scrolls — the same way column auto-fit degrades.
+ */
+export function useScrollRowIntoView({
+  tableRef,
+  scrollContainerRef,
+}: ScrollRowIntoViewRefs): ScrollRowIntoView {
+  return useCallback(
+    (index: number) => {
+      const scroller = scrollContainerRef?.current;
+      const table = tableRef.current;
+      if (!scroller || !table) return;
+      const row = table.querySelector<HTMLElement>(
+        `tr[data-row-index="${index}"]`,
+      );
+      if (!row) return;
+      const rowBounds = row.getBoundingClientRect();
+      const delta = scrollDeltaToShowRow(
+        scroller.getBoundingClientRect(),
+        rowBounds,
+        // One row of clearance, measured from the row itself so it stays correct
+        // when row heights differ.
+        rowBounds.height,
+      );
+      if (delta !== 0) scroller.scrollTop += delta;
+    },
+    [tableRef, scrollContainerRef],
+  );
+}

--- a/src/hooks/useSelectedRowVisibility.test.ts
+++ b/src/hooks/useSelectedRowVisibility.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftSnapshot } from "@/bindings/DraftSnapshot";
+import { resetJobStore, useJobStore } from "@/store/jobStore";
+
+import { useSelectedRowVisibility } from "./useSelectedRowVisibility";
+
+function makeDraft(count: number): DraftSnapshot {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      path: `/tmp/item-${i}.rar`,
+      kind: "rar" as const,
+      outputStem: `item-${i}`,
+    })),
+    namingTemplate: null,
+    startNumber: 1,
+    outputDir: null,
+    outputMode: "zip",
+    conflictPolicy: "autoRename",
+  };
+}
+
+function setup() {
+  const scrollRowIntoView = vi.fn();
+  renderHook(() => useSelectedRowVisibility(scrollRowIntoView));
+  return { scrollRowIntoView };
+}
+
+/** Commit a new selection and let the layout effect flush. */
+function select(indices: number[]): void {
+  act(() => {
+    useJobStore.setState({
+      selectedIndices: indices,
+      selectionAnchor: indices.length > 0 ? indices[0] : null,
+    });
+  });
+}
+
+beforeEach(() => {
+  resetJobStore();
+  vi.clearAllMocks();
+  useJobStore.setState({ draft: makeDraft(10) });
+});
+
+describe("useSelectedRowVisibility", () => {
+  it("shows the bottommost row when the selection moves down", () => {
+    const { scrollRowIntoView } = setup();
+    select([3]);
+    select([4, 5]);
+    expect(scrollRowIntoView).toHaveBeenLastCalledWith(5);
+  });
+
+  it("shows the topmost row when the selection moves up", () => {
+    const { scrollRowIntoView } = setup();
+    select([4, 5]);
+    select([3, 4]);
+    expect(scrollRowIntoView).toHaveBeenLastCalledWith(3);
+  });
+
+  it("does not scroll on select-all", () => {
+    const { scrollRowIntoView } = setup();
+    act(() => {
+      useJobStore.getState().selectAll();
+    });
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when the selection is cleared", () => {
+    const { scrollRowIntoView } = setup();
+    select([3]);
+    scrollRowIntoView.mockClear();
+    act(() => {
+      useJobStore.getState().clearSelection();
+    });
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll for the selection already present at mount", () => {
+    useJobStore.setState({ selectedIndices: [3], selectionAnchor: 3 });
+    const { scrollRowIntoView } = setup();
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when the store rewrites the same selection into a new array", () => {
+    const { scrollRowIntoView } = setup();
+    select([3]);
+    scrollRowIntoView.mockClear();
+    act(() => {
+      // A fresh array literal with the same contents: the `selectedIndices`
+      // selector reference changes, so the layout effect genuinely re-runs,
+      // and it is `selectionFocusIndex`'s `sameIndices` check (not a skipped
+      // effect) that must suppress the scroll.
+      useJobStore.setState({ selectedIndices: [3], selectionAnchor: 3 });
+    });
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when the items change alongside the selection", () => {
+    const { scrollRowIntoView } = setup();
+    select([0, 1]);
+    scrollRowIntoView.mockClear();
+    act(() => {
+      // What a grouped move / drag commit looks like: a fresh draft plus the
+      // block's new positions in one update. The reorder path owns that
+      // landing (or deliberately declines it), so this hook must stay out.
+      useJobStore.setState({
+        draft: makeDraft(10),
+        selectedIndices: [8, 9],
+        selectionAnchor: 8,
+      });
+    });
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not scroll when the item count changes but the selection does not", () => {
+    const { scrollRowIntoView } = setup();
+    select([3]);
+    scrollRowIntoView.mockClear();
+    act(() => {
+      // itemCount is a dependency of the layout effect, so this re-runs it
+      // with an unchanged selection.
+      useJobStore.setState({ draft: makeDraft(12) });
+    });
+    expect(scrollRowIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSelectedRowVisibility.ts
+++ b/src/hooks/useSelectedRowVisibility.ts
@@ -1,0 +1,47 @@
+import { useLayoutEffect, useRef } from "react";
+
+import type { ScrollRowIntoView } from "@/hooks/useScrollRowIntoView";
+import { selectionFocusIndex } from "@/lib/row-visibility";
+import { useJobStore } from "@/store/jobStore";
+
+/**
+ * Keeps the selected queue row visible: on a PURE selection change — one where
+ * the queue contents did not also change — the edge row on the side the
+ * selection grew towards is scrolled into view. It stays inert for select-all,
+ * for a cleared selection, and at mount.
+ *
+ * Any change that also swapped `draft.items` is somebody else's business. It is
+ * either a move, whose landing row the reorder path already scrolls to from
+ * correctly-measured geometry, or a drag / add / remove, which is deliberately
+ * out of scope. That matters because a grouped move commits the block's new
+ * positions as the selection, which would otherwise send this hook chasing the
+ * block's trailing row long after the drop. Skipping those changes also removes
+ * the double-fire where both paths scrolled to the same row after a grouped
+ * move, and guarantees this hook never measures while a FLIP slide is in flight
+ * — a FLIP only ever runs when `items` changed.
+ *
+ * The work runs in a LAYOUT effect so the scroll lands in the same frame as the
+ * render that caused it, with no intermediate paint at the old offset.
+ */
+export function useSelectedRowVisibility(
+  scrollRowIntoView: ScrollRowIntoView,
+): void {
+  const selectedIndices = useJobStore((s) => s.selectedIndices);
+  const items = useJobStore((s) => s.draft.items);
+  // Both seeded with their mount-time values so an already-selected row does not
+  // yank the scroller as soon as the queue renders.
+  const previousRef = useRef(selectedIndices);
+  const previousItemsRef = useRef(items);
+
+  useLayoutEffect(() => {
+    const previous = previousRef.current;
+    const previousItems = previousItemsRef.current;
+    previousRef.current = selectedIndices;
+    previousItemsRef.current = items;
+    // The queue contents changed: not a pure selection change, so leave the
+    // scroller to whoever owns that edit (see the note above).
+    if (previousItems !== items) return;
+    const target = selectionFocusIndex(previous, selectedIndices, items.length);
+    if (target !== null) scrollRowIntoView(target);
+  }, [selectedIndices, items, scrollRowIntoView]);
+}

--- a/src/lib/row-visibility.test.ts
+++ b/src/lib/row-visibility.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { scrollDeltaToShowRow, selectionFocusIndex } from "./row-visibility";
+
+// A scroller occupying viewport rows 100..400.
+const VIEW = { top: 100, bottom: 400 };
+
+describe("scrollDeltaToShowRow", () => {
+  it("does not scroll a row that already clears both margins", () => {
+    expect(scrollDeltaToShowRow(VIEW, { top: 200, bottom: 230 }, 30)).toBe(0);
+  });
+
+  it("scrolls up by the shortfall when the row crowds the top edge", () => {
+    // The row's top (110) must reach 130 = view top + margin, so 20px up.
+    expect(scrollDeltaToShowRow(VIEW, { top: 110, bottom: 140 }, 30)).toBe(-20);
+  });
+
+  it("scrolls down by the shortfall when the row crowds the bottom edge", () => {
+    // The row's bottom (390) must reach 370 = view bottom - margin: 20px down.
+    expect(scrollDeltaToShowRow(VIEW, { top: 360, bottom: 390 }, 30)).toBe(20);
+  });
+
+  it("brings a fully off-screen row in with its margin intact", () => {
+    expect(scrollDeltaToShowRow(VIEW, { top: 500, bottom: 530 }, 30)).toBe(160);
+  });
+
+  it("clamps to the top edge for a row taller than the view", () => {
+    // Honouring the bottom margin would push the row's top off-screen, so the
+    // top edge wins and the row's start stays visible.
+    expect(scrollDeltaToShowRow(VIEW, { top: 150, bottom: 600 }, 30)).toBe(50);
+  });
+});
+
+describe("selectionFocusIndex", () => {
+  it("shows nothing when the selection was cleared", () => {
+    expect(selectionFocusIndex([2], [], 10)).toBeNull();
+  });
+
+  it("shows nothing for select-all", () => {
+    expect(selectionFocusIndex([0], [0, 1, 2], 3)).toBeNull();
+  });
+
+  it("shows nothing when the selection is unchanged", () => {
+    expect(selectionFocusIndex([1, 2], [1, 2], 10)).toBeNull();
+  });
+
+  it("shows the topmost row when the selection moved up", () => {
+    expect(selectionFocusIndex([4, 5], [3, 4], 10)).toBe(3);
+  });
+
+  it("shows the bottommost row when the selection moved down", () => {
+    expect(selectionFocusIndex([4, 5], [5, 6], 10)).toBe(6);
+  });
+
+  it("shows the bottommost row of a brand-new selection", () => {
+    expect(selectionFocusIndex([], [7], 10)).toBe(7);
+  });
+});

--- a/src/lib/row-visibility.ts
+++ b/src/lib/row-visibility.ts
@@ -1,0 +1,61 @@
+// Pure math for keeping a queue row visible. No DOM, no store, no IO: callers
+// hand in plain rect numbers and get back a scroll delta, which keeps the
+// arithmetic unit-testable in an environment (jsdom) that has no layout.
+
+/** The vertical span of an element, in viewport coordinates. */
+export interface VerticalBounds {
+  top: number;
+  bottom: number;
+}
+
+/**
+ * Pixels to ADD to the scroller's `scrollTop` so `row` sits inside `view` with
+ * `margin` pixels of clearance at whichever edge it was crowding. Negative
+ * scrolls up, positive scrolls down, and `0` means the row already clears both
+ * margins — scrolling is minimum-distance, so a visible row never moves.
+ *
+ * A row taller than the view cannot satisfy both margins at once; the top edge
+ * wins, so the start of the row stays visible rather than an arbitrary slice.
+ */
+export function scrollDeltaToShowRow(
+  view: VerticalBounds,
+  row: VerticalBounds,
+  margin: number,
+): number {
+  const shortfallAbove = row.top - margin - view.top;
+  if (shortfallAbove < 0) return shortfallAbove;
+  const shortfallBelow = row.bottom + margin - view.bottom;
+  if (shortfallBelow > 0) {
+    // Never scroll so far down that the row's own top leaves the view.
+    return Math.min(shortfallBelow, row.top - view.top);
+  }
+  return 0;
+}
+
+/** True when both sorted index lists hold exactly the same rows. */
+function sameIndices(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/**
+ * Which row a selection change should bring into view, or `null` when the
+ * change should not scroll at all. `previous` and `next` must be sorted
+ * ascending, which every store path that writes `selectedIndices` guarantees.
+ *
+ * Nothing scrolls when the selection was cleared (Escape, or a structural edit
+ * that drops it), when every row is selected (Cmd+A — scrolling would fight the
+ * user's reading position), or when the selection did not actually change (an
+ * unrelated re-render). Otherwise the edge row on the side the selection grew
+ * towards is the one the user is tracking.
+ */
+export function selectionFocusIndex(
+  previous: number[],
+  next: number[],
+  itemCount: number,
+): number | null {
+  if (next.length === 0) return null;
+  if (itemCount > 0 && next.length === itemCount) return null;
+  if (sameIndices(previous, next)) return null;
+  const grewUpward = previous.length > 0 && next[0] < previous[0];
+  return grewUpward ? next[0] : next[next.length - 1];
+}


### PR DESCRIPTION
## Summary

Moving a selected queue row down with the arrow keys or the ▲/▼ buttons pushed it past the bottom of the work area, and the row kept going where the user could not see it. The tracked row now scrolls into view whenever it moves and whenever the selection changes: minimum distance plus one row of clearance, always instant. A row already fully visible does not move the scroller. Drag-and-drop landing stays deliberately out of scope on both drag paths, because `EdgeAutoScroller` already keeps the pointer's neighbourhood on screen.

## Background / Motivation

- The work-area scroller (`<main>` in `RightCanvas`) had no notion of a focused row. With 44 queued files and a ~10-row fold, holding ▼ on row 5 walked it off the bottom edge after five presses and the user lost track of where it landed.
- The one existing auto-scroll, `EdgeAutoScroller` (`src/components/edge-autoscroll.ts`), only runs *during* a pointer drag — it is driven by pointer position, so it does nothing for the keyboard and the move buttons, which is exactly where the problem was reported.
- Every reorder path already funnels through `useReorderAnimation`'s `animateMove`, and rows already carry `data-row-index` for the FLIP measurement, so the hook points needed were all present. What was missing was a decision about *which* row to follow and a place to measure it that does not fight the slide animation.
- **The measurement window is narrow, and the obvious placement is wrong.** This FLIP implementation inverts rows using the animation's own first keyframe rather than an inline style. `el.animate()` leaves the animation play-pending with hold time 0, so that keyframe composes into style at the next style flush — and `getBoundingClientRect()` forces exactly that flush. A scroll measured once the slides are running therefore reads each row's **pre-move** position, one FLIP delta short. The symptom is quiet for a keyboard move (the promised one-row margin silently collapses to zero) and loud for a long single-row drag (`dy` of hundreds of px, so the scroller jumps back toward the top on release). The codebase already guards the mirror case — `animateMove` calls `settleActive()` before `measureTops()` "so the pre-move measurement reads true layout positions, not transformed ones" — but the post-`animate()` side had no equivalent.
- **"Drag landing is out of scope" does not hold by itself.** `animatedMoveSelectedTo` passing `null` covers only half of it: `ReorderDndProvider.drop` routes a *single-row* drag through `animatedReorder(from, to)`, and `applyMovePlan` rewrites `selectedIndices`, so a grouped drop reaches a `selectedIndices` watcher anyway. Both leaks scroll at the instant of `pointerup`, pulling content out from under the pointer at the end of exactly the long downward drag where edge auto-scroll just engaged.

## Changes

### Pure visibility math (`src/lib/row-visibility.ts`)

- `scrollDeltaToShowRow(view, row, margin) -> number` — pixels to add to `scrollTop`; negative scrolls up, positive down, `0` when the row already clears both margins. A row taller than the view clamps to the top edge (`Math.min(shortfallBelow, row.top - view.top)`) so its start stays visible rather than an arbitrary slice.
- `selectionFocusIndex(previous, next, itemCount) -> number | null` — the row a selection change should show, or `null` for a cleared selection, for select-all (scrolling would fight the reading position), and for an unchanged selection. Otherwise the edge row on the side the selection grew towards.
- No imports at all, keeping `src/lib` the pure layer.

### The only DOM-touching piece (`src/hooks/useScrollRowIntoView.ts`)

- `useScrollRowIntoView({ tableRef, scrollContainerRef }) -> ScrollRowIntoView` resolves `tr[data-row-index="N"]`, reads both rects, and assigns `scrollTop`. Never `scrollTo` / `scrollIntoView` / `behavior: "smooth"` — the row is already sliding, and a competing smooth scroll lags a held-down arrow key.
- The margin is `rowBounds.height`, taken from the target row itself, so "one row" stays correct when row heights differ.
- `useCallback` over the two refs, so the callback is stable and safe in the effect dependency arrays below. Guarded no-op without a scroller, without a table, and for an unrendered index; with no layout (jsdom) the rects are zero-sized, the delta is `0`, and nothing scrolls — the same way column auto-fit degrades.

### The move path, wedged between measurement and slides (`src/components/reorder-animation.tsx`)

- `useReorderAnimation(containerRef, scrollRowIntoView?)`; the second parameter is optional so no call site was forced to change. `animateMove` gains a `focusIndex` parameter, stashed in `pendingFocusRef` **before** `await apply()` — the same reason the FLIP capture sits there, since the commit can flush React's effects before the awaiting code resumes — and cleared alongside `pendingRef` on the failed/no-op path.
- The stash is consumed inside the **existing FLIP layout effect**, after `computeFlipDeltas` and before the `deltas.forEach` that starts the animations. That is the only window where every rect is untransformed. Scrolling there cannot corrupt the slide: `deltas` came from the pre-scroll before/after tops and a transform is a relative displacement, so both endpoints shift by the same amount, all inside one layout-effect flush with no intermediate paint. The reduced-motion branch (`pending === null`, no row transformed) still scrolls.
- `animatedReorder` targets the landing index `to`; `animatedMoveSelected` targets the edge of the block in the direction of travel (`plan.selected` last going down, first going up).

### Drag landing stays out of scope (`src/components/reorder-dnd.tsx`)

- New `ReorderOptions { showLandingRow?: boolean }` on `AnimatedReorder`, defaulting to the previous behaviour. `drop`'s single-row branch passes `{ showLandingRow: false }`; the move buttons, the arrow keys, `plainReorder` and the context hooks are untouched (a trailing optional parameter keeps every two-argument call site assignable).
- `animatedMoveSelectedTo` continues to pass `null` for the grouped branch.

### The selection watcher fires only on a pure selection change (`src/hooks/useSelectedRowVisibility.ts`)

- Watches `selectedIndices` and `draft.items.length` in a `useLayoutEffect`, seeding `previousRef` with the mount-time selection so an already-selected row does not yank the scroller on first render.
- Returns without scrolling when `draft.items` changed reference. Any change to the queue contents is either a move — whose landing row the reorder path already handles, with correctly-measured geometry — or a drag/add/remove, which is out of scope. Only a selection change against an unchanged queue is this hook's business. That single guard closes the grouped-drag leak, removes the double-fire where a grouped move made both paths scroll to the same row, and keeps this hook from ever measuring in the same commit as a FLIP.

### Wiring (`src/components/TaskList.tsx`)

- Three lines, in a fixed order: `useScrollRowIntoView` (no effect), `useReorderAnimation(tableRef, scrollRowIntoView)`, `useSelectedRowVisibility(scrollRowIntoView)`. React runs layout effects in declaration order; with the items guard the two no longer compete, so the order is kept as the defensive arrangement and the comment says so rather than citing a rationale that no longer applies.

### Tests

- `src/lib/row-visibility.test.ts` (11) — overflow above and below, fully visible, short by exactly the margin, a row taller than the view; and every `selectionFocusIndex` branch.
- `src/hooks/useScrollRowIntoView.test.ts` (6) — rects stubbed per `data-row-index` over a uniform grid, asserting exact `scrollTop` values; all three no-op guards; referential stability across re-renders. The scroller is a plain object with a writable `scrollTop`, matching `edge-autoscroll.test.ts`, because jsdom pins `scrollTop` to 0 on real elements.
- `src/hooks/useSelectedRowVisibility.test.ts` (8) — direction per side, no scroll for select-all / clear / mount; and two that genuinely re-enter the layout effect while leaving the selection semantically unchanged (a fresh array with the same indices, and an item-count change), since an unrelated `setState` never re-renders the hook at all and would assert vacuously.
- `src/components/reorder-animation.test.tsx` (+8) — landing index per move shape, no scroll on a drag relocate or a clamped no-op, the opt-out, the reduced-motion path, and the ordering guarantee. The last asserts `lastIndexOf("measure") < indexOf("scroll") < indexOf("animate")` on a shared log; its container puts rows on a 20px grid because rows all reporting `top: 0` make every delta zero, so `el.animate()` never fires and the ordering is unobservable.
- `src/components/TaskList.test.tsx` (+5) — through the live wiring: a move below the fold scrolls, an already-visible landing row does not, a pure selection change scrolls, and neither a single-row nor a grouped pointer drag scrolls on release (baseline captured after the last `pointerMove`, so edge auto-scroll is excluded and the assertion is strict equality).

## Verification

- `pnpm test` — 665 passed
- `pnpm lint:ci` — clean
- `pnpm fmt:check` — clean
- `pnpm build` — clean (tsc + vite build)
- `pnpm knip` — clean, no ignore entries added

jsdom has no layout and no `Element.animate`, so the measurement-window property is covered by asserting call order as a proxy rather than pixel positions. **Not yet verified on a real webview:** drag a row from near the top of a long queue down into the bottom edge zone and release — the list must not jump on `pointerup`. Then hold ArrowDown on a mid-list selected row and confirm it settles one row above the fold rather than flush against it.
