### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,7 +3883,7 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simple-archiver"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.13.1",
  "serde",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "simple-archiver-core"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "async_zip",
  "chardetng",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver-core"
-version = "0.12.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-archiver",
   "private": true,
-  "version": "0.12.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-archiver"
-version = "0.12.0"
+version = "1.0.0"
 description = "Simple Archiver"
 authors = ["Yasuyuki Takeo"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "simple-archiver",
-  "version": "0.12.0",
+  "version": "1.0.0",
   "identifier": "com.simplearchiver.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release version bump `0.12.0` → `1.0.0` ahead of cutting the `v1.0.0` release.

`1.0.0` marks the first stable release: the drag-and-drop → batch-rename → re-archive
workflow (rar / zip / folder input, zip or folder output, bounded parallelism, live
progress + ETA, cancel, run summary) has been shipping and hardened since `v0.1.0`, and
the correctness pass in `v0.12.0` closed the last known engine-level defects.

Bumps the version in all six tracked locations:

- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `crates/core/Cargo.toml`
- `Cargo.lock` (`simple-archiver` + `simple-archiver-core`)

## What ships in v1.0.0 (since v0.12.0)

Improvements

- Keep the focused queue row scrolled into view when moving through the queue with the keyboard (#267)

Repository / CI

- Add the `ci-ok` aggregate gate as the single required status check (#284)
- Verify `site/**` on pull requests with a dedicated site job (#283)
- Split low-risk Renovate update types into automergeable lanes, and exempt
  `lockFileMaintenance` from the 7-day release gate (#282, #285)
- Document the Renovate dependency-update workflow and its real automerge paths (#286)

Also included: dependency updates across the frontend, site, mise, and GitHub Actions
(#260–#265, #268–#275).

## Verification

- `cargo metadata --locked` exits 0 (lockfile consistent)
- Diff is exactly the six version lines, nothing else
