### PR TITLE
chore(renovate): split low-risk update types into automergeable lanes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "schedule": ["before 9am on monday"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 15,
   "labels": ["dependencies"],
   "customManagers": [
     {
@@ -45,6 +45,39 @@
       "addLabels": ["tooling"]
     },
     {
+      "description": "Automerge lane: low-risk update types get their OWN branch per manager. Renovate only automerges a branch when every update in it is automergeable, so the group key must carry the automerge decision — otherwise a single minor update blocks the whole group.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "frontend (npm) auto",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["site/**"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "site (npm) auto",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "backend (cargo) auto",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "pin", "digest", "pinDigest"],
+      "groupName": "github-actions auto",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "mise auto",
+      "automerge": true
+    },
+    {
+      "description": "Fixed libraries stay last so that automerge:false overrides the automerge lanes above.",
       "matchPackageNames": [
         "tauri",
         "tauri-build",
@@ -69,17 +102,6 @@
       "groupName": "fixed-libs major (review required)",
       "addLabels": ["review-required"],
       "automerge": false
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest", "pin", "pinDigest"],
-      "automerge": true
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary

Renovate only automerges a branch when *every* update inside it is automergeable, so grouping by manager while flagging automerge by update type left the two axes at right angles and the `automerge: true` flags could never fire. `packageRules` is re-keyed on manager × automerge eligibility: `patch` / `pin` / `digest` updates now get their own `<manager> auto` branch per manager, everything else stays in the existing review lanes, and `prConcurrentLimit` goes 10 → 15 so the extra branches are not starved of slots.

## Background / Motivation

- All 28 merged Renovate PRs report `mergedBy=yasuflatland-lf`; `renovate[bot]` has merged **0** of them. `automerge: true` has been in `renovate.json` for three months and has never once fired. Nine Renovate PRs are open and stalled, the oldest (#266) since 2026-07-26.
- The two automerge rules deleted here could not fire in the shape they were written: neither carried a `groupName`, so their updates landed in the branch the manager-keyed rule above them had already named, next to updates that are not automergeable. #272 `github-actions` mixed 2 digest bumps (`Swatinem/rust-cache`, `pnpm/action-setup`) with 2 minors (node 24.18→24.19, pnpm 11.17→11.21); #268 `frontend (npm)` mixed `@types/react` patches with knip 6.29→6.32, vite 8.1.5→8.2.1, lucide-react 1.27→1.31 and oxlint 1.75→1.78. A single non-automergeable update disqualifies the whole branch.
- Widening npm automerge from `devDependencies` patch to *all* patch updates is deliberate, not incidental: CI already covers clippy / nextest / vitest / tsc / knip plus the Tauri build on two OSes, and `minimumReleaseAge: "7 days"` with `internalChecksFilter: "strict"` keeps too-fresh releases out of a branch before it is even opened. `cargo`, `mise` and `github-actions` patches had no automerge rule at all and were merged by hand every time.
- This is safe to merge only after #277 lands and the `main` ruleset is flipped to `enforcement: active` with `ci-ok` as its required check. As measured today `main` has ruleset `enforcement: disabled`, no classic branch protection (`404 Branch not protected`) and zero required status checks — which is exactly why `viewerCanEnableAutoMerge` is `false` on all 9 open PRs. Landing these lanes first would let a `renovate/*-auto` PR be auto-merged before any check reports.

## Changes

### Automerge lanes, one branch per manager (`renovate.json`)

- Five new rules keyed `frontend (npm) auto` / `site (npm) auto` / `backend (cargo) auto` / `github-actions auto` / `mise auto`, each `matchUpdateTypes: ["patch", "pin", "digest"]` + `automerge: true`. Because the group key now carries the automerge decision, a minor bump can no longer land in the same branch and block it.
- `github-actions auto` additionally matches `pinDigest`, preserving the coverage of the rule it replaces.
- The first of the five carries a `description` recording the branch-level rule, so the next reader does not re-derive why the group key and the automerge flag must agree.
- `site (npm) auto` keeps the `matchFileNames: ["site/**"]` narrowing of the review lane it mirrors.

### Rule ordering and the review lanes

- The five baseline manager lanes (`frontend (npm)`, `site (npm)`, `backend (cargo)`, `github-actions`, `mise`) and their `addLabels` are unchanged and stay first.
- The three `fixed-libs major (review required)` rules stay last so their `automerge: false` overrides the lanes above for tauri / tauri-build / tauri-plugin-opener / tauri-plugin-dialog / `@tauri-apps/**` majors, for async_zip / unrar / mockall / loom on major+minor+patch, and for bitflags on every update type. A `description` on the first of them states that the position is load-bearing.
- Final inventory: 13 rules in the order baseline (0–4) → auto (5–9) → fixed-libs (10–12).

### Rules removed

- The ungrouped `github-actions` rule (`digest` / `pin` / `pinDigest`, `automerge: true`) and the ungrouped npm rule (`matchDepTypes: ["devDependencies"]`, `patch`, `automerge: true`) are deleted — both are subsumed by `github-actions auto` and `frontend (npm) auto`, which additionally give the updates a branch of their own.

### Concurrency headroom

- `prConcurrentLimit`: 10 → 15. The maximum number of concurrent Renovate groups doubles from 5 to 10, and at the old limit the new lanes would sit queued behind the review lanes.
- `extends`, `schedule`, `timezone`, `minimumReleaseAge`, `internalChecksFilter`, `customManagers`, `lockFileMaintenance` and `labels` are untouched — the diff is `renovate.json` only, +34 / −12.

## Verification

Run against the branch's `renovate.json`:

- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8'))"` — parses.
- `pnpm dlx --package renovate renovate-config-validator` — `Config validated successfully against 1 file(s)`, exit 0.
- Rule inventory — 13 entries; `automerge` is absent on 0–4, `true` on 5–9 (`frontend (npm) auto`, `site (npm) auto`, `backend (cargo) auto`, `github-actions auto`, `mise auto`), `false` on 10–12 (`fixed-libs major (review required)`).
- `prConcurrentLimit` — `15`.
- `git diff main...HEAD --stat` — `renovate.json | 46 ++++++------`, 1 file changed, 34 insertions, 12 deletions.

Once merged, the config only proves itself at Renovate's next run (forceable from the Dependency Dashboard checkbox):

```bash
# 1. the new lanes exist as their own branches
gh pr list --state open --json number,headRefName \
  --jq '.[] | select(.headRefName | test("auto")) | "\(.number) \(.headRefName)"'

# 2. the only conclusive evidence for the epic — a PR merged by the bot, not by a human
gh pr list --state merged --limit 50 --json number,mergedBy \
  --jq '.[] | select(.mergedBy.login == "app/renovate") | .number'
```

Expect Renovate to close and recreate the existing group branches on the first run after merge; the churn is expected, not a regression.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('ok')"` → `ok`
- [x] `pnpm dlx --package renovate renovate-config-validator` → `Config validated successfully against 1 file(s)`, exit 0
- [x] `node -e "const c=require('./renovate.json'); console.log(c.packageRules.length, c.prConcurrentLimit)"` → `13 15`
- [x] Rule order asserted: baseline 0–4 → `*-auto` 5–9 → `fixed-libs major (review required)` 10–12, so `automerge: false` still wins for the pinned libraries
- [x] `git diff main...HEAD --stat` → `renovate.json` only; no diff in `extends` / `schedule` / `timezone` / `minimumReleaseAge` / `internalChecksFilter` / `customManagers` / `lockFileMaintenance`
- [ ] #277 merged and ruleset `17055465` reporting `{"enforcement":"active","checks":["ci-ok"]}` **before** this PR is merged
- [ ] After merge, the next Renovate run opens at least one `renovate/*-auto` branch
- [ ] A Renovate PR eventually shows `mergedBy.login == "app/renovate"` (the `app/` prefix is load-bearing: `gh` renders bot actors as `app/renovate`, so the bare `renovate` predicate returns zero rows even when automerge works)

Closes #278

