### PR TITLE
fix(ci): verify site/** on pull requests with a dedicated site job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 
 # Skipped only for changes that no job in this workflow verifies:
-# - `site/**` is already ignored by `knip.json` and is built and checked by deploy-pages.yml.
 # - `**/*.md` is safe because no CI gate reads or analyzes Markdown.
 # - `LICENSE` is safe because no CI gate reads it.
+# `site/**` was ignored here until the `site` job below existed: the comment claimed
+# deploy-pages.yml checked it, but that workflow only runs on `push: main`, so a site-only pull
+# request produced ZERO check runs and reached `main` unverified (PR #271: 2 files, 0 check-runs).
 # `pnpm knip` is the one repo-wide gate. Therefore `docs/**`, `.claude/**`, and
 # `.superpowers/**` are deliberately not ignored even though they contain no CI-relevant code
 # today: knip would gate a `.ts` or `.js` file added there. GitHub only skips when EVERY changed
@@ -12,7 +14,6 @@ on:
   push:
     branches: [main]
     paths-ignore: &ci-irrelevant-paths
-      - "site/**"
       - "**/*.md"
       - "LICENSE"
   pull_request:
@@ -158,6 +159,29 @@ jobs:
           files: coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
+      - run: pnpm build
+
+  site:
+    name: site (oxlint + oxfmt + vitest + build + knip)
+    runs-on: ubuntu-latest
+    # site/ is an independent pnpm project: its own pnpm-lock.yaml, pnpm-workspace.yaml,
+    # .oxlintrc.json, .oxfmtrc.json and knip.json. The root knip.json ignores `site/**`, so the
+    # `frontend` job above never sees these files.
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Pure JavaScript; without install_args mise installs the Rust toolchain for nothing
+      # (same reasoning as the `frontend` job).
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          install_args: node pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm fmt:check
+      - run: pnpm lint:ci
+      - run: pnpm knip
+      - run: pnpm test
       - run: pnpm build
 
   app:

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,6 +101,7 @@ This project is designed around TDD. **Write tests before implementation.**
 | `loom` | ubuntu | loom-clippy + loom-nextest for `simple-archiver-core` (concurrency model verification) |
 | `hygiene` | ubuntu | cargo-machete (unused deps) + cargo-modules orphan check on the core crate |
 | `frontend` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm run test:coverage`, Codecov upload (`frontend` flag), `pnpm build` |
+| `site` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm test`, `pnpm build` for the independent `site/` pnpm project; no Codecov upload |
 | `app` | macos + windows (matrix) | Windows: one nextest invocation for `simple-archiver-core` + `simple-archiver`; macOS: clippy + nextest for `simple-archiver` only; `pnpm install --frozen-lockfile`, then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend; Vitest runs once in the `frontend` job (jsdom-only, with no OS-dependent behaviour) |
 
 The presentation-crate clippy + nextest steps in the `app` job were added in PR6; the Tauri toolchain (gtk/webkit headers on Linux) is unavailable on ubuntu, so those steps run only on the mac/windows runners.


### PR DESCRIPTION
## Summary

A pull request whose whole diff lives under `site/**` produced **zero** check runs and could reach `main` completely unverified — `site/**` sat in `ci.yml`'s `paths-ignore`, and the comment that justified it pointed at `deploy-pages.yml`, which only runs on `push: main`, i.e. after the merge. This drops `site/**` from the shared ignore anchor and adds a dedicated `site` job that runs the independent `site/` pnpm project's own five gates, so those changes are checked before merge instead of after.

## Background / Motivation

