### PR TITLE
ci: add the ci-ok aggregate gate as the single required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,14 @@
 name: CI
 
-# Skipped only for changes that no job in this workflow verifies:
-# - `**/*.md` is safe because no CI gate reads or analyzes Markdown.
-# - `LICENSE` is safe because no CI gate reads it.
-# `site/**` was ignored here until the `site` job below existed: the comment claimed
-# deploy-pages.yml checked it, but that workflow only runs on `push: main`, so a site-only pull
-# request produced ZERO check runs and reached `main` unverified (PR #271: 2 files, 0 check-runs).
-# `pnpm knip` is the one repo-wide gate. Therefore `docs/**`, `.claude/**`, and
-# `.superpowers/**` are deliberately not ignored even though they contain no CI-relevant code
-# today: knip would gate a `.ts` or `.js` file added there. GitHub only skips when EVERY changed
-# file matches, so a PR touching both a `.md` file and `src/` still runs the full workflow.
+# Every pull request runs the full workflow. `paths-ignore` was removed when `ci-ok` became the
+# single required status check: a workflow skipped by a path filter never reports `ci-ok`, and a
+# required check that is never reported blocks the pull request forever. GitHub cannot express
+# "only when every changed file matches", so the usual same-named no-op workflow does not work
+# here — a pull request mixing `README.md` and `src/` would trigger both and report `ci-ok` twice.
 on:
   push:
     branches: [main]
-    paths-ignore: &ci-irrelevant-paths
-      - "**/*.md"
-      - "LICENSE"
   pull_request:
-    paths-ignore: *ci-irrelevant-paths
 
 # CI-only debuginfo trimming. `line-tables-only` keeps file:line in panic and test-failure
 # backtraces (all CI needs) and drops variable/type DWARF, which nothing in CI reads. This cuts
@@ -32,7 +23,7 @@ env:
 
 # One in-flight run per PR: Renovate force-pushes its branches repeatedly (17 runs on
 # `renovate/frontend-(npm)` in the last 100 PR runs), and without this every superseded push
-# keeps six jobs running to completion on a commit that will never merge, holding concurrency
+# keeps every job in this workflow running to completion on a commit that will never merge, holding
 # slots that the current run needs. Pull-request runs are grouped by PR number, so a new push
 # cancels the previous run. `push` events fall back to `github.run_id`, which is unique per run,
 # so pushes to main never share a group. GitHub cancels a pending run in a group when a newer one
@@ -230,3 +221,25 @@ jobs:
       # tauri build runs `beforeBuildCommand: pnpm build`, so the frontend is
       # built here too — a separate `pnpm build` step would be redundant.
       - run: pnpm tauri build --no-bundle --debug
