### PR TITLE
chore(renovate): exempt lockFileMaintenance from the 7-day release gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["before 9am on monday"]
+    "schedule": ["before 9am on monday"],
+    "minimumReleaseAge": null
   }
 }


### PR DESCRIPTION
## Summary

`lockFileMaintenance` re-resolves the lock files weekly, so its branches almost always contain a transitive dependency published within the last seven days — which the repo-wide `minimumReleaseAge: "7 days"` immediately marks pending. This adds a single `"minimumReleaseAge": null` line inside the `lockFileMaintenance` block so that one update type stops emitting a `renovate/stability-days` check, while the seven-day gate stays fully in force for every ordinary dependency update.

## Background / Motivation

- PR #275 (`renovate/lock-file-maintenance-backend-(cargo)`) has all 8 CI jobs green, yet `gh api repos/{owner}/{repo}/commits/$sha/status` reports `pending renovate/stability-days — "Updates have not met minimum release age requirement"`. That one non-CI status is enough to hold the PR at `mergeStateStatus: UNSTABLE`, and Renovate refuses to automerge an unstable branch. PR #272 carries the identical pending line.
- The two settings cannot both be satisfied. `lockFileMaintenance` runs `before 9am on monday` and re-resolves the lock to the newest compatible versions; a fresh resolution practically always picks up something released inside the last week, `minimumReleaseAge: "7 days"` marks it pending, and by the time that wait would expire the next Monday run has already pulled in newer releases. Update period (7 days) ≤ wait period (7 days), so the branch never converges on its own.
- `internalChecksFilter: "strict"` keeps that pending check attached to the branch instead of dropping the offending update, so nothing resolves the stall from the Renovate side either.
- This is layer 3 of the three root causes measured in epic #281: all 28 merged Renovate PRs show `mergedBy=yasuflatland-lf` and **zero** were merged by `renovate[bot]`, with 9 Renovate PRs currently stuck open (the oldest, #266, since 2026-07-26). Layers 1 and 2 were addressed by #277 and #276; this PR removes the last blocker for the lock file maintenance lane specifically.
- The gate is redundant here by construction. `minimumReleaseAge` exists to avoid picking up a **direct** dependency that gets yanked or poisoned right after publish; lock file regeneration never moves a direct dependency's version range, only transitive resolution. The direct-dependency case is already covered by the top-level setting plus `internalChecksFilter: "strict"`, so applying the same gate twice buys nothing and costs the whole lane.

## Changes

### The override (`renovate.json`)

- One key added to the existing `lockFileMaintenance` block: `"minimumReleaseAge": null`. `enabled: true`, `automerge: true` and `schedule: ["before 9am on monday"]` are untouched. Whole diff against the base branch: `renovate.json` only, `1 file changed, 2 insertions(+), 1 deletion(-)` — the deletion is the trailing comma on the preceding `schedule` line.
- Top-level `minimumReleaseAge: "7 days"` and `internalChecksFilter: "strict"` are unchanged, so the seven-day wait still applies to every normal dependency update.
- `packageRules` is not touched at all — zero diff against `chore/renovate-automerge-policy`, so #282's 13-rule rewrite is not re-litigated in this PR.

### Why `null` rather than `"0 days"`

- Confirmed against Renovate's own source rather than inferred: the `lockFileMaintenance` block is spread into the parent config by `flatten.js`, so it genuinely overrides the top-level value; `branch/index.js` guards the entire stability block behind `isNonEmptyString(upgrade.minimumReleaseAge)`, so `null` means no `stabilityStatus` is ever computed and the `renovate/stability-days` context is never created in the first place — as opposed to being created and passing.
- `"0 days"` parses to the same runtime behaviour but reads as a value rather than as "unset what the parent set". Upstream's own shipped presets use `null` for `lockFileMaintenance`, so this matches the idiom reviewers will recognise.

### Deliberately out of scope

- The pending `renovate/stability-days` on #272 stays. It gates node 24.19.0 and pnpm 11.21.0 — direct-dependency minors — which is exactly what the top-level gate is for; it clears with time.
- `schedule` changes, `packageRules` changes, and the cleanup/manual merge of the currently stuck PRs (tracked in #280).

## Verification

The change is only observable on the next Renovate run. Once this lands, the following must print nothing for the stability context on the next weekly lock file maintenance branch:

```bash
sha=$(gh pr view <new lock-file-maintenance PR> --json headRefOid --jq .headRefOid)
gh api repos/{owner}/{repo}/commits/$sha/status --jq '.statuses[] | "\(.state)\t\(.context)"'
# expect: no renovate/stability-days line at all (not "success" — absent)
```

The epic's only accepted final evidence is a Renovate PR whose `mergedBy.login` is `renovate`, which is tracked in #280.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8'))"` → `json ok` (exit 0)
- [x] `NPM_CONFIG_USERCONFIG=/dev/null CI=true mise exec -- pnpm dlx --package renovate renovate-config-validator` → `Config validated successfully against 1 file(s)` (exit 0; the `RE2 not usable` warning is a native-module fallback and does not affect the result)
- [x] `node -e "const l=require('./renovate.json').lockFileMaintenance; console.log(l.minimumReleaseAge === null, 'minimumReleaseAge' in l)"` → `true true` (strict JSON `null`, not the string `"0 days"`, and the key is present)
- [x] `node -e "const c=require('./renovate.json'); console.log(c.minimumReleaseAge, c.internalChecksFilter)"` → `7 days strict` (top-level gate left alone)
- [x] `git diff chore/renovate-automerge-policy...HEAD --stat` → `renovate.json` only, 1 file changed, and no diff inside `packageRules`
- [ ] After merge: the next `before 9am on monday` lock file maintenance PR shows no `renovate/stability-days` status and reaches `mergeStateStatus: CLEAN`

> **Stacked on #282 (`chore/renovate-automerge-policy`).** That PR must merge first; GitHub then retargets this PR to `main` automatically.

Closes #279