- Measured on the site dependency PR #271 (`renovate/site-(npm)`): `gh api repos/{owner}/{repo}/pulls/271/files --jq 'length'` → **2 files changed**, `gh api repos/{owner}/{repo}/commits/$sha/check-runs --jq '.total_count'` → **0 check-runs**. Every site dependency bump merged so far has landed with no verification signal at all.
- Two settings combine to produce that: `.github/workflows/ci.yml` lists `"site/**"` in the `&ci-irrelevant-paths` anchor consumed by both the `push` and `pull_request` `paths-ignore`, so a site-only diff skips the workflow entirely; and `.github/workflows/deploy-pages.yml` triggers on `on: push: branches: [main]` only, so it never sees a pull request.
- The comment at the top of `ci.yml` asserted that `site/**` "is built and checked by deploy-pages.yml". That premise has never held for pull requests, so the ignore entry was resting on a documented-but-false justification.
- `site/` is not covered by the `frontend` job either: it is an independent pnpm project with its own `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.oxlintrc.json`, `.oxfmtrc.json` and `knip.json`, and the root `knip.json` carries `"ignore": ["site/**"]`. Nothing in the `frontend` job's `src`-scoped scripts reads a single file under `site/`.
- This also blocks the Renovate auto-merge epic (#281). Its baseline measurement: 9 open Renovate PRs are stalled, all 9 report `viewerCanEnableAutoMerge: false` and `autoMergeRequest: null`, and `renovate[bot]` has merged 0 of the 28 merged Renovate PRs. The planned fix is a required `ci-ok` check (#277) — but a PR that reports no checks at all would sit permanently on "Expected — Waiting for status to be reported", so the reporting hole has to close first.

## Changes

### `paths-ignore` no longer skips site-only pull requests (`.github/workflows/ci.yml`)

- Removed `- "site/**"` from the `&ci-irrelevant-paths` anchor on `push.paths-ignore`; `pull_request.paths-ignore` picks the change up through the existing `*ci-irrelevant-paths` alias, so the two triggers still cannot drift. The remaining entries are `**/*.md` and `LICENSE`.
- Rewrote the stale header comment: instead of claiming `deploy-pages.yml` covers `site/**`, it now records why the entry is gone, naming the failure it caused (`PR #271: 2 files, 0 check-runs`) so the entry is not reintroduced.
- `push.branches: [main]`, the `env:` block, the `concurrency:` block and the `docs/**` / `.claude/**` / `.superpowers/**` reasoning about `pnpm knip` being the one repo-wide gate are untouched.

### New `site` job (`.github/workflows/ci.yml`)

- `site: name: site (oxlint + oxfmt + vitest + build + knip)` on `ubuntu-latest`, placed between `frontend` and `app`, with `defaults.run.working-directory: site` so every `run` step executes inside the nested project while `uses:` steps still resolve the root `mise.toml`.
- Steps: `pnpm install --frozen-lockfile`, `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm test`, `pnpm build` — only scripts that exist in `site/package.json` (`build` = `tsc && vite build`, `test` = `vitest run`; there is no `test:coverage`, and no Codecov upload step).
- `jdx/mise-action` is pinned to the same SHA as `frontend` and passed `install_args: node pnpm`, because `site/` is pure JavaScript and an unscoped install would pull the Rust toolchain for nothing. `actions/checkout` reuses the existing pinned SHA as well, leaving digest bumps to Renovate.

### Docs (`docs/development.md`)

- Added the `site` row to the `## CI jobs` table, directly after `frontend`, listing the five gates and noting the absence of a Codecov upload.

## Verification

- On this PR: `gh pr checks 283 | grep '^site'` → `site (oxlint + oxfmt + vitest + build + knip)  pass  15s`.
- That the ignore list really changed: `python3 -c "import yaml;d=yaml.safe_load(open('.github/workflows/ci.yml'));print(d[True]['push']['paths-ignore'], d[True]['pull_request']['paths-ignore'])"` → `['**/*.md', 'LICENSE']` on both triggers, with `site/**` absent.
- Job inventory: the same `yaml.safe_load` gives `['app', 'core', 'frontend', 'hygiene', 'loom', 'site']`.
- After merge, the empirical proof is a site-only PR: rebase #271 onto `main` and re-run `gh api repos/{owner}/{repo}/commits/$(gh pr view 271 --json headRefOid --jq .headRefOid)/check-runs --jq '.total_count'` — the baseline `0` must become non-zero, with `site` among the contexts.

Caveat: this PR's own diff touches `.github/` and `docs/`, so it cannot itself demonstrate the "a site-only change now triggers CI" path — that follows from `site/**` no longer appearing in either `paths-ignore` (verified above) and from GitHub evaluating path filters over the whole `base...head` diff.

## Test plan

- [x] `pnpm -C site install --frozen-lockfile` — exit 0, lockfile in sync
- [x] `pnpm -C site fmt:check` — 17 files formatted correctly
- [x] `pnpm -C site lint:ci` — `oxlint --deny-warnings`, exit 0
- [x] `pnpm -C site knip` — exit 0
- [x] `pnpm -C site test` — 2 files, 10 tests passed
- [x] `pnpm -C site build` — `tsc && vite build` succeeded
- [x] `actionlint .github/workflows/ci.yml` — exit 0 (baseline on `main` is clean too, so no pre-existing noise is masked)
- [x] `site (oxlint + oxfmt + vitest + build + knip)` appears in this PR's check-runs and passes
- [x] Regression: the six pre-existing jobs stay green — `core`, `loom`, `hygiene`, `frontend`, `app (macos-latest)`, `app (windows-latest)`, plus both Codecov contexts, for 9 passing checks total
- [x] `.github/workflows/deploy-pages.yml`, the root `knip.json` (`"ignore": ["site/**"]`) and `renovate.json` are untouched — all out of scope here
- [x] Every line written into `ci.yml` and `docs/development.md` is English
- [ ] Post-merge: rebase #271 and confirm its site-only diff now reports check-runs including `site`

Closes #276