+
+  # The one and only required status check. Branch protection points at this job, so adding,
+  # renaming or splitting any job above never means editing the ruleset. `if: always()` makes it
+  # run even when a dependency failed or was skipped; the step then fails unless EVERY dependency
+  # reported `success` — a skipped dependency is a failure here, never a silent pass. `needs`
+  # collapses the `app` matrix into a single entry whose result is the matrix's overall result.
+  ci-ok:
+    name: ci-ok
+    needs: [core, loom, hygiene, frontend, site, app]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless every required job succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key)=\(.value.result)"'
+          failed=$(echo "$NEEDS" | jq -r '[to_entries[] | select(.value.result != "success") | .key] | join(", ")')
+          if [ -n "$failed" ]; then
+            echo "::error::required jobs did not succeed: $failed"
+            exit 1
+          fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -103,8 +103,11 @@ This project is designed around TDD. **Write tests before implementation.**
 | `frontend` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm run test:coverage`, Codecov upload (`frontend` flag), `pnpm build` |
 | `site` | ubuntu | `pnpm fmt:check`, `pnpm lint:ci`, `pnpm knip`, `pnpm test`, `pnpm build` for the independent `site/` pnpm project; no Codecov upload |
 | `app` | macos + windows (matrix) | Windows: one nextest invocation for `simple-archiver-core` + `simple-archiver`; macOS: clippy + nextest for `simple-archiver` only; `pnpm install --frozen-lockfile`, then `pnpm tauri build --no-bundle --debug`, whose `beforeBuildCommand: pnpm build` builds the frontend; Vitest runs once in the `frontend` job (jsdom-only, with no OS-dependent behaviour) |
+| `ci-ok` | ubuntu | Aggregates the results of every job above. The single required status check; fails unless every dependency reported `success` |
 
 The presentation-crate clippy + nextest steps in the `app` job were added in PR6; the Tauri toolchain (gtk/webkit headers on Linux) is unavailable on ubuntu, so those steps run only on the mac/windows runners.
+
+The `main` ruleset (`required_status_checks`) demands exactly one context: `ci-ok`. When you add a job, add it to `ci-ok`'s `needs` — the ruleset itself never needs editing. Codecov statuses stay informational and are never made required.
 
 ## Release (binaries)
 


### PR DESCRIPTION
## Summary

The workflow gains one aggregate job, `ci-ok`, that depends on every other job and fails unless all of them reported `success`. The `main` ruleset can then require that single context instead of a list of job names, which is what GitHub's auto-merge needs in order to arm at all. Because a workflow skipped by a path filter never reports its checks — and a required check that is never reported blocks a pull request forever — `paths-ignore` is removed in the same change, so every pull request now runs the full workflow.

## Background / Motivation

- `allow_auto_merge` is already `true` on the repository, yet a GraphQL sweep of the open pull requests returns `viewerCanEnableAutoMerge: false` for all 9 of them. Auto-merge is a "wait for the outstanding requirements, then merge" feature; with zero required checks there is nothing to wait for, so GitHub refuses to enable it. Renovate's `platformAutomerge` (default `true`) has been hitting exactly this for three months without a single automatic merge landing.
- There is nothing to require yet: `repos/{owner}/{repo}/branches/main/protection` returns `404 Branch not protected`, and ruleset `17055465` reads `{"enforcement":"disabled","conditions":{"ref_name":{"include":[],"exclude":[]}},"rules":["deletion","non_fast_forward"]}` — disabled, matching no branch, and carrying no `required_status_checks` rule.
- Requiring the individual job contexts would mean editing the ruleset every time a job is added, renamed, or split — the `site` job arrived only one PR ago (#283), which is precisely the churn an aggregate job removes.
- `paths-ignore` cannot survive `ci-ok` becoming the required check. A `README.md`-only pull request would skip the workflow entirely, `ci-ok` would never be reported, and GitHub would sit on "Expected — Waiting for status to be reported" forever. The usual workaround — a same-named no-op workflow behind an inverted filter — does not work either, because `paths` and `paths-ignore` both mean "any changed file matches", so a pull request touching both `README.md` and `src/` would trigger both workflows and report `ci-ok` twice. The repository is public, so the only cost of dropping the filter is wall-clock time.

## Changes

### The `ci-ok` aggregate job (`.github/workflows/ci.yml`)

- New job at the end of the file: `name: ci-ok` (matching the job id, since the required-check context name comes from `name` and a mismatch leaves the ruleset permanently unsatisfiable), `needs: [core, loom, hygiene, frontend, site, app]`, `if: always()`, `runs-on: ubuntu-latest`.
- The single step reads `toJSON(needs)` through `env: NEEDS` rather than interpolating it into the `run:` body, keeping the workflow-expression value off the shell command line. It prints every dependency's result, then exits 1 listing each one whose result is not `success` — `failure`, `skipped` and `cancelled` all fail, so a skipped dependency can never pass silently.
- `needs` collapses the `app` matrix into one entry whose result is the matrix's overall result, so new matrix legs need no wiring.

### Path filters removed (`.github/workflows/ci.yml`)

- `paths-ignore` is dropped from both `push` and `pull_request`, together with the `&ci-irrelevant-paths` anchor and its `*ci-irrelevant-paths` alias; no orphan reference is left anywhere under `.github/`. The `on:` block is now `push: {branches: [main]}` plus a bare `pull_request:`.
- The header comment is replaced with the reason the filter cannot come back while `ci-ok` is the required check, including the "GitHub cannot express *only when every changed file matches*" constraint.
- The concurrency comment no longer hard-codes a job count ("six jobs" → "every job in this workflow"), which would drift on the next job added.

### Documentation (`docs/development.md`)

- The CI jobs table gains a `ci-ok` row describing it as the aggregate and the single required status check.
- A new paragraph records the operating rule: the `main` ruleset demands exactly one context, `ci-ok`; a new job is wired in through `ci-ok`'s `needs` rather than by editing the ruleset; Codecov statuses stay informational and are never made required.

## Verification

- `actionlint .github/workflows/ci.yml` — exit 0.
- YAML parse of the branch file: `jobs` keys are `core, loom, hygiene, frontend, site, app, ci-ok`; `ci-ok` is `{"name":"ci-ok","needs":["core","loom","hygiene","frontend","site","app"],"if":"always()","runs-on":"ubuntu-latest"}`; the `on:` block parses to `{"push": {"branches": ["main"]}, "pull_request": null}` with no `paths-ignore` on either trigger; the step's only `env` entry is `NEEDS: ${{ toJSON(needs) }}`.
- `git grep -n 'ci-irrelevant-paths' -- .github/` — zero hits on the branch.
- Behavioural proof of the step body, extracted from the parsed YAML and run under synthetic `NEEDS` payloads: all-`success` → exit 0; one `failure`, one `skipped`, one `cancelled` → exit 1 each, printing `::error::required jobs did not succeed: site`. The extracted body contains no literal `toJSON(needs)`.
- `docs/development.md` codepoint scan — 214 lines, 0 containing CJK, so the file stays English-only.

Once merged, the check to look for on a pull request is a status context literally named `ci-ok` (not `ci-ok / ci-ok`); `gh pr checks <N>` should list it alongside the per-job runs.

## Test plan

- [ ] `ci-ok` runs and is green on this pull request and on `main` after merge: `gh run list --workflow=ci.yml --branch=main --limit 1 --json conclusion --jq '.[0].conclusion'` returns `success`.
- [ ] Force one dependency to fail on a throwaway commit and confirm `ci-ok` fails too, naming that job in the `::error::` annotation; revert the commit afterwards.
- [ ] Open a documentation-only pull request (touching just a `.md` file) and confirm the workflow now runs and reports `ci-ok`, instead of producing zero check runs the way the site-only PR #271 did under the old filter.
- [ ] After the ruleset update below: `gh api repos/yasuflatland-lf/simple-archiver/rulesets/17055465 --jq '{enforcement, include: .conditions.ref_name.include, checks: [.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]}'` returns `{"enforcement":"active","include":["~DEFAULT_BRANCH"],"checks":["ci-ok"]}`.
- [ ] Re-run the auto-merge sweep — `viewerCanEnableAutoMerge` must be `true` for at least one open pull request, against the baseline of 9 out of 9 `false`.

## Follow-up (required, post-merge)

Nothing in this diff changes repository settings. After `ci-ok` has gone green once on `main`, ruleset `17055465` must be updated to `enforcement: active`, `conditions.ref_name.include: ["~DEFAULT_BRANCH"]` (it is an empty array today, so an active ruleset would still match nothing), and a `required_status_checks` rule listing exactly `ci-ok` with `strict_required_status_checks_policy: false`. Until then the per-job contexts stay unrequired and this change has no effect. Open pull requests whose head commit predates `ci-ok` will sit pending and need a rebase.

> Stacked on #283 (`fix/ci-verify-site-on-pr`). Merge that one first: `ci-ok`'s `needs` includes the `site` job introduced there, and a `needs` entry that does not resolve makes the whole workflow unparseable. GitHub retargets this pull request to `main` automatically once #283 merges.

Closes #277
